### PR TITLE
Add Apache 2.0 license headers to all source files

### DIFF
--- a/bench/vector_bench.cc
+++ b/bench/vector_bench.cc
@@ -1,4 +1,20 @@
 
+/*
+ * Copyright 2025 ClapDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #define ANKERL_NANOBENCH_IMPLEMENT
 #include <iostream>
 #include <vector>

--- a/container/vectra.hpp
+++ b/container/vectra.hpp
@@ -1,4 +1,20 @@
 
+/*
+ * Copyright 2025 ClapDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 #include <concepts>
 #include <cstdint>

--- a/tests/test_main.cc
+++ b/tests/test_main.cc
@@ -1,2 +1,18 @@
+/*
+ * Copyright 2025 ClapDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"

--- a/tests/vectra_test.cc
+++ b/tests/vectra_test.cc
@@ -1,4 +1,20 @@
 
+/*
+ * Copyright 2025 ClapDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "container/vectra.hpp"
 
 #include <doctest/doctest.h>


### PR DESCRIPTION
## Summary
- Added Apache 2.0 license headers with ClapDB, Inc. copyright to all project source files
- Updated container/vectra.hpp, tests/vectra_test.cc, tests/test_main.cc, and bench/vector_bench.cc
- Ensures legal compliance and proper attribution for the Containa project

## Test plan
- [x] Verify all source files now contain proper license headers
- [x] Confirm files still compile and function correctly 
- [x] Check that header format follows Apache 2.0 standard

🤖 Generated with [Claude Code](https://claude.ai/code)