### PR TITLE
Remove std::format support from vectra

### DIFF
--- a/container/vectra.hpp
+++ b/container/vectra.hpp
@@ -20,7 +20,6 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
-#include <format>
 #include <iterator>
 #include <limits>
 #include <new>
@@ -1440,21 +1439,4 @@ template <class T, class Predicate>
 constexpr auto erase_if(stdb::container::vectra<T>& vec, Predicate pred) -> std::size_t {
     return vec.erase_if(pred);
 }
-
-template <typename T>
-struct formatter<stdb::container::vectra<T>> : std::formatter<std::string>
-{
-    auto format(const stdb::container::vectra<T>& vec, std::format_context& ctx) const {
-        std::string result = "[";
-        for (std::size_t i = 0; i < vec.size(); ++i) {
-            if (i > 0) {
-                result += ", ";
-            }
-            result += std::format("{}", vec[i]);
-        }
-        result += "]";
-        return std::formatter<std::string>::format(result, ctx);
-    }
-};
-
 }  // namespace std

--- a/tests/vectra_test.cc
+++ b/tests/vectra_test.cc
@@ -911,11 +911,6 @@ TEST_CASE("Hilbert::stdb_vector::int") {
         vectra<int> result_vec = {1, 5, 5, 7, 5, 9};
         CHECK_EQ(vec == result_vec, true);
     }
-    SUBCASE("fmt") {
-        vectra<int> vec = {1, 2, 3, 4, 5};
-        std::string str = std::format("{}", vec);
-        CHECK_EQ(str, "[1, 2, 3, 4, 5]");
-    }
 }
 
 class non_movable


### PR DESCRIPTION
## Summary
- Remove std::formatter specialization for vectra class from container/vectra.hpp
- Remove corresponding test case from tests/vectra_test.cc  
- Eliminate dependency on C++20 format library to improve compatibility

## Test plan
- [x] Verify existing tests still pass
- [x] Confirm no compilation errors
- [x] Check that vectra functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)