### PR TITLE
Add container variants: small_vectra, static_vectra, ring_buffer, devectra

### DIFF
--- a/bench/vector_bench.cc
+++ b/bench/vector_bench.cc
@@ -16,10 +16,15 @@
  */
 
 #define ANKERL_NANOBENCH_IMPLEMENT
+#include <deque>
 #include <iostream>
 #include <vector>
 
 #include "../nanobench/src/include/nanobench.h"
+#include "container/devectra.hpp"
+#include "container/ring_buffer.hpp"
+#include "container/small_vectra.hpp"
+#include "container/static_vectra.hpp"
 #include "container/vectra.hpp"
 
 namespace stdb::container {
@@ -81,6 +86,58 @@ void push_back_unsafe() {
         vec.template push_back<Safety::Unsafe>(i);
     }
     ankerl::nanobench::doNotOptimizeAway(vec);
+}
+
+// small_vectra benchmarks - for small sizes (inline storage)
+constexpr size_t small_times = 16;  // Fits in inline storage
+
+template <typename T, size_t N>
+void push_back_small_vectra_inline() {
+    small_vectra<T, N> vec;
+    for (size_t i = 0; i < N; ++i) {
+        vec.push_back(static_cast<T>(i));
+    }
+    ankerl::nanobench::doNotOptimizeAway(vec);
+}
+
+template <typename T, size_t N>
+void push_back_small_vectra_overflow() {
+    small_vectra<T, N> vec;
+    for (size_t i = 0; i < N * 4; ++i) {
+        vec.push_back(static_cast<T>(i));
+    }
+    ankerl::nanobench::doNotOptimizeAway(vec);
+}
+
+template <typename T, size_t N>
+void push_back_std_vector_small() {
+    std::vector<T> vec;
+    for (size_t i = 0; i < N; ++i) {
+        vec.push_back(static_cast<T>(i));
+    }
+    ankerl::nanobench::doNotOptimizeAway(vec);
+}
+
+template <typename T, size_t N>
+void create_destroy_small_vectra() {
+    for (size_t iter = 0; iter < 1000; ++iter) {
+        small_vectra<T, N> vec;
+        for (size_t i = 0; i < N; ++i) {
+            vec.push_back(static_cast<T>(i));
+        }
+        ankerl::nanobench::doNotOptimizeAway(vec);
+    }
+}
+
+template <typename T, size_t N>
+void create_destroy_std_vector() {
+    for (size_t iter = 0; iter < 1000; ++iter) {
+        std::vector<T> vec;
+        for (size_t i = 0; i < N; ++i) {
+            vec.push_back(static_cast<T>(i));
+        }
+        ankerl::nanobench::doNotOptimizeAway(vec);
+    }
 }
 
 template <typename T>
@@ -458,6 +515,244 @@ int main() {
         vec.reserve(times);
         vec.fill<Safety::Unsafe>(&filler);
         ankerl::nanobench::doNotOptimizeAway(vec);
+    });
+
+    // === SMALL_VECTRA BENCHMARKS ===
+    std::cout << "\n=== small_vectra Performance (Inline Storage) ===\n";
+
+    // Compare small_vectra vs std::vector for small sizes (stays inline)
+    bench.run("push_back std::vector<int64_t> (16 elements)", []() { push_back_std_vector_small<int64_t, 16>(); });
+    bench.run("push_back small_vectra<int64_t,16> (inline)", []() { push_back_small_vectra_inline<int64_t, 16>(); });
+
+    bench.run("push_back std::vector<int32_t> (16 elements)", []() { push_back_std_vector_small<int32_t, 16>(); });
+    bench.run("push_back small_vectra<int32_t,16> (inline)", []() { push_back_small_vectra_inline<int32_t, 16>(); });
+
+    bench.run("push_back std::vector<int64_t> (8 elements)", []() { push_back_std_vector_small<int64_t, 8>(); });
+    bench.run("push_back small_vectra<int64_t,8> (inline)", []() { push_back_small_vectra_inline<int64_t, 8>(); });
+
+    // Test overflow behavior (inline -> heap transition)
+    std::cout << "\n=== small_vectra Overflow Performance ===\n";
+    bench.run("push_back small_vectra<int64_t,8> overflow to 32",
+              []() { push_back_small_vectra_overflow<int64_t, 8>(); });
+    bench.run("push_back std::vector<int64_t> (32 elements)", []() { push_back_std_vector_small<int64_t, 32>(); });
+
+    // Create/destroy cycle comparison (shows allocation savings)
+    std::cout << "\n=== small_vectra Create/Destroy Cycle (1000x) ===\n";
+    bench.run("create/destroy std::vector<int64_t> 8 elem x1000", []() { create_destroy_std_vector<int64_t, 8>(); });
+    bench.run("create/destroy small_vectra<int64_t,8> x1000", []() { create_destroy_small_vectra<int64_t, 8>(); });
+
+    bench.run("create/destroy std::vector<int32_t> 16 elem x1000", []() { create_destroy_std_vector<int32_t, 16>(); });
+    bench.run("create/destroy small_vectra<int32_t,16> x1000", []() { create_destroy_small_vectra<int32_t, 16>(); });
+
+    // === DEVECTRA BENCHMARKS ===
+    std::cout << "\n=== devectra vs std::deque - push_front Performance ===\n";
+
+    // push_front comparison - this is where devectra should shine vs vector
+    bench.run("push_front std::deque<int64_t> (64K)", []() {
+        std::deque<int64_t> dq;
+        for (size_t i = 0; i < times; ++i) {
+            dq.push_front(static_cast<int64_t>(i));
+        }
+        ankerl::nanobench::doNotOptimizeAway(dq);
+    });
+    bench.run("push_front devectra<int64_t> (64K)", []() {
+        devectra<int64_t> dv;
+        dv.reserve_front(times);
+        for (size_t i = 0; i < times; ++i) {
+            dv.push_front(static_cast<int64_t>(i));
+        }
+        ankerl::nanobench::doNotOptimizeAway(dv);
+    });
+    bench.run("push_front devectra<int64_t> no reserve (64K)", []() {
+        devectra<int64_t> dv;
+        for (size_t i = 0; i < times; ++i) {
+            dv.push_front(static_cast<int64_t>(i));
+        }
+        ankerl::nanobench::doNotOptimizeAway(dv);
+    });
+
+    std::cout << "\n=== devectra vs std::deque - push_back Performance ===\n";
+
+    bench.run("push_back std::deque<int64_t> (64K)", []() {
+        std::deque<int64_t> dq;
+        for (size_t i = 0; i < times; ++i) {
+            dq.push_back(static_cast<int64_t>(i));
+        }
+        ankerl::nanobench::doNotOptimizeAway(dq);
+    });
+    bench.run("push_back devectra<int64_t> (64K)", []() {
+        devectra<int64_t> dv;
+        dv.reserve_back(times);
+        for (size_t i = 0; i < times; ++i) {
+            dv.push_back(static_cast<int64_t>(i));
+        }
+        ankerl::nanobench::doNotOptimizeAway(dv);
+    });
+    bench.run("push_back devectra<int64_t> no reserve (64K)", []() {
+        devectra<int64_t> dv;
+        for (size_t i = 0; i < times; ++i) {
+            dv.push_back(static_cast<int64_t>(i));
+        }
+        ankerl::nanobench::doNotOptimizeAway(dv);
+    });
+
+    std::cout << "\n=== devectra vs std::deque - Mixed push_front/push_back ===\n";
+
+    bench.run("mixed push std::deque<int64_t> (64K)", []() {
+        std::deque<int64_t> dq;
+        for (size_t i = 0; i < times; ++i) {
+            if (i % 2 == 0) {
+                dq.push_front(static_cast<int64_t>(i));
+            } else {
+                dq.push_back(static_cast<int64_t>(i));
+            }
+        }
+        ankerl::nanobench::doNotOptimizeAway(dq);
+    });
+    bench.run("mixed push devectra<int64_t> (64K)", []() {
+        devectra<int64_t> dv;
+        for (size_t i = 0; i < times; ++i) {
+            if (i % 2 == 0) {
+                dv.push_front(static_cast<int64_t>(i));
+            } else {
+                dv.push_back(static_cast<int64_t>(i));
+            }
+        }
+        ankerl::nanobench::doNotOptimizeAway(dv);
+    });
+
+    std::cout << "\n=== devectra vs std::deque - pop_front Performance ===\n";
+
+    bench.run("pop_front std::deque<int64_t> (64K)", []() {
+        std::deque<int64_t> dq(times);
+        while (!dq.empty()) {
+            dq.pop_front();
+        }
+        ankerl::nanobench::doNotOptimizeAway(dq);
+    });
+    bench.run("pop_front devectra<int64_t> (64K)", []() {
+        devectra<int64_t> dv(times);
+        while (!dv.empty()) {
+            dv.pop_front();
+        }
+        ankerl::nanobench::doNotOptimizeAway(dv);
+    });
+
+    std::cout << "\n=== devectra vs std::deque - Random Access ===\n";
+
+    bench.run("random access std::deque<int64_t> (64K)", []() {
+        std::deque<int64_t> dq(times);
+        int64_t sum = 0;
+        for (size_t i = 0; i < times; ++i) {
+            sum += dq[i];
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+    bench.run("random access devectra<int64_t> (64K)", []() {
+        devectra<int64_t> dv(times);
+        int64_t sum = 0;
+        for (size_t i = 0; i < times; ++i) {
+            sum += dv[i];
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+    // === STATIC_VECTRA BENCHMARKS ===
+    std::cout << "\n=== static_vectra vs std::vector (Fixed Size) ===\n";
+
+    constexpr size_t static_size = 64;
+
+    bench.run("push_back std::vector<int64_t> (64 elements)", []() {
+        std::vector<int64_t> vec;
+        vec.reserve(static_size);
+        for (size_t i = 0; i < static_size; ++i) {
+            vec.push_back(static_cast<int64_t>(i));
+        }
+        ankerl::nanobench::doNotOptimizeAway(vec);
+    });
+    bench.run("push_back static_vectra<int64_t,64>", []() {
+        static_vectra<int64_t, static_size> vec;
+        for (size_t i = 0; i < static_size; ++i) {
+            vec.push_back(static_cast<int64_t>(i));
+        }
+        ankerl::nanobench::doNotOptimizeAway(vec);
+    });
+
+    std::cout << "\n=== static_vectra Create/Destroy (No Heap) ===\n";
+
+    bench.run("create/destroy std::vector<int64_t> 64 elem x1000", []() {
+        for (size_t iter = 0; iter < 1000; ++iter) {
+            std::vector<int64_t> vec;
+            vec.reserve(static_size);
+            for (size_t i = 0; i < static_size; ++i) {
+                vec.push_back(static_cast<int64_t>(i));
+            }
+            ankerl::nanobench::doNotOptimizeAway(vec);
+        }
+    });
+    bench.run("create/destroy static_vectra<int64_t,64> x1000", []() {
+        for (size_t iter = 0; iter < 1000; ++iter) {
+            static_vectra<int64_t, static_size> vec;
+            for (size_t i = 0; i < static_size; ++i) {
+                vec.push_back(static_cast<int64_t>(i));
+            }
+            ankerl::nanobench::doNotOptimizeAway(vec);
+        }
+    });
+
+    // === RING_BUFFER BENCHMARKS ===
+    std::cout << "\n=== ring_buffer Performance ===\n";
+
+    constexpr size_t ring_size = 1024;
+
+    bench.run("push_back ring_buffer<int64_t,1024> (fill)", []() {
+        ring_buffer<int64_t, ring_size> rb;
+        for (size_t i = 0; i < ring_size; ++i) {
+            rb.push_back(static_cast<int64_t>(i));
+        }
+        ankerl::nanobench::doNotOptimizeAway(rb);
+    });
+    bench.run("push_back ring_buffer<int64_t,1024> (overflow 4x)", []() {
+        ring_buffer<int64_t, ring_size> rb;
+        for (size_t i = 0; i < ring_size * 4; ++i) {
+            rb.push_back(static_cast<int64_t>(i));
+        }
+        ankerl::nanobench::doNotOptimizeAway(rb);
+    });
+
+    std::cout << "\n=== ring_buffer vs std::deque (FIFO Queue Pattern) ===\n";
+
+    // Simulate a FIFO queue pattern with fixed buffer
+    bench.run("FIFO std::deque<int64_t> (keep 1024 max)", []() {
+        std::deque<int64_t> dq;
+        for (size_t i = 0; i < times; ++i) {
+            dq.push_back(static_cast<int64_t>(i));
+            if (dq.size() > ring_size) {
+                dq.pop_front();
+            }
+        }
+        ankerl::nanobench::doNotOptimizeAway(dq);
+    });
+    bench.run("FIFO ring_buffer<int64_t,1024> (auto-overwrite)", []() {
+        ring_buffer<int64_t, ring_size> rb;
+        for (size_t i = 0; i < times; ++i) {
+            rb.push_back(static_cast<int64_t>(i));
+        }
+        ankerl::nanobench::doNotOptimizeAway(rb);
+    });
+
+    std::cout << "\n=== ring_buffer Iteration ===\n";
+
+    bench.run("iterate ring_buffer<int64_t,1024>", []() {
+        ring_buffer<int64_t, ring_size> rb;
+        for (size_t i = 0; i < ring_size; ++i) {
+            rb.push_back(static_cast<int64_t>(i));
+        }
+        int64_t sum = 0;
+        for (auto val : rb) {
+            sum += val;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
     });
 
     return 0;

--- a/container/devectra.hpp
+++ b/container/devectra.hpp
@@ -1,0 +1,853 @@
+/*
+ * Copyright 2025 ClapDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <algorithm>
+
+#include "vectra.hpp"
+
+namespace stdb::container {
+
+/*
+ * devectra is a double-ended vector that supports efficient insertion
+ * and removal at both ends.
+ *
+ * Template parameters:
+ *   T - Element type
+ *   Alloc - Allocator type (for API compatibility, currently unused)
+ *
+ * Key features:
+ *   - O(1) amortized push_front and push_back
+ *   - O(1) pop_front and pop_back
+ *   - O(1) random access
+ *   - Contiguous storage (unlike std::deque)
+ *   - Reserves space at both ends to minimize reallocations
+ *
+ * Use cases:
+ *   - Double-ended queue operations
+ *   - Undo/redo stacks
+ *   - Sliding window with additions at both ends
+ *   - When you need both push_front and push_back performance
+ */
+template <typename T, typename Alloc = std::allocator<T>>
+class devectra
+{
+   public:
+    using size_type = std::size_t;
+    using value_type = T;
+    using difference_type = std::ptrdiff_t;
+    using pointer = T*;
+    using const_pointer = const T*;
+    using reference = T&;
+    using const_reference = const T&;
+    using rvalue_reference = T&&;
+    using allocator_type = Alloc;
+
+   private:
+    T* _buffer = nullptr;     // Start of allocated buffer
+    size_type _offset = 0;    // Offset from buffer start to first element
+    size_type _size = 0;      // Number of elements
+    size_type _capacity = 0;  // Total buffer capacity
+
+    static constexpr size_type kDefaultCapacity = 8;
+    static constexpr size_type kGrowthNumerator = 3;
+    static constexpr size_type kGrowthDenominator = 2;
+
+    [[nodiscard, gnu::always_inline]] auto data_start() noexcept -> T* { return _buffer + _offset; }
+
+    [[nodiscard, gnu::always_inline]] auto data_start() const noexcept -> const T* { return _buffer + _offset; }
+
+    [[nodiscard, gnu::always_inline]] auto data_end() noexcept -> T* { return _buffer + _offset + _size; }
+
+    [[nodiscard, gnu::always_inline]] auto data_end() const noexcept -> const T* { return _buffer + _offset + _size; }
+
+    // Space available at front (before first element)
+    [[nodiscard]] auto front_spare() const noexcept -> size_type { return _offset; }
+
+    // Space available at back (after last element)
+    [[nodiscard]] auto back_spare() const noexcept -> size_type { return _capacity - _offset - _size; }
+
+    void allocate(size_type cap) {
+        _buffer = static_cast<T*>(std::malloc(cap * sizeof(T)));
+        if (_buffer == nullptr) [[unlikely]] {
+            throw std::bad_alloc();
+        }
+        _capacity = cap;
+    }
+
+    void deallocate() noexcept {
+        std::free(_buffer);
+        _buffer = nullptr;
+        _capacity = 0;
+    }
+
+    // Grow the buffer, centering elements to leave space at both ends
+    void grow(size_type min_capacity) {
+        size_type new_cap = std::max(min_capacity, (_capacity * kGrowthNumerator) / kGrowthDenominator + 1);
+        if (new_cap < kDefaultCapacity) {
+            new_cap = kDefaultCapacity;
+        }
+
+        T* new_buffer = static_cast<T*>(std::malloc(new_cap * sizeof(T)));
+        if (new_buffer == nullptr) [[unlikely]] {
+            throw std::bad_alloc();
+        }
+
+        // Center elements in new buffer
+        size_type new_offset = (new_cap - _size) / 2;
+
+        if (_size > 0) {
+            (void)move_range_without_overlap(new_buffer + new_offset, data_start(), data_end());
+        }
+
+        deallocate();
+        _buffer = new_buffer;
+        _offset = new_offset;
+        _capacity = new_cap;
+    }
+
+    // Make room at front by shifting elements or growing
+    // Optimized to avoid shifting on every alternating push_front/push_back
+    void make_room_front(size_type count = 1) {
+        if (front_spare() >= count) {
+            return;
+        }
+
+        size_type total_spare = front_spare() + back_spare();
+
+        // Only shift if back has SIGNIFICANTLY more space than we need
+        // This prevents shifting on every alternating push_front/push_back
+        constexpr size_type kShiftThreshold = 4;
+        if (total_spare >= count && back_spare() >= count * kShiftThreshold) {
+            // Shift elements to center (not all the way to back)
+            // Leave some slack on both sides for future operations
+            size_type target_front = (total_spare + count) / 2;
+            if (target_front < count) target_front = count;
+            size_type new_offset = target_front;
+            if (new_offset + _size > _capacity) new_offset = _capacity - _size;
+
+            if (new_offset > _offset && _size > 0) {
+                // Shift right
+                T* src = data_start();
+                T* dst = _buffer + new_offset;
+                if constexpr (IsRelocatable<T>) {
+                    std::memmove(dst, src, _size * sizeof(T));
+                } else {
+                    // Move from end to start to handle overlap
+                    for (size_type i = _size; i > 0; --i) {
+                        new (dst + i - 1) T(std::move(src[i - 1]));
+                        if constexpr (NeedsCleanUp<T>) {
+                            src[i - 1].~T();
+                        }
+                    }
+                }
+                _offset = new_offset;
+            }
+            return;
+        }
+
+        // Grow and center elements - leave room for both front and back operations
+        size_type min_cap = count + _size + count;  // Extra slack for back too
+        size_type new_cap = std::max(min_cap, (_capacity * kGrowthNumerator) / kGrowthDenominator + 1);
+        if (new_cap < kDefaultCapacity) {
+            new_cap = kDefaultCapacity;
+        }
+
+        T* new_buffer = static_cast<T*>(std::malloc(new_cap * sizeof(T)));
+        if (new_buffer == nullptr) [[unlikely]] {
+            throw std::bad_alloc();
+        }
+
+        // Center elements in new buffer
+        size_type new_offset = (new_cap - _size) / 2;
+        if (new_offset < count) {
+            new_offset = count;
+        }
+
+        if (_size > 0) {
+            (void)move_range_without_overlap(new_buffer + new_offset, data_start(), data_end());
+        }
+
+        deallocate();
+        _buffer = new_buffer;
+        _offset = new_offset;
+        _capacity = new_cap;
+    }
+
+    // Make room at back by shifting elements or growing
+    // Optimized to avoid shifting on every alternating push_front/push_back
+    void make_room_back(size_type count = 1) {
+        if (back_spare() >= count) {
+            return;
+        }
+
+        size_type total_spare = front_spare() + back_spare();
+
+        // Only shift if front has SIGNIFICANTLY more space than we need
+        constexpr size_type kShiftThreshold = 4;
+        if (total_spare >= count && front_spare() >= count * kShiftThreshold) {
+            // Shift elements to center (not all the way to front)
+            size_type target_back = (total_spare + count) / 2;
+            if (target_back < count) target_back = count;
+            size_type new_offset = _capacity - _size - target_back;
+            if (new_offset > _offset) new_offset = _offset;  // Don't shift right
+
+            if (new_offset < _offset && _size > 0) {
+                // Shift left
+                T* src = data_start();
+                T* dst = _buffer + new_offset;
+                if constexpr (IsRelocatable<T>) {
+                    std::memmove(dst, src, _size * sizeof(T));
+                } else {
+                    for (size_type i = 0; i < _size; ++i) {
+                        new (dst + i) T(std::move(src[i]));
+                        if constexpr (NeedsCleanUp<T>) {
+                            src[i].~T();
+                        }
+                    }
+                }
+                _offset = new_offset;
+            }
+            return;
+        }
+
+        // Grow and center elements - leave room for both front and back operations
+        size_type min_cap = count + _size + count;  // Extra slack for front too
+        size_type new_cap = std::max(min_cap, (_capacity * kGrowthNumerator) / kGrowthDenominator + 1);
+        if (new_cap < kDefaultCapacity) {
+            new_cap = kDefaultCapacity;
+        }
+
+        T* new_buffer = static_cast<T*>(std::malloc(new_cap * sizeof(T)));
+        if (new_buffer == nullptr) [[unlikely]] {
+            throw std::bad_alloc();
+        }
+
+        // Center elements in new buffer
+        size_type new_offset = (new_cap - _size) / 2;
+        if (new_offset + _size + count > new_cap) {
+            new_offset = new_cap - _size - count;
+        }
+
+        if (_size > 0) {
+            (void)move_range_without_overlap(new_buffer + new_offset, data_start(), data_end());
+        }
+
+        deallocate();
+        _buffer = new_buffer;
+        _offset = new_offset;
+        _capacity = new_cap;
+    }
+
+   public:
+    // Default constructor
+    constexpr devectra() noexcept = default;
+
+    // Constructor with size
+    explicit devectra(size_type count) {
+        if (count > 0) {
+            allocate(count);
+            _offset = 0;
+            _size = count;
+            construct_range(data_start(), data_end());
+        }
+    }
+
+    // Constructor with size and value
+    devectra(size_type count, const T& value) {
+        if (count > 0) {
+            allocate(count);
+            _offset = 0;
+            _size = count;
+            construct_range_with_cref(data_start(), data_end(), value);
+        }
+    }
+
+    // Constructor from iterators
+    template <std::forward_iterator InputIt>
+    devectra(InputIt first, InputIt last) {
+        auto dist = std::distance(first, last);
+        if (dist > 0) {
+            size_type count = static_cast<size_type>(dist);
+            allocate(count);
+            _offset = 0;
+            _size = count;
+            copy_from_iterator(data_start(), first, last);
+        }
+    }
+
+    // Constructor from initializer list
+    devectra(std::initializer_list<T> init) : devectra(init.begin(), init.end()) {}
+
+    // Copy constructor
+    devectra(const devectra& other) {
+        if (other._size > 0) {
+            allocate(other._size);
+            _offset = 0;
+            _size = other._size;
+            copy_range(data_start(), other.data_start(), other.data_end());
+        }
+    }
+
+    // Move constructor
+    devectra(devectra&& other) noexcept
+        : _buffer(other._buffer), _offset(other._offset), _size(other._size), _capacity(other._capacity) {
+        other._buffer = nullptr;
+        other._offset = 0;
+        other._size = 0;
+        other._capacity = 0;
+    }
+
+    // Copy assignment
+    auto operator=(const devectra& other) -> devectra& {
+        if (this == &other) [[unlikely]] {
+            return *this;
+        }
+
+        destroy_range(data_start(), data_end());
+
+        if (other._size > _capacity) {
+            deallocate();
+            allocate(other._size);
+        }
+
+        _offset = 0;
+        _size = other._size;
+        if (_size > 0) {
+            copy_range(data_start(), other.data_start(), other.data_end());
+        }
+        return *this;
+    }
+
+    // Move assignment
+    auto operator=(devectra&& other) noexcept -> devectra& {
+        if (this == &other) [[unlikely]] {
+            return *this;
+        }
+
+        destroy_range(data_start(), data_end());
+        deallocate();
+
+        _buffer = other._buffer;
+        _offset = other._offset;
+        _size = other._size;
+        _capacity = other._capacity;
+
+        other._buffer = nullptr;
+        other._offset = 0;
+        other._size = 0;
+        other._capacity = 0;
+
+        return *this;
+    }
+
+    ~devectra() {
+        destroy_range(data_start(), data_end());
+        deallocate();
+    }
+
+    // Capacity
+    [[nodiscard, gnu::always_inline]] constexpr auto size() const noexcept -> size_type { return _size; }
+
+    [[nodiscard, gnu::always_inline]] constexpr auto capacity() const noexcept -> size_type { return _capacity; }
+
+    [[nodiscard, gnu::always_inline]] constexpr auto empty() const noexcept -> bool { return _size == 0; }
+
+    [[nodiscard, gnu::always_inline]] constexpr auto max_size() const noexcept -> size_type {
+        return kFastVectorMaxSize / sizeof(T);
+    }
+
+    [[nodiscard]] auto front_capacity() const noexcept -> size_type { return front_spare(); }
+
+    [[nodiscard]] auto back_capacity() const noexcept -> size_type { return back_spare(); }
+
+    void reserve(size_type new_cap) {
+        if (new_cap > _capacity) {
+            grow(new_cap);
+        }
+    }
+
+    void reserve_front(size_type count) {
+        if (front_spare() < count) {
+            make_room_front(count);
+        }
+    }
+
+    void reserve_back(size_type count) {
+        if (back_spare() < count) {
+            make_room_back(count);
+        }
+    }
+
+    void shrink_to_fit() {
+        if (_size == 0) {
+            deallocate();
+            _offset = 0;
+            return;
+        }
+
+        if (_size == _capacity && _offset == 0) {
+            return;
+        }
+
+        T* new_buffer = static_cast<T*>(std::malloc(_size * sizeof(T)));
+        if (new_buffer == nullptr) [[unlikely]] {
+            return;  // Don't throw, just keep current allocation
+        }
+
+        (void)move_range_without_overlap(new_buffer, data_start(), data_end());
+        deallocate();
+        _buffer = new_buffer;
+        _offset = 0;
+        _capacity = _size;
+    }
+
+    // Element access
+    [[nodiscard, gnu::always_inline]] auto operator[](size_type index) noexcept -> reference {
+        Assert(index < _size, "index out of range");
+        return data_start()[index];
+    }
+
+    [[nodiscard, gnu::always_inline]] auto operator[](size_type index) const noexcept -> const_reference {
+        Assert(index < _size, "index out of range");
+        return data_start()[index];
+    }
+
+    [[nodiscard]] auto at(size_type index) -> reference {
+        if (index >= _size) [[unlikely]] {
+            throw std::out_of_range("devectra::at: index out of range");
+        }
+        return data_start()[index];
+    }
+
+    [[nodiscard]] auto at(size_type index) const -> const_reference {
+        if (index >= _size) [[unlikely]] {
+            throw std::out_of_range("devectra::at: index out of range");
+        }
+        return data_start()[index];
+    }
+
+    [[nodiscard, gnu::always_inline]] auto data() noexcept -> pointer { return data_start(); }
+
+    [[nodiscard, gnu::always_inline]] auto data() const noexcept -> const_pointer { return data_start(); }
+
+    [[nodiscard, gnu::always_inline]] auto front() noexcept -> reference {
+        Assert(_size > 0, "front on empty container");
+        return *data_start();
+    }
+
+    [[nodiscard, gnu::always_inline]] auto front() const noexcept -> const_reference {
+        Assert(_size > 0, "front on empty container");
+        return *data_start();
+    }
+
+    [[nodiscard, gnu::always_inline]] auto back() noexcept -> reference {
+        Assert(_size > 0, "back on empty container");
+        return *(data_end() - 1);
+    }
+
+    [[nodiscard, gnu::always_inline]] auto back() const noexcept -> const_reference {
+        Assert(_size > 0, "back on empty container");
+        return *(data_end() - 1);
+    }
+
+    // Modifiers - Front operations
+    void push_front(const value_type& value) {
+        make_room_front(1);
+        --_offset;
+        copy_cref(data_start(), value);
+        ++_size;
+    }
+
+    void push_front(value_type&& value) {
+        make_room_front(1);
+        --_offset;
+        copy_value(data_start(), std::move(value));
+        ++_size;
+    }
+
+    template <typename... Args>
+    auto emplace_front(Args&&... args) -> reference {
+        make_room_front(1);
+        --_offset;
+        new (data_start()) T(std::forward<Args>(args)...);
+        ++_size;
+        return front();
+    }
+
+    void pop_front() noexcept {
+        Assert(_size > 0, "pop_front on empty container");
+        destroy_ptr(data_start());
+        ++_offset;
+        --_size;
+    }
+
+    // Modifiers - Back operations
+    void push_back(const value_type& value) {
+        make_room_back(1);
+        copy_cref(data_end(), value);
+        ++_size;
+    }
+
+    void push_back(value_type&& value) {
+        make_room_back(1);
+        copy_value(data_end(), std::move(value));
+        ++_size;
+    }
+
+    template <typename... Args>
+    auto emplace_back(Args&&... args) -> reference {
+        make_room_back(1);
+        new (data_end()) T(std::forward<Args>(args)...);
+        ++_size;
+        return back();
+    }
+
+    void pop_back() noexcept {
+        Assert(_size > 0, "pop_back on empty container");
+        --_size;
+        destroy_ptr(data_end());
+    }
+
+    void clear() noexcept {
+        destroy_range(data_start(), data_end());
+        // Center the offset for future insertions
+        _offset = _capacity / 2;
+        _size = 0;
+    }
+
+    void resize(size_type count) {
+        if (count > _size) {
+            if (count > _capacity) {
+                grow(count);
+            } else if (_offset + count > _capacity) {
+                // Need to shift left
+                make_room_back(count - _size);
+            }
+            T* old_end = data_end();
+            _size = count;
+            construct_range(old_end, data_end());
+        } else if (count < _size) {
+            T* new_end = data_start() + count;
+            destroy_range(new_end, data_end());
+            _size = count;
+        }
+    }
+
+    void resize(size_type count, const value_type& value) {
+        if (count > _size) {
+            if (count > _capacity) {
+                grow(count);
+            } else if (_offset + count > _capacity) {
+                make_room_back(count - _size);
+            }
+            T* old_end = data_end();
+            _size = count;
+            construct_range_with_cref(old_end, data_end(), value);
+        } else if (count < _size) {
+            T* new_end = data_start() + count;
+            destroy_range(new_end, data_end());
+            _size = count;
+        }
+    }
+
+    void assign(size_type count, const value_type& value) {
+        destroy_range(data_start(), data_end());
+        if (count > _capacity) {
+            deallocate();
+            allocate(count);
+        }
+        _offset = (_capacity - count) / 2;
+        _size = count;
+        if (count > 0) {
+            construct_range_with_cref(data_start(), data_end(), value);
+        }
+    }
+
+    template <std::forward_iterator InputIt>
+    void assign(InputIt first, InputIt last) {
+        auto dist = std::distance(first, last);
+        Assert(dist >= 0, "invalid iterator range");
+        size_type count = static_cast<size_type>(dist);
+
+        destroy_range(data_start(), data_end());
+        if (count > _capacity) {
+            deallocate();
+            allocate(count);
+        }
+        _offset = (_capacity - count) / 2;
+        _size = count;
+        if (count > 0) {
+            copy_from_iterator(data_start(), first, last);
+        }
+    }
+
+    void assign(std::initializer_list<T> ilist) { assign(ilist.begin(), ilist.end()); }
+
+    // Iterator support
+    template <bool Const>
+    struct IteratorT
+    {
+        using iterator_category = std::contiguous_iterator_tag;
+        using difference_type = std::ptrdiff_t;
+        using value_type = std::conditional_t<Const, const T, T>;
+        using pointer = std::conditional_t<Const, const T*, T*>;
+        using reference = std::conditional_t<Const, const T&, T&>;
+
+       private:
+        pointer _ptr;
+
+       public:
+        IteratorT() : _ptr(nullptr) {}
+        ~IteratorT() = default;
+        explicit IteratorT(pointer ptr) : _ptr(ptr) {}
+        IteratorT(IteratorT&& rhs) noexcept : _ptr(std::exchange(rhs._ptr, nullptr)) {}
+        IteratorT(const IteratorT&) noexcept = default;
+
+        template <bool OtherConst>
+        requires(!OtherConst && Const)
+        IteratorT(IteratorT<OtherConst> rhs) noexcept : _ptr(rhs.operator->()) {}
+
+        auto operator=(IteratorT&& rhs) noexcept -> IteratorT& {
+            _ptr = std::exchange(rhs._ptr, nullptr);
+            return *this;
+        }
+        auto operator=(const IteratorT&) noexcept -> IteratorT& = default;
+
+        [[gnu::always_inline]] constexpr auto operator++() noexcept -> IteratorT& {
+            ++_ptr;
+            return *this;
+        }
+        [[gnu::always_inline, nodiscard]] constexpr auto operator++(int) noexcept -> IteratorT {
+            auto tmp = *this;
+            ++_ptr;
+            return tmp;
+        }
+        [[gnu::always_inline]] constexpr auto operator--() noexcept -> IteratorT& {
+            --_ptr;
+            return *this;
+        }
+        [[gnu::always_inline, nodiscard]] constexpr auto operator--(int) noexcept -> IteratorT {
+            auto tmp = *this;
+            --_ptr;
+            return tmp;
+        }
+        [[gnu::always_inline]] constexpr auto operator+=(difference_type n) noexcept -> IteratorT& {
+            _ptr += n;
+            return *this;
+        }
+        [[gnu::always_inline]] constexpr auto operator-=(difference_type n) noexcept -> IteratorT& {
+            _ptr -= n;
+            return *this;
+        }
+
+        [[nodiscard, gnu::always_inline]] constexpr auto operator*() const noexcept -> reference { return *_ptr; }
+        [[nodiscard, gnu::always_inline]] constexpr auto operator->() const noexcept -> pointer { return _ptr; }
+        [[nodiscard, gnu::always_inline]] constexpr auto operator[](size_type pos) const noexcept -> reference {
+            return *(_ptr + pos);
+        }
+
+        friend auto operator<=>(const IteratorT& lhs, const IteratorT& rhs) noexcept -> std::strong_ordering = default;
+        friend auto operator-(const IteratorT& lhs, const IteratorT& rhs) noexcept -> difference_type {
+            return lhs._ptr - rhs._ptr;
+        }
+        friend auto operator+(const IteratorT& lhs, difference_type offset) noexcept -> IteratorT {
+            return IteratorT{lhs._ptr + offset};
+        }
+        friend auto operator-(const IteratorT& lhs, difference_type offset) noexcept -> IteratorT {
+            return IteratorT{lhs._ptr - offset};
+        }
+        friend auto operator+(difference_type offset, const IteratorT& rhs) noexcept -> IteratorT {
+            return IteratorT{rhs._ptr + offset};
+        }
+    };
+
+    using iterator = IteratorT<false>;
+    using const_iterator = IteratorT<true>;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+    [[nodiscard]] auto begin() noexcept -> iterator { return iterator(data_start()); }
+    [[nodiscard]] auto begin() const noexcept -> const_iterator { return const_iterator(data_start()); }
+    [[nodiscard]] auto cbegin() const noexcept -> const_iterator { return const_iterator(data_start()); }
+    [[nodiscard]] auto end() noexcept -> iterator { return iterator(data_end()); }
+    [[nodiscard]] auto end() const noexcept -> const_iterator { return const_iterator(data_end()); }
+    [[nodiscard]] auto cend() const noexcept -> const_iterator { return const_iterator(data_end()); }
+    [[nodiscard]] auto rbegin() noexcept -> reverse_iterator { return std::make_reverse_iterator(end()); }
+    [[nodiscard]] auto rbegin() const noexcept -> const_reverse_iterator { return std::make_reverse_iterator(end()); }
+    [[nodiscard]] auto crbegin() const noexcept -> const_reverse_iterator { return std::make_reverse_iterator(cend()); }
+    [[nodiscard]] auto rend() noexcept -> reverse_iterator { return std::make_reverse_iterator(begin()); }
+    [[nodiscard]] auto rend() const noexcept -> const_reverse_iterator { return std::make_reverse_iterator(begin()); }
+    [[nodiscard]] auto crend() const noexcept -> const_reverse_iterator { return std::make_reverse_iterator(cbegin()); }
+
+    // Swap
+    void swap(devectra& other) noexcept {
+        std::swap(_buffer, other._buffer);
+        std::swap(_offset, other._offset);
+        std::swap(_size, other._size);
+        std::swap(_capacity, other._capacity);
+    }
+
+    // Erase
+    auto erase(const_iterator pos) -> iterator {
+        Assert(pos >= cbegin() && pos < cend(), "invalid iterator");
+        T* pos_ptr = const_cast<T*>(pos.operator->());
+        destroy_ptr(pos_ptr);
+        move_range_forward(pos_ptr, pos_ptr + 1, data_end());
+        --_size;
+        return iterator(pos_ptr);
+    }
+
+    auto erase(const_iterator first, const_iterator last) -> iterator {
+        Assert(first >= cbegin() && last <= cend(), "invalid range");
+        Assert(last >= first, "invalid range");
+        T* first_ptr = const_cast<T*>(first.operator->());
+        T* last_ptr = const_cast<T*>(last.operator->());
+        if (first_ptr != last_ptr) {
+            destroy_range(first_ptr, last_ptr);
+            move_range_forward(first_ptr, last_ptr, data_end());
+            _size -= static_cast<size_type>(last_ptr - first_ptr);
+        }
+        return iterator(first_ptr);
+    }
+
+    // Insert
+    auto insert(const_iterator pos, const value_type& value) -> iterator {
+        size_type index = pos.operator->() - data_start();
+        Assert(index <= _size, "invalid iterator");
+
+        // Decide whether to shift left or right based on position
+        if (index <= _size / 2) {
+            // Closer to front - shift front elements left
+            make_room_front(1);
+            --_offset;
+            ++_size;
+            T* new_pos = data_start() + index;
+            if (index > 0) {
+                // Move elements [0, index) one position left
+                move_range_forward(data_start(), data_start() + 1, new_pos + 1);
+            }
+            copy_cref(new_pos, value);
+            return iterator(new_pos);
+        } else {
+            // Closer to back - shift back elements right
+            make_room_back(1);
+            T* pos_ptr = data_start() + index;
+            if (index < _size) {
+                // Move elements [index, size) one position right
+                // Use backward move to handle overlap
+                T* src_end = data_end();
+                T* dst_end = src_end + 1;
+                if constexpr (IsRelocatable<T>) {
+                    std::memmove(pos_ptr + 1, pos_ptr, (_size - index) * sizeof(T));
+                } else {
+                    for (T* p = src_end - 1; p >= pos_ptr; --p) {
+                        new (p + 1) T(std::move(*p));
+                        if constexpr (NeedsCleanUp<T>) {
+                            p->~T();
+                        }
+                    }
+                }
+            }
+            copy_cref(pos_ptr, value);
+            ++_size;
+            return iterator(pos_ptr);
+        }
+    }
+
+    auto insert(const_iterator pos, value_type&& value) -> iterator {
+        size_type index = pos.operator->() - data_start();
+        Assert(index <= _size, "invalid iterator");
+
+        if (index <= _size / 2) {
+            make_room_front(1);
+            --_offset;
+            ++_size;
+            T* new_pos = data_start() + index;
+            if (index > 0) {
+                move_range_forward(data_start(), data_start() + 1, new_pos + 1);
+            }
+            copy_value(new_pos, std::move(value));
+            return iterator(new_pos);
+        } else {
+            make_room_back(1);
+            T* pos_ptr = data_start() + index;
+            if (index < _size) {
+                if constexpr (IsRelocatable<T>) {
+                    std::memmove(pos_ptr + 1, pos_ptr, (_size - index) * sizeof(T));
+                } else {
+                    for (T* p = data_end() - 1; p >= pos_ptr; --p) {
+                        new (p + 1) T(std::move(*p));
+                        if constexpr (NeedsCleanUp<T>) {
+                            p->~T();
+                        }
+                    }
+                }
+            }
+            copy_value(pos_ptr, std::move(value));
+            ++_size;
+            return iterator(pos_ptr);
+        }
+    }
+};
+
+// Comparison operators
+template <typename T>
+auto operator==(const devectra<T>& lhs, const devectra<T>& rhs) -> bool {
+    if (lhs.size() != rhs.size()) return false;
+    for (std::size_t i = 0; i < lhs.size(); ++i) {
+        if (lhs[i] != rhs[i]) return false;
+    }
+    return true;
+}
+
+template <typename T>
+auto operator<=>(const devectra<T>& lhs, const devectra<T>& rhs) -> std::strong_ordering {
+    for (std::size_t i = 0; i < std::min(lhs.size(), rhs.size()); ++i) {
+        if (lhs[i] < rhs[i]) return std::strong_ordering::less;
+        if (lhs[i] > rhs[i]) return std::strong_ordering::greater;
+    }
+    if (lhs.size() < rhs.size()) return std::strong_ordering::less;
+    if (lhs.size() > rhs.size()) return std::strong_ordering::greater;
+    return std::strong_ordering::equal;
+}
+
+}  // namespace stdb::container
+
+namespace std {
+
+template <typename T>
+constexpr void swap(stdb::container::devectra<T>& lhs, stdb::container::devectra<T>& rhs) noexcept {
+    lhs.swap(rhs);
+}
+
+template <typename T, typename U>
+constexpr auto erase(stdb::container::devectra<T>& vec, const U& value) -> std::size_t {
+    auto it = std::remove(vec.begin(), vec.end(), value);
+    auto count = vec.end() - it;
+    vec.erase(it, vec.end());
+    return count;
+}
+
+template <typename T, typename Pred>
+constexpr auto erase_if(stdb::container::devectra<T>& vec, Pred pred) -> std::size_t {
+    auto it = std::remove_if(vec.begin(), vec.end(), pred);
+    auto count = vec.end() - it;
+    vec.erase(it, vec.end());
+    return count;
+}
+
+}  // namespace std

--- a/container/ring_buffer.hpp
+++ b/container/ring_buffer.hpp
@@ -1,0 +1,450 @@
+/*
+ * Copyright 2025 ClapDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <algorithm>
+#include <optional>
+
+#include "vectra.hpp"
+
+namespace stdb::container {
+
+/*
+ * ring_buffer is a fixed-size circular buffer.
+ * When full, new elements overwrite the oldest elements.
+ *
+ * Template parameters:
+ *   T - Element type
+ *   N - Buffer capacity (fixed at compile time)
+ *
+ * Key features:
+ *   - Fixed capacity, no dynamic allocation
+ *   - FIFO semantics: push_back adds to tail, pop_front removes from head
+ *   - When full, push_back overwrites the oldest element
+ *   - O(1) push_back, pop_front, front, back operations
+ *   - Supports iteration over all elements (oldest to newest)
+ *
+ * Use cases:
+ *   - Logging buffers (keep last N entries)
+ *   - Audio/video sample buffers
+ *   - Sliding window algorithms
+ *   - Producer-consumer patterns with bounded buffer
+ */
+template <typename T, std::size_t N>
+class ring_buffer
+{
+    static_assert(N > 0, "ring_buffer capacity must be greater than 0");
+
+   public:
+    using size_type = std::size_t;
+    using value_type = T;
+    using difference_type = std::ptrdiff_t;
+    using pointer = T*;
+    using const_pointer = const T*;
+    using reference = T&;
+    using const_reference = const T&;
+
+    static constexpr size_type static_capacity = N;
+
+   private:
+    alignas(T) std::byte _storage[N * sizeof(T)];
+    size_type _head = 0;  // Index of the oldest element (front)
+    size_type _size = 0;  // Current number of elements
+
+    [[nodiscard, gnu::always_inline]] auto storage_ptr() noexcept -> T* { return reinterpret_cast<T*>(_storage); }
+
+    [[nodiscard, gnu::always_inline]] auto storage_ptr() const noexcept -> const T* {
+        return reinterpret_cast<const T*>(_storage);
+    }
+
+    // Get the actual index in storage for a logical index
+    [[nodiscard, gnu::always_inline]] constexpr auto actual_index(size_type logical_idx) const noexcept -> size_type {
+        return (_head + logical_idx) % N;
+    }
+
+    // Get the tail index (where next element will be written)
+    [[nodiscard, gnu::always_inline]] constexpr auto tail_index() const noexcept -> size_type {
+        return (_head + _size) % N;
+    }
+
+   public:
+    // Default constructor
+    constexpr ring_buffer() noexcept = default;
+
+    // Constructor with initial elements
+    ring_buffer(std::initializer_list<T> init) {
+        for (const auto& elem : init) {
+            push_back(elem);
+        }
+    }
+
+    // Copy constructor
+    ring_buffer(const ring_buffer& other) : _head(0), _size(0) {
+        for (size_type i = 0; i < other._size; ++i) {
+            push_back(other[i]);
+        }
+    }
+
+    // Move constructor
+    ring_buffer(ring_buffer&& other) noexcept : _head(0), _size(0) {
+        for (size_type i = 0; i < other._size; ++i) {
+            push_back(std::move(other[i]));
+        }
+        other.clear();
+    }
+
+    // Copy assignment
+    auto operator=(const ring_buffer& other) -> ring_buffer& {
+        if (this == &other) [[unlikely]] {
+            return *this;
+        }
+        clear();
+        for (size_type i = 0; i < other._size; ++i) {
+            push_back(other[i]);
+        }
+        return *this;
+    }
+
+    // Move assignment
+    auto operator=(ring_buffer&& other) noexcept -> ring_buffer& {
+        if (this == &other) [[unlikely]] {
+            return *this;
+        }
+        clear();
+        for (size_type i = 0; i < other._size; ++i) {
+            push_back(std::move(other[i]));
+        }
+        other.clear();
+        return *this;
+    }
+
+    ~ring_buffer() { clear(); }
+
+    // Capacity
+    [[nodiscard, gnu::always_inline]] constexpr auto size() const noexcept -> size_type { return _size; }
+
+    [[nodiscard, gnu::always_inline]] static constexpr auto capacity() noexcept -> size_type { return N; }
+
+    [[nodiscard, gnu::always_inline]] static constexpr auto max_size() noexcept -> size_type { return N; }
+
+    [[nodiscard, gnu::always_inline]] constexpr auto empty() const noexcept -> bool { return _size == 0; }
+
+    [[nodiscard, gnu::always_inline]] constexpr auto full() const noexcept -> bool { return _size == N; }
+
+    [[nodiscard, gnu::always_inline]] constexpr auto available() const noexcept -> size_type { return N - _size; }
+
+    // Element access
+    [[nodiscard, gnu::always_inline]] auto operator[](size_type index) noexcept -> reference {
+        Assert(index < _size, "index out of range");
+        return storage_ptr()[actual_index(index)];
+    }
+
+    [[nodiscard, gnu::always_inline]] auto operator[](size_type index) const noexcept -> const_reference {
+        Assert(index < _size, "index out of range");
+        return storage_ptr()[actual_index(index)];
+    }
+
+    [[nodiscard]] auto at(size_type index) -> reference {
+        if (index >= _size) [[unlikely]] {
+            throw std::out_of_range("ring_buffer::at: index out of range");
+        }
+        return storage_ptr()[actual_index(index)];
+    }
+
+    [[nodiscard]] auto at(size_type index) const -> const_reference {
+        if (index >= _size) [[unlikely]] {
+            throw std::out_of_range("ring_buffer::at: index out of range");
+        }
+        return storage_ptr()[actual_index(index)];
+    }
+
+    [[nodiscard, gnu::always_inline]] auto front() noexcept -> reference {
+        Assert(_size > 0, "front on empty buffer");
+        return storage_ptr()[_head];
+    }
+
+    [[nodiscard, gnu::always_inline]] auto front() const noexcept -> const_reference {
+        Assert(_size > 0, "front on empty buffer");
+        return storage_ptr()[_head];
+    }
+
+    [[nodiscard, gnu::always_inline]] auto back() noexcept -> reference {
+        Assert(_size > 0, "back on empty buffer");
+        return storage_ptr()[actual_index(_size - 1)];
+    }
+
+    [[nodiscard, gnu::always_inline]] auto back() const noexcept -> const_reference {
+        Assert(_size > 0, "back on empty buffer");
+        return storage_ptr()[actual_index(_size - 1)];
+    }
+
+    // Modifiers
+
+    // Push element to the back. If full, overwrites the oldest element.
+    void push_back(const value_type& value) {
+        if (_size == N) {
+            // Overwrite oldest element
+            storage_ptr()[_head] = value;
+            _head = (_head + 1) % N;
+        } else {
+            new (storage_ptr() + tail_index()) T(value);
+            ++_size;
+        }
+    }
+
+    void push_back(value_type&& value) {
+        if (_size == N) {
+            // Overwrite oldest element
+            storage_ptr()[_head] = std::move(value);
+            _head = (_head + 1) % N;
+        } else {
+            new (storage_ptr() + tail_index()) T(std::move(value));
+            ++_size;
+        }
+    }
+
+    template <typename... Args>
+    auto emplace_back(Args&&... args) -> reference {
+        if (_size == N) {
+            // Destroy oldest and construct new in its place
+            T* ptr = storage_ptr() + _head;
+            ptr->~T();
+            new (ptr) T(std::forward<Args>(args)...);
+            _head = (_head + 1) % N;
+            return *ptr;
+        } else {
+            T* ptr = storage_ptr() + tail_index();
+            new (ptr) T(std::forward<Args>(args)...);
+            ++_size;
+            return *ptr;
+        }
+    }
+
+    // Push element, but don't overwrite if full. Returns false if buffer was full.
+    auto try_push_back(const value_type& value) -> bool {
+        if (_size == N) {
+            return false;
+        }
+        new (storage_ptr() + tail_index()) T(value);
+        ++_size;
+        return true;
+    }
+
+    auto try_push_back(value_type&& value) -> bool {
+        if (_size == N) {
+            return false;
+        }
+        new (storage_ptr() + tail_index()) T(std::move(value));
+        ++_size;
+        return true;
+    }
+
+    // Pop from front (oldest element)
+    void pop_front() noexcept {
+        Assert(_size > 0, "pop_front on empty buffer");
+        destroy_ptr(storage_ptr() + _head);
+        _head = (_head + 1) % N;
+        --_size;
+    }
+
+    // Pop from back (newest element)
+    void pop_back() noexcept {
+        Assert(_size > 0, "pop_back on empty buffer");
+        --_size;
+        destroy_ptr(storage_ptr() + actual_index(_size));
+    }
+
+    // Try to pop front, returns the value if successful
+    [[nodiscard]] auto try_pop_front() -> std::optional<T> {
+        if (_size == 0) {
+            return std::nullopt;
+        }
+        T* ptr = storage_ptr() + _head;
+        std::optional<T> result(std::move(*ptr));
+        destroy_ptr(ptr);
+        _head = (_head + 1) % N;
+        --_size;
+        return result;
+    }
+
+    void clear() noexcept {
+        for (size_type i = 0; i < _size; ++i) {
+            destroy_ptr(storage_ptr() + actual_index(i));
+        }
+        _head = 0;
+        _size = 0;
+    }
+
+    // Iterator support
+    template <bool Const>
+    class IteratorT
+    {
+       public:
+        using iterator_category = std::random_access_iterator_tag;
+        using difference_type = std::ptrdiff_t;
+        using value_type = std::conditional_t<Const, const T, T>;
+        using pointer = std::conditional_t<Const, const T*, T*>;
+        using reference = std::conditional_t<Const, const T&, T&>;
+
+       private:
+        using buffer_ptr = std::conditional_t<Const, const ring_buffer*, ring_buffer*>;
+        buffer_ptr _buffer;
+        size_type _index;  // Logical index (0 = front)
+
+       public:
+        IteratorT() : _buffer(nullptr), _index(0) {}
+        IteratorT(buffer_ptr buf, size_type idx) : _buffer(buf), _index(idx) {}
+        ~IteratorT() = default;
+        IteratorT(const IteratorT&) = default;
+        IteratorT(IteratorT&&) noexcept = default;
+        auto operator=(const IteratorT&) -> IteratorT& = default;
+        auto operator=(IteratorT&&) noexcept -> IteratorT& = default;
+
+        // Convert mutable to const iterator
+        template <bool OtherConst>
+        requires(!OtherConst && Const)
+        IteratorT(const IteratorT<OtherConst>& other) : _buffer(other._buffer), _index(other._index) {}
+
+        [[nodiscard]] auto operator*() const -> reference { return (*_buffer)[_index]; }
+
+        [[nodiscard]] auto operator->() const -> pointer { return &(*_buffer)[_index]; }
+
+        [[nodiscard]] auto operator[](difference_type n) const -> reference { return (*_buffer)[_index + n]; }
+
+        auto operator++() -> IteratorT& {
+            ++_index;
+            return *this;
+        }
+        auto operator++(int) -> IteratorT {
+            auto tmp = *this;
+            ++_index;
+            return tmp;
+        }
+        auto operator--() -> IteratorT& {
+            --_index;
+            return *this;
+        }
+        auto operator--(int) -> IteratorT {
+            auto tmp = *this;
+            --_index;
+            return tmp;
+        }
+
+        auto operator+=(difference_type n) -> IteratorT& {
+            _index += n;
+            return *this;
+        }
+        auto operator-=(difference_type n) -> IteratorT& {
+            _index -= n;
+            return *this;
+        }
+
+        friend auto operator+(const IteratorT& it, difference_type n) -> IteratorT {
+            return IteratorT{it._buffer, it._index + n};
+        }
+        friend auto operator+(difference_type n, const IteratorT& it) -> IteratorT {
+            return IteratorT{it._buffer, it._index + n};
+        }
+        friend auto operator-(const IteratorT& it, difference_type n) -> IteratorT {
+            return IteratorT{it._buffer, it._index - n};
+        }
+        friend auto operator-(const IteratorT& lhs, const IteratorT& rhs) -> difference_type {
+            return static_cast<difference_type>(lhs._index) - static_cast<difference_type>(rhs._index);
+        }
+
+        friend auto operator==(const IteratorT& lhs, const IteratorT& rhs) -> bool {
+            return lhs._buffer == rhs._buffer && lhs._index == rhs._index;
+        }
+        friend auto operator!=(const IteratorT& lhs, const IteratorT& rhs) -> bool { return !(lhs == rhs); }
+        friend auto operator<(const IteratorT& lhs, const IteratorT& rhs) -> bool { return lhs._index < rhs._index; }
+        friend auto operator<=(const IteratorT& lhs, const IteratorT& rhs) -> bool { return lhs._index <= rhs._index; }
+        friend auto operator>(const IteratorT& lhs, const IteratorT& rhs) -> bool { return lhs._index > rhs._index; }
+        friend auto operator>=(const IteratorT& lhs, const IteratorT& rhs) -> bool { return lhs._index >= rhs._index; }
+
+        // Allow const_iterator to access private members of iterator
+        template <bool>
+        friend class IteratorT;
+    };
+
+    using iterator = IteratorT<false>;
+    using const_iterator = IteratorT<true>;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+    [[nodiscard]] auto begin() noexcept -> iterator { return iterator(this, 0); }
+    [[nodiscard]] auto begin() const noexcept -> const_iterator { return const_iterator(this, 0); }
+    [[nodiscard]] auto cbegin() const noexcept -> const_iterator { return const_iterator(this, 0); }
+    [[nodiscard]] auto end() noexcept -> iterator { return iterator(this, _size); }
+    [[nodiscard]] auto end() const noexcept -> const_iterator { return const_iterator(this, _size); }
+    [[nodiscard]] auto cend() const noexcept -> const_iterator { return const_iterator(this, _size); }
+    [[nodiscard]] auto rbegin() noexcept -> reverse_iterator { return std::make_reverse_iterator(end()); }
+    [[nodiscard]] auto rbegin() const noexcept -> const_reverse_iterator { return std::make_reverse_iterator(end()); }
+    [[nodiscard]] auto crbegin() const noexcept -> const_reverse_iterator { return std::make_reverse_iterator(cend()); }
+    [[nodiscard]] auto rend() noexcept -> reverse_iterator { return std::make_reverse_iterator(begin()); }
+    [[nodiscard]] auto rend() const noexcept -> const_reverse_iterator { return std::make_reverse_iterator(begin()); }
+    [[nodiscard]] auto crend() const noexcept -> const_reverse_iterator { return std::make_reverse_iterator(cbegin()); }
+
+    // Swap
+    void swap(ring_buffer& other) noexcept {
+        ring_buffer temp(std::move(*this));
+        *this = std::move(other);
+        other = std::move(temp);
+    }
+
+    // Linearize: copy elements to a contiguous array (oldest first)
+    template <typename OutputIt>
+    void copy_to(OutputIt out) const {
+        for (size_type i = 0; i < _size; ++i) {
+            *out++ = (*this)[i];
+        }
+    }
+
+    // Check if a value exists
+    [[nodiscard]] auto contains(const value_type& value) const -> bool {
+        for (size_type i = 0; i < _size; ++i) {
+            if ((*this)[i] == value) {
+                return true;
+            }
+        }
+        return false;
+    }
+};
+
+// Comparison operators
+template <typename T, std::size_t N>
+auto operator==(const ring_buffer<T, N>& lhs, const ring_buffer<T, N>& rhs) -> bool {
+    if (lhs.size() != rhs.size()) return false;
+    for (std::size_t i = 0; i < lhs.size(); ++i) {
+        if (lhs[i] != rhs[i]) return false;
+    }
+    return true;
+}
+
+template <typename T, std::size_t N>
+auto operator!=(const ring_buffer<T, N>& lhs, const ring_buffer<T, N>& rhs) -> bool {
+    return !(lhs == rhs);
+}
+
+}  // namespace stdb::container
+
+namespace std {
+
+template <typename T, std::size_t N>
+void swap(stdb::container::ring_buffer<T, N>& lhs, stdb::container::ring_buffer<T, N>& rhs) noexcept {
+    lhs.swap(rhs);
+}
+
+}  // namespace std

--- a/container/small_vectra.hpp
+++ b/container/small_vectra.hpp
@@ -1,0 +1,865 @@
+/*
+ * Copyright 2025 ClapDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <algorithm>
+
+#include "vectra.hpp"
+
+namespace stdb::container {
+
+/*
+ * small_vectra is a vector-like container with inline storage optimization.
+ * It stores up to N elements inline (no heap allocation), and automatically
+ * switches to heap allocation when capacity exceeds N.
+ *
+ * Template parameters:
+ *   T - Element type
+ *   N - Number of elements to store inline (default: calculated from 64 bytes)
+ *   Alloc - Allocator type (for API compatibility, currently unused)
+ *
+ * Key features:
+ *   - Zero heap allocation for small sizes (≤ N elements)
+ *   - Automatic transition to heap when capacity > N
+ *   - Same API as vectra/std::vector
+ *   - Supports Safe/Unsafe modes like vectra
+ */
+template <typename T, std::size_t N = (sizeof(T) >= 64 ? 1 : 64 / sizeof(T)), typename Alloc = std::allocator<T>>
+class small_vectra
+{
+   public:
+    using size_type = std::size_t;
+    using value_type = T;
+    using difference_type = std::ptrdiff_t;
+    using pointer = T*;
+    using const_pointer = const T*;
+    using reference = T&;
+    using const_reference = const T&;
+    using rvalue_reference = T&&;
+    using allocator_type = Alloc;
+
+    static constexpr size_type inline_capacity = N;
+
+   private:
+    // Inline storage - properly aligned for T
+    alignas(T) std::byte _inline_storage[N * sizeof(T)];
+
+    T* _start;   // buffer start
+    T* _finish;  // valid end (one past last element)
+    T* _edge;    // buffer end (capacity boundary)
+
+    [[nodiscard, gnu::always_inline]] auto inline_ptr() noexcept -> T* { return reinterpret_cast<T*>(_inline_storage); }
+
+    [[nodiscard, gnu::always_inline]] auto inline_ptr() const noexcept -> const T* {
+        return reinterpret_cast<const T*>(_inline_storage);
+    }
+
+    [[nodiscard, gnu::always_inline]] auto is_inline() const noexcept -> bool {
+        return _start == reinterpret_cast<const T*>(_inline_storage);
+    }
+
+    void allocate_heap(size_type cap) {
+        Assert(cap > N, "allocate_heap should only be called when cap > N");
+        _start = static_cast<T*>(std::malloc(cap * sizeof(T)));
+        if (_start == nullptr) [[unlikely]] {
+            throw std::bad_alloc();
+        }
+        _edge = _start + cap;
+    }
+
+    void free_heap() noexcept {
+        if (!is_inline()) {
+            std::free(_start);
+        }
+    }
+
+    // Migrate from inline to heap storage
+    void migrate_to_heap(size_type new_cap) {
+        Assert(is_inline(), "migrate_to_heap should only be called when inline");
+        Assert(new_cap > N, "new_cap should be larger than inline capacity");
+
+        T* old_start = _start;
+        T* old_finish = _finish;
+        size_type old_size = size();
+
+        allocate_heap(new_cap);
+        _finish = _start + old_size;
+
+        if (old_size > 0) {
+            (void)move_range_without_overlap(_start, old_start, old_finish);
+        }
+    }
+
+    // Reallocate heap storage with existing data (grow only)
+    void realloc_heap(size_type new_cap) {
+        Assert(!is_inline(), "realloc_heap should only be called when on heap");
+        Assert(new_cap > capacity(), "new_cap should be larger than current capacity");
+
+        T* old_start = _start;
+        T* old_finish = _finish;
+        size_type old_size = size();
+
+        allocate_heap(new_cap);
+        _finish = _start + old_size;
+
+        if (old_size > 0) {
+            (void)move_range_without_overlap(_start, old_start, old_finish);
+        }
+        std::free(old_start);
+    }
+
+    // Shrink heap storage to fit current size
+    void shrink_heap(size_type new_cap) {
+        Assert(!is_inline(), "shrink_heap should only be called when on heap");
+        Assert(new_cap >= size(), "new_cap should be at least current size");
+        Assert(new_cap < capacity(), "new_cap should be smaller than current capacity");
+
+        T* old_start = _start;
+        T* old_finish = _finish;
+        size_type old_size = size();
+
+        _start = static_cast<T*>(std::malloc(new_cap * sizeof(T)));
+        if (_start == nullptr) [[unlikely]] {
+            _start = old_start;  // Restore on failure
+            throw std::bad_alloc();
+        }
+        _edge = _start + new_cap;
+        _finish = _start + old_size;
+
+        if (old_size > 0) {
+            (void)move_range_without_overlap(_start, old_start, old_finish);
+        }
+        std::free(old_start);
+    }
+
+    // Reallocate (handles both inline->heap and heap->larger heap)
+    void realloc_with_old_data(size_type new_cap) {
+        if (is_inline()) {
+            migrate_to_heap(new_cap);
+        } else {
+            realloc_heap(new_cap);
+        }
+    }
+
+    // Reallocate and emplace an element at the end
+    template <typename... Args>
+    void realloc_and_emplace_back(size_type new_cap, Args&&... args) {
+        Assert(new_cap > size(), "new_cap should be larger than current size");
+
+        T* old_start = _start;
+        T* old_finish = _finish;
+        size_type old_size = size();
+        bool was_inline = is_inline();
+
+        allocate_heap(new_cap);
+        _finish = _start + old_size;
+        new (_finish++) T(std::forward<Args>(args)...);
+
+        if (old_size > 0) {
+            (void)move_range_without_overlap(_start, old_start, old_finish);
+        }
+
+        if (!was_inline) {
+            std::free(old_start);
+        }
+    }
+
+    [[nodiscard]] auto compute_new_capacity(size_type new_size) const -> size_type {
+        Assert(new_size > capacity(), "new_size should be larger than current capacity");
+        if (auto next_cap = compute_next_capacity(); next_cap > new_size) {
+            return next_cap;
+        }
+        return new_size;
+    }
+
+    [[nodiscard]] auto compute_next_capacity() const -> size_type {
+        auto cap = capacity();
+        if (cap < 4096 * 32 / sizeof(T) && cap >= N) [[likely]] {
+            return (cap * 3 + 1) / 2;
+        }
+        if (cap >= 4096 * 32 / sizeof(T)) [[likely]] {
+            return cap * 2;
+        }
+        // Initial expansion from inline: at least double the inline capacity
+        return std::max(N * 2, size_type(1));
+    }
+
+   public:
+    // Default constructor - uses inline storage
+    constexpr small_vectra() noexcept
+        : _start(reinterpret_cast<T*>(_inline_storage)),
+          _finish(reinterpret_cast<T*>(_inline_storage)),
+          _edge(reinterpret_cast<T*>(_inline_storage) + N) {}
+
+    constexpr explicit small_vectra([[maybe_unused]] const Alloc& alloc) noexcept : small_vectra() {}
+
+    // Constructor with size
+    explicit small_vectra(size_type count) : small_vectra() {
+        if (count > N) {
+            allocate_heap(count);
+        }
+        _finish = _start + count;
+        if (count > 0) {
+            construct_range(_start, _finish);
+        }
+    }
+
+    // Constructor with size and value
+    small_vectra(size_type count, const T& value) : small_vectra() {
+        if (count > N) {
+            allocate_heap(count);
+        }
+        _finish = _start + count;
+        if (count > 0) {
+            construct_range_with_cref(_start, _finish, value);
+        }
+    }
+
+    // Constructor from iterators
+    template <std::forward_iterator InputIt>
+    small_vectra(InputIt first, InputIt last) : small_vectra() {
+        auto dist = std::distance(first, last);
+        Assert(dist >= 0, "invalid iterator range");
+        size_type count = static_cast<size_type>(dist);
+
+        if (count > N) {
+            allocate_heap(count);
+        }
+        if (count > 0) {
+            copy_from_iterator(_start, first, last);
+            _finish = _start + count;
+        }
+    }
+
+    // Constructor from initializer list
+    small_vectra(std::initializer_list<T> init) : small_vectra(init.begin(), init.end()) {}
+
+    // Copy constructor
+    small_vectra(const small_vectra& other) : small_vectra() {
+        size_type other_size = other.size();
+        if (other_size > N) {
+            allocate_heap(other_size);
+        }
+        if (other_size > 0) {
+            copy_range(_start, other._start, other._finish);
+            _finish = _start + other_size;
+        }
+    }
+
+    // Move constructor
+    small_vectra(small_vectra&& other) noexcept : small_vectra() {
+        if (other.is_inline()) {
+            // Move elements from other's inline storage to our inline storage
+            size_type other_size = other.size();
+            if (other_size > 0) {
+                (void)move_range_without_overlap(_start, other._start, other._finish);
+                _finish = _start + other_size;
+            }
+            other._finish = other._start;
+        } else {
+            // Steal the heap pointer
+            _start = other._start;
+            _finish = other._finish;
+            _edge = other._edge;
+            // Reset other to inline state
+            other._start = other.inline_ptr();
+            other._finish = other._start;
+            other._edge = other._start + N;
+        }
+    }
+
+    // Copy assignment
+    auto operator=(const small_vectra& other) -> small_vectra& {
+        if (this == &other) [[unlikely]] {
+            return *this;
+        }
+
+        size_type other_size = other.size();
+
+        // Destroy current elements
+        destroy_range(_start, _finish);
+
+        if (other_size > capacity()) {
+            // Need more capacity
+            free_heap();
+            if (other_size > N) {
+                allocate_heap(other_size);
+            } else {
+                // Switch back to inline
+                _start = inline_ptr();
+                _edge = _start + N;
+            }
+        }
+
+        if (other_size > 0) {
+            copy_range(_start, other._start, other._finish);
+        }
+        _finish = _start + other_size;
+
+        return *this;
+    }
+
+    // Move assignment
+    auto operator=(small_vectra&& other) noexcept -> small_vectra& {
+        if (this == &other) [[unlikely]] {
+            return *this;
+        }
+
+        // Destroy current elements and free heap if needed
+        destroy_range(_start, _finish);
+        free_heap();
+
+        if (other.is_inline()) {
+            // Move elements from other's inline storage
+            _start = inline_ptr();
+            _edge = _start + N;
+            size_type other_size = other.size();
+            if (other_size > 0) {
+                (void)move_range_without_overlap(_start, other._start, other._finish);
+            }
+            _finish = _start + other_size;
+            other._finish = other._start;
+        } else {
+            // Steal heap pointer
+            _start = other._start;
+            _finish = other._finish;
+            _edge = other._edge;
+            // Reset other to inline
+            other._start = other.inline_ptr();
+            other._finish = other._start;
+            other._edge = other._start + N;
+        }
+
+        return *this;
+    }
+
+    ~small_vectra() {
+        destroy_range(_start, _finish);
+        free_heap();
+    }
+
+    // Capacity
+    [[nodiscard, gnu::always_inline]] constexpr auto size() const noexcept -> size_type {
+        return static_cast<size_type>(_finish - _start);
+    }
+
+    [[nodiscard, gnu::always_inline]] constexpr auto capacity() const noexcept -> size_type {
+        return static_cast<size_type>(_edge - _start);
+    }
+
+    [[nodiscard, gnu::always_inline]] constexpr auto empty() const noexcept -> bool { return _finish == _start; }
+
+    [[nodiscard, gnu::always_inline]] constexpr auto max_size() const noexcept -> size_type {
+        return kFastVectorMaxSize / sizeof(T);
+    }
+
+    [[nodiscard, gnu::always_inline]] auto is_small() const noexcept -> bool { return is_inline(); }
+
+    void reserve(size_type new_cap) {
+        if (new_cap > capacity()) {
+            realloc_with_old_data(new_cap);
+        }
+    }
+
+    void shrink_to_fit() {
+        size_type sz = size();
+        if (sz == capacity()) {
+            return;
+        }
+
+        if (sz <= N && !is_inline()) {
+            // Can move back to inline storage
+            T* old_start = _start;
+            T* old_finish = _finish;
+            _start = inline_ptr();
+            _edge = _start + N;
+            if (sz > 0) {
+                (void)move_range_without_overlap(_start, old_start, old_finish);
+            }
+            _finish = _start + sz;
+            std::free(old_start);
+        } else if (sz > N && sz < capacity()) {
+            // Shrink heap allocation
+            shrink_heap(sz);
+        }
+    }
+
+    // Element access
+    [[nodiscard, gnu::always_inline]] constexpr auto operator[](size_type index) noexcept -> reference {
+        Assert(index < size(), "index out of range");
+        return _start[index];
+    }
+
+    [[nodiscard, gnu::always_inline]] constexpr auto operator[](size_type index) const noexcept -> const_reference {
+        Assert(index < size(), "index out of range");
+        return _start[index];
+    }
+
+    [[nodiscard, gnu::always_inline]] constexpr auto at(size_type index) -> reference {
+        Assert(index < size(), "index out of range");
+        return _start[index];
+    }
+
+    [[nodiscard, gnu::always_inline]] constexpr auto at(size_type index) const -> const_reference {
+        Assert(index < size(), "index out of range");
+        return _start[index];
+    }
+
+    [[nodiscard, gnu::always_inline]] constexpr auto data() noexcept -> pointer { return _start; }
+    [[nodiscard, gnu::always_inline]] constexpr auto data() const noexcept -> const_pointer { return _start; }
+
+    [[nodiscard, gnu::always_inline]] constexpr auto front() noexcept -> reference {
+        Assert(size() > 0, "front on empty container");
+        return *_start;
+    }
+
+    [[nodiscard, gnu::always_inline]] constexpr auto front() const noexcept -> const_reference {
+        Assert(size() > 0, "front on empty container");
+        return *_start;
+    }
+
+    [[nodiscard, gnu::always_inline]] constexpr auto back() noexcept -> reference {
+        Assert(size() > 0, "back on empty container");
+        return *(_finish - 1);
+    }
+
+    [[nodiscard, gnu::always_inline]] constexpr auto back() const noexcept -> const_reference {
+        Assert(size() > 0, "back on empty container");
+        return *(_finish - 1);
+    }
+
+    // Iterator support (reuse vectra's iterator)
+    template <bool Const>
+    struct IteratorT
+    {
+        using iterator_category = std::contiguous_iterator_tag;
+        using difference_type = std::ptrdiff_t;
+        using value_type = std::conditional_t<Const, const T, T>;
+        using pointer = std::conditional_t<Const, const T*, T*>;
+        using reference = std::conditional_t<Const, const T&, T&>;
+
+       private:
+        pointer _ptr;
+
+       public:
+        IteratorT() : _ptr(nullptr) {}
+        ~IteratorT() = default;
+        explicit IteratorT(pointer ptr) : _ptr(ptr) {}
+        IteratorT(IteratorT&& rhs) noexcept : _ptr(std::exchange(rhs._ptr, nullptr)) {}
+        IteratorT(const IteratorT&) noexcept = default;
+
+        template <bool OtherConst>
+        requires(!OtherConst && Const)
+        IteratorT(IteratorT<OtherConst> rhs) noexcept : _ptr(rhs.operator->()) {}
+
+        auto operator=(IteratorT&& rhs) noexcept -> IteratorT& {
+            _ptr = std::exchange(rhs._ptr, nullptr);
+            return *this;
+        }
+        auto operator=(const IteratorT&) noexcept -> IteratorT& = default;
+
+        [[gnu::always_inline]] constexpr auto operator++() noexcept -> IteratorT& {
+            ++_ptr;
+            return *this;
+        }
+        [[gnu::always_inline, nodiscard]] constexpr auto operator++(int) noexcept -> IteratorT {
+            auto tmp = *this;
+            ++_ptr;
+            return tmp;
+        }
+        [[gnu::always_inline]] constexpr auto operator--() noexcept -> IteratorT& {
+            --_ptr;
+            return *this;
+        }
+        [[gnu::always_inline, nodiscard]] constexpr auto operator--(int) noexcept -> IteratorT {
+            auto tmp = *this;
+            --_ptr;
+            return tmp;
+        }
+        [[gnu::always_inline]] constexpr auto operator+=(difference_type n) noexcept -> IteratorT& {
+            _ptr += n;
+            return *this;
+        }
+        [[gnu::always_inline]] constexpr auto operator-=(difference_type n) noexcept -> IteratorT& {
+            _ptr -= n;
+            return *this;
+        }
+
+        [[nodiscard, gnu::always_inline]] constexpr auto operator*() const noexcept -> reference { return *_ptr; }
+        [[nodiscard, gnu::always_inline]] constexpr auto operator->() const noexcept -> pointer { return _ptr; }
+        [[nodiscard, gnu::always_inline]] constexpr auto operator[](size_type pos) const noexcept -> reference {
+            return *(_ptr + pos);
+        }
+
+        friend auto operator<=>(const IteratorT& lhs, const IteratorT& rhs) noexcept -> std::strong_ordering = default;
+        friend auto operator-(const IteratorT& lhs, const IteratorT& rhs) noexcept -> difference_type {
+            return lhs._ptr - rhs._ptr;
+        }
+        friend auto operator+(const IteratorT& lhs, difference_type offset) noexcept -> IteratorT {
+            return IteratorT{lhs._ptr + offset};
+        }
+        friend auto operator-(const IteratorT& lhs, difference_type offset) noexcept -> IteratorT {
+            return IteratorT{lhs._ptr - offset};
+        }
+        friend auto operator+(difference_type offset, const IteratorT& rhs) noexcept -> IteratorT {
+            return IteratorT{rhs._ptr + offset};
+        }
+    };
+
+    using iterator = IteratorT<false>;
+    using const_iterator = IteratorT<true>;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+    [[nodiscard]] auto begin() noexcept -> iterator { return iterator(_start); }
+    [[nodiscard]] auto begin() const noexcept -> const_iterator { return const_iterator(_start); }
+    [[nodiscard]] auto cbegin() const noexcept -> const_iterator { return const_iterator(_start); }
+    [[nodiscard]] auto end() noexcept -> iterator { return iterator(_finish); }
+    [[nodiscard]] auto end() const noexcept -> const_iterator { return const_iterator(_finish); }
+    [[nodiscard]] auto cend() const noexcept -> const_iterator { return const_iterator(_finish); }
+    [[nodiscard]] auto rbegin() noexcept -> reverse_iterator { return std::make_reverse_iterator(end()); }
+    [[nodiscard]] auto rbegin() const noexcept -> const_reverse_iterator { return std::make_reverse_iterator(end()); }
+    [[nodiscard]] auto crbegin() const noexcept -> const_reverse_iterator { return std::make_reverse_iterator(cend()); }
+    [[nodiscard]] auto rend() noexcept -> reverse_iterator { return std::make_reverse_iterator(begin()); }
+    [[nodiscard]] auto rend() const noexcept -> const_reverse_iterator { return std::make_reverse_iterator(begin()); }
+    [[nodiscard]] auto crend() const noexcept -> const_reverse_iterator { return std::make_reverse_iterator(cbegin()); }
+
+    // Modifiers
+    template <Safety safety = Safety::Safe>
+    void push_back(const value_type& value) {
+        if constexpr (safety == Safety::Safe) {
+            if (_finish == _edge) [[unlikely]] {
+                realloc_and_emplace_back(compute_next_capacity(), value);
+                return;
+            }
+        } else {
+            Assert(_finish != _edge, "push_back on full container");
+            VECTRA_ASSUME(_finish < _edge);
+        }
+        copy_cref(_finish, value);
+        ++_finish;
+    }
+
+    template <Safety safety = Safety::Safe>
+    void push_back(value_type&& value) {
+        if constexpr (safety == Safety::Safe) {
+            if (_finish == _edge) [[unlikely]] {
+                realloc_and_emplace_back(compute_next_capacity(), std::move(value));
+                return;
+            }
+        } else {
+            Assert(_finish != _edge, "push_back on full container");
+            VECTRA_ASSUME(_finish < _edge);
+        }
+        copy_value(_finish, std::move(value));
+        ++_finish;
+    }
+
+    template <Safety safety = Safety::Safe, typename... Args>
+    auto emplace_back(Args&&... args) -> reference {
+        if constexpr (safety == Safety::Safe) {
+            if (_finish == _edge) [[unlikely]] {
+                realloc_and_emplace_back(compute_next_capacity(), std::forward<Args>(args)...);
+                return *(_finish - 1);
+            }
+        } else {
+            Assert(_finish != _edge, "emplace_back on full container");
+            VECTRA_ASSUME(_finish < _edge);
+        }
+        new (_finish) T(std::forward<Args>(args)...);
+        ++_finish;
+        return *(_finish - 1);
+    }
+
+    void pop_back() noexcept {
+        Assert(size() > 0, "pop_back on empty container");
+        --_finish;
+        destroy_ptr(_finish);
+    }
+
+    void clear() noexcept {
+        destroy_range(_start, _finish);
+        _finish = _start;
+    }
+
+    void resize(size_type count) {
+        if (count > size()) {
+            if (count > capacity()) {
+                realloc_with_old_data(count);
+            }
+            T* old_finish = _finish;
+            _finish = _start + count;
+            construct_range(old_finish, _finish);
+        } else if (count < size()) {
+            T* new_finish = _start + count;
+            destroy_range(new_finish, _finish);
+            _finish = new_finish;
+        }
+    }
+
+    void resize(size_type count, const value_type& value) {
+        if (count > size()) {
+            if (count > capacity()) {
+                realloc_with_old_data(count);
+            }
+            T* old_finish = _finish;
+            _finish = _start + count;
+            construct_range_with_cref(old_finish, _finish, value);
+        } else if (count < size()) {
+            T* new_finish = _start + count;
+            destroy_range(new_finish, _finish);
+            _finish = new_finish;
+        }
+    }
+
+    void assign(size_type count, const value_type& value) {
+        destroy_range(_start, _finish);
+        if (count > capacity()) {
+            free_heap();
+            if (count > N) {
+                allocate_heap(count);
+            } else {
+                _start = inline_ptr();
+                _edge = _start + N;
+            }
+        }
+        _finish = _start + count;
+        if (count > 0) {
+            construct_range_with_cref(_start, _finish, value);
+        }
+    }
+
+    template <std::forward_iterator InputIt>
+    void assign(InputIt first, InputIt last) {
+        auto dist = std::distance(first, last);
+        Assert(dist >= 0, "invalid iterator range");
+        size_type count = static_cast<size_type>(dist);
+
+        destroy_range(_start, _finish);
+        if (count > capacity()) {
+            free_heap();
+            if (count > N) {
+                allocate_heap(count);
+            } else {
+                _start = inline_ptr();
+                _edge = _start + N;
+            }
+        }
+        _finish = _start + count;
+        if (count > 0) {
+            copy_from_iterator(_start, first, last);
+        }
+    }
+
+    void assign(std::initializer_list<T> ilist) { assign(ilist.begin(), ilist.end()); }
+
+    // Erase operations
+    auto erase(const_iterator pos) -> iterator {
+        Assert(pos >= cbegin() && pos < cend(), "invalid iterator");
+        T* pos_ptr = const_cast<T*>(pos.operator->());
+        destroy_ptr(pos_ptr);
+        move_range_forward(pos_ptr, pos_ptr + 1, _finish);
+        --_finish;
+        return iterator(pos_ptr);
+    }
+
+    auto erase(const_iterator first, const_iterator last) -> iterator {
+        Assert(first >= cbegin() && last <= cend(), "invalid range");
+        Assert(last >= first, "invalid range");
+        T* first_ptr = const_cast<T*>(first.operator->());
+        T* last_ptr = const_cast<T*>(last.operator->());
+        if (first_ptr != last_ptr) {
+            destroy_range(first_ptr, last_ptr);
+            move_range_forward(first_ptr, last_ptr, _finish);
+            _finish -= (last_ptr - first_ptr);
+        }
+        return iterator(first_ptr);
+    }
+
+    // Insert operations
+    template <Safety safety = Safety::Safe>
+    auto insert(const_iterator pos, const value_type& value) -> iterator {
+        T* pos_ptr = const_cast<T*>(pos.operator->());
+        if constexpr (safety == Safety::Safe) {
+            if (_finish == _edge) [[unlikely]] {
+                difference_type pos_index = pos_ptr - _start;
+                reserve(compute_next_capacity());
+                pos_ptr = _start + pos_index;
+            }
+        }
+        Assert(_finish != _edge, "insert on full container");
+
+        if (pos_ptr == _finish) {
+            copy_cref(_finish++, value);
+            return iterator(pos_ptr);
+        }
+
+        // Move elements backward
+        if (pos_ptr < _finish - 1) {
+            move_backward(pos_ptr + 1, pos_ptr, _finish);
+        } else {
+            move_range_forward(pos_ptr + 1, pos_ptr, _finish);
+        }
+        copy_cref(pos_ptr, value);
+        ++_finish;
+        return iterator(pos_ptr);
+    }
+
+    template <Safety safety = Safety::Safe>
+    auto insert(const_iterator pos, value_type&& value) -> iterator {
+        T* pos_ptr = const_cast<T*>(pos.operator->());
+        if constexpr (safety == Safety::Safe) {
+            if (_finish == _edge) [[unlikely]] {
+                difference_type pos_index = pos_ptr - _start;
+                reserve(compute_next_capacity());
+                pos_ptr = _start + pos_index;
+            }
+        }
+        Assert(_finish != _edge, "insert on full container");
+
+        if (pos_ptr == _finish) {
+            copy_value(_finish++, std::move(value));
+            return iterator(pos_ptr);
+        }
+
+        if (pos_ptr < _finish - 1) {
+            move_backward(pos_ptr + 1, pos_ptr, _finish);
+        } else {
+            move_range_forward(pos_ptr + 1, pos_ptr, _finish);
+        }
+        copy_value(pos_ptr, std::move(value));
+        ++_finish;
+        return iterator(pos_ptr);
+    }
+
+    void swap(small_vectra& other) noexcept {
+        if (is_inline() && other.is_inline()) {
+            // Both inline: swap elements
+            size_type this_size = size();
+            size_type other_size = other.size();
+            size_type min_size = std::min(this_size, other_size);
+
+            // Swap common elements
+            for (size_type i = 0; i < min_size; ++i) {
+                std::swap(_start[i], other._start[i]);
+            }
+
+            // Move extra elements
+            if (this_size > other_size) {
+                (void)move_range_without_overlap(other._start + min_size, _start + min_size, _finish);
+                destroy_range(_start + min_size, _finish);
+            } else if (other_size > this_size) {
+                (void)move_range_without_overlap(_start + min_size, other._start + min_size, other._finish);
+                destroy_range(other._start + min_size, other._finish);
+            }
+
+            _finish = _start + other_size;
+            other._finish = other._start + this_size;
+        } else if (!is_inline() && !other.is_inline()) {
+            // Both heap: swap pointers
+            std::swap(_start, other._start);
+            std::swap(_finish, other._finish);
+            std::swap(_edge, other._edge);
+        } else {
+            // One inline, one heap: move the inline one to temp, then swap
+            small_vectra temp(std::move(*this));
+            *this = std::move(other);
+            other = std::move(temp);
+        }
+    }
+
+   private:
+    // Helper for backward move (handles overlap correctly)
+    void move_backward(T* dst, T* src, T* src_end) {
+        Assert(dst != nullptr && src != nullptr, "null pointers");
+        Assert(src < src_end, "invalid range");
+
+        size_type count = src_end - src;
+        T* dst_end = dst + count - 1;
+        T* src_ptr = src_end - 1;
+
+        if constexpr (IsRelocatable<T>) {
+            for (size_type i = 0; i < count; ++i) {
+                *(dst_end--) = *(src_ptr--);
+            }
+        } else if constexpr (std::is_move_constructible_v<T>) {
+            static_assert(std::is_nothrow_move_constructible_v<T>);
+            while (src_ptr >= src) {
+                new (dst_end--) T(std::move(*src_ptr));
+                if constexpr (NeedsCleanUp<T>) {
+                    src_ptr->~T();
+                }
+                --src_ptr;
+            }
+        } else {
+            static_assert(std::is_copy_constructible_v<T>);
+            while (src_ptr >= src) {
+                new (dst_end) T(*src_ptr);
+                src_ptr->~T();
+                --dst_end;
+                --src_ptr;
+            }
+        }
+    }
+};
+
+// Comparison operators
+template <typename T, std::size_t N>
+auto operator==(const small_vectra<T, N>& lhs, const small_vectra<T, N>& rhs) -> bool {
+    if (lhs.size() != rhs.size()) return false;
+    for (std::size_t i = 0; i < lhs.size(); ++i) {
+        if (lhs[i] != rhs[i]) return false;
+    }
+    return true;
+}
+
+template <typename T, std::size_t N>
+auto operator<=>(const small_vectra<T, N>& lhs, const small_vectra<T, N>& rhs) -> std::strong_ordering {
+    for (std::size_t i = 0; i < std::min(lhs.size(), rhs.size()); ++i) {
+        if (lhs[i] < rhs[i]) return std::strong_ordering::less;
+        if (lhs[i] > rhs[i]) return std::strong_ordering::greater;
+    }
+    if (lhs.size() < rhs.size()) return std::strong_ordering::less;
+    if (lhs.size() > rhs.size()) return std::strong_ordering::greater;
+    return std::strong_ordering::equal;
+}
+
+}  // namespace stdb::container
+
+namespace std {
+
+template <typename T, std::size_t N>
+constexpr void swap(stdb::container::small_vectra<T, N>& lhs, stdb::container::small_vectra<T, N>& rhs) noexcept {
+    lhs.swap(rhs);
+}
+
+template <typename T, std::size_t N, typename U>
+constexpr auto erase(stdb::container::small_vectra<T, N>& vec, const U& value) -> std::size_t {
+    auto it = std::remove(vec.begin(), vec.end(), value);
+    auto count = vec.end() - it;
+    vec.erase(it, vec.end());
+    return count;
+}
+
+template <typename T, std::size_t N, typename Pred>
+constexpr auto erase_if(stdb::container::small_vectra<T, N>& vec, Pred pred) -> std::size_t {
+    auto it = std::remove_if(vec.begin(), vec.end(), pred);
+    auto count = vec.end() - it;
+    vec.erase(it, vec.end());
+    return count;
+}
+
+}  // namespace std

--- a/container/static_vectra.hpp
+++ b/container/static_vectra.hpp
@@ -1,0 +1,643 @@
+/*
+ * Copyright 2025 ClapDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <algorithm>
+#include <stdexcept>
+
+#include "vectra.hpp"
+
+namespace stdb::container {
+
+/*
+ * static_vectra is a fixed-capacity vector with embedded storage.
+ * It NEVER performs dynamic memory allocation.
+ *
+ * Template parameters:
+ *   T - Element type
+ *   N - Maximum capacity (fixed at compile time)
+ *
+ * Key features:
+ *   - Zero heap allocation - all storage is inline
+ *   - Fixed maximum capacity known at compile time
+ *   - Suitable for embedded systems, real-time systems, and latency-sensitive code
+ *   - Throws std::length_error when capacity is exceeded (in Safe mode)
+ *   - Supports Safe/Unsafe modes like vectra
+ *
+ * Use cases:
+ *   - Embedded systems without heap
+ *   - Real-time systems requiring deterministic memory behavior
+ *   - Stack-allocated buffers with known maximum size
+ *   - Performance-critical code avoiding allocation overhead
+ */
+template <typename T, std::size_t N>
+class static_vectra
+{
+    static_assert(N > 0, "static_vectra capacity must be greater than 0");
+
+   public:
+    using size_type = std::size_t;
+    using value_type = T;
+    using difference_type = std::ptrdiff_t;
+    using pointer = T*;
+    using const_pointer = const T*;
+    using reference = T&;
+    using const_reference = const T&;
+    using rvalue_reference = T&&;
+
+    static constexpr size_type static_capacity = N;
+
+   private:
+    alignas(T) std::byte _storage[N * sizeof(T)];
+    size_type _size = 0;
+
+    [[nodiscard, gnu::always_inline]] auto data_ptr() noexcept -> T* { return reinterpret_cast<T*>(_storage); }
+
+    [[nodiscard, gnu::always_inline]] auto data_ptr() const noexcept -> const T* {
+        return reinterpret_cast<const T*>(_storage);
+    }
+
+    void throw_if_full() const {
+        if (_size >= N) [[unlikely]] {
+            throw std::length_error("static_vectra capacity exceeded");
+        }
+    }
+
+    void throw_if_insufficient(size_type required) const {
+        if (required > N) [[unlikely]] {
+            throw std::length_error("static_vectra capacity exceeded");
+        }
+    }
+
+   public:
+    // Default constructor
+    constexpr static_vectra() noexcept = default;
+
+    // Constructor with size (default-initialized elements)
+    explicit static_vectra(size_type count) : _size(0) {
+        throw_if_insufficient(count);
+        _size = count;
+        if (count > 0) {
+            construct_range(data_ptr(), data_ptr() + count);
+        }
+    }
+
+    // Constructor with size and value
+    static_vectra(size_type count, const T& value) : _size(0) {
+        throw_if_insufficient(count);
+        _size = count;
+        if (count > 0) {
+            construct_range_with_cref(data_ptr(), data_ptr() + count, value);
+        }
+    }
+
+    // Constructor from iterators
+    template <std::forward_iterator InputIt>
+    static_vectra(InputIt first, InputIt last) : _size(0) {
+        auto dist = std::distance(first, last);
+        Assert(dist >= 0, "invalid iterator range");
+        size_type count = static_cast<size_type>(dist);
+        throw_if_insufficient(count);
+        if (count > 0) {
+            copy_from_iterator(data_ptr(), first, last);
+            _size = count;
+        }
+    }
+
+    // Constructor from initializer list
+    static_vectra(std::initializer_list<T> init) : static_vectra(init.begin(), init.end()) {}
+
+    // Copy constructor
+    static_vectra(const static_vectra& other) : _size(0) {
+        if (other._size > 0) {
+            copy_range(data_ptr(), other.data_ptr(), other.data_ptr() + other._size);
+            _size = other._size;
+        }
+    }
+
+    // Move constructor
+    static_vectra(static_vectra&& other) noexcept : _size(0) {
+        if (other._size > 0) {
+            (void)move_range_without_overlap(data_ptr(), other.data_ptr(), other.data_ptr() + other._size);
+            _size = other._size;
+            other._size = 0;
+        }
+    }
+
+    // Copy assignment
+    auto operator=(const static_vectra& other) -> static_vectra& {
+        if (this == &other) [[unlikely]] {
+            return *this;
+        }
+        destroy_range(data_ptr(), data_ptr() + _size);
+        if (other._size > 0) {
+            copy_range(data_ptr(), other.data_ptr(), other.data_ptr() + other._size);
+        }
+        _size = other._size;
+        return *this;
+    }
+
+    // Move assignment
+    auto operator=(static_vectra&& other) noexcept -> static_vectra& {
+        if (this == &other) [[unlikely]] {
+            return *this;
+        }
+        destroy_range(data_ptr(), data_ptr() + _size);
+        if (other._size > 0) {
+            (void)move_range_without_overlap(data_ptr(), other.data_ptr(), other.data_ptr() + other._size);
+        }
+        _size = other._size;
+        other._size = 0;
+        return *this;
+    }
+
+    ~static_vectra() { destroy_range(data_ptr(), data_ptr() + _size); }
+
+    // Capacity
+    [[nodiscard, gnu::always_inline]] constexpr auto size() const noexcept -> size_type { return _size; }
+
+    [[nodiscard, gnu::always_inline]] static constexpr auto capacity() noexcept -> size_type { return N; }
+
+    [[nodiscard, gnu::always_inline]] static constexpr auto max_size() noexcept -> size_type { return N; }
+
+    [[nodiscard, gnu::always_inline]] constexpr auto empty() const noexcept -> bool { return _size == 0; }
+
+    [[nodiscard, gnu::always_inline]] constexpr auto full() const noexcept -> bool { return _size == N; }
+
+    [[nodiscard, gnu::always_inline]] constexpr auto available() const noexcept -> size_type { return N - _size; }
+
+    // reserve is a no-op for static_vectra (capacity is fixed)
+    // but we provide it for API compatibility
+    void reserve(size_type new_cap) {
+        if (new_cap > N) [[unlikely]] {
+            throw std::length_error("static_vectra::reserve: capacity exceeded");
+        }
+    }
+
+    // shrink_to_fit is a no-op (capacity is fixed)
+    constexpr void shrink_to_fit() noexcept {}
+
+    // Element access
+    [[nodiscard, gnu::always_inline]] constexpr auto operator[](size_type index) noexcept -> reference {
+        Assert(index < _size, "index out of range");
+        return data_ptr()[index];
+    }
+
+    [[nodiscard, gnu::always_inline]] constexpr auto operator[](size_type index) const noexcept -> const_reference {
+        Assert(index < _size, "index out of range");
+        return data_ptr()[index];
+    }
+
+    [[nodiscard, gnu::always_inline]] constexpr auto at(size_type index) -> reference {
+        if (index >= _size) [[unlikely]] {
+            throw std::out_of_range("static_vectra::at: index out of range");
+        }
+        return data_ptr()[index];
+    }
+
+    [[nodiscard, gnu::always_inline]] constexpr auto at(size_type index) const -> const_reference {
+        if (index >= _size) [[unlikely]] {
+            throw std::out_of_range("static_vectra::at: index out of range");
+        }
+        return data_ptr()[index];
+    }
+
+    [[nodiscard, gnu::always_inline]] constexpr auto data() noexcept -> pointer { return data_ptr(); }
+
+    [[nodiscard, gnu::always_inline]] constexpr auto data() const noexcept -> const_pointer { return data_ptr(); }
+
+    [[nodiscard, gnu::always_inline]] constexpr auto front() noexcept -> reference {
+        Assert(_size > 0, "front on empty container");
+        return data_ptr()[0];
+    }
+
+    [[nodiscard, gnu::always_inline]] constexpr auto front() const noexcept -> const_reference {
+        Assert(_size > 0, "front on empty container");
+        return data_ptr()[0];
+    }
+
+    [[nodiscard, gnu::always_inline]] constexpr auto back() noexcept -> reference {
+        Assert(_size > 0, "back on empty container");
+        return data_ptr()[_size - 1];
+    }
+
+    [[nodiscard, gnu::always_inline]] constexpr auto back() const noexcept -> const_reference {
+        Assert(_size > 0, "back on empty container");
+        return data_ptr()[_size - 1];
+    }
+
+    // Iterator support
+    template <bool Const>
+    struct IteratorT
+    {
+        using iterator_category = std::contiguous_iterator_tag;
+        using difference_type = std::ptrdiff_t;
+        using value_type = std::conditional_t<Const, const T, T>;
+        using pointer = std::conditional_t<Const, const T*, T*>;
+        using reference = std::conditional_t<Const, const T&, T&>;
+
+       private:
+        pointer _ptr;
+
+       public:
+        IteratorT() : _ptr(nullptr) {}
+        ~IteratorT() = default;
+        explicit IteratorT(pointer ptr) : _ptr(ptr) {}
+        IteratorT(IteratorT&& rhs) noexcept : _ptr(std::exchange(rhs._ptr, nullptr)) {}
+        IteratorT(const IteratorT&) noexcept = default;
+
+        template <bool OtherConst>
+        requires(!OtherConst && Const)
+        IteratorT(IteratorT<OtherConst> rhs) noexcept : _ptr(rhs.operator->()) {}
+
+        auto operator=(IteratorT&& rhs) noexcept -> IteratorT& {
+            _ptr = std::exchange(rhs._ptr, nullptr);
+            return *this;
+        }
+        auto operator=(const IteratorT&) noexcept -> IteratorT& = default;
+
+        [[gnu::always_inline]] constexpr auto operator++() noexcept -> IteratorT& {
+            ++_ptr;
+            return *this;
+        }
+        [[gnu::always_inline, nodiscard]] constexpr auto operator++(int) noexcept -> IteratorT {
+            auto tmp = *this;
+            ++_ptr;
+            return tmp;
+        }
+        [[gnu::always_inline]] constexpr auto operator--() noexcept -> IteratorT& {
+            --_ptr;
+            return *this;
+        }
+        [[gnu::always_inline, nodiscard]] constexpr auto operator--(int) noexcept -> IteratorT {
+            auto tmp = *this;
+            --_ptr;
+            return tmp;
+        }
+        [[gnu::always_inline]] constexpr auto operator+=(difference_type n) noexcept -> IteratorT& {
+            _ptr += n;
+            return *this;
+        }
+        [[gnu::always_inline]] constexpr auto operator-=(difference_type n) noexcept -> IteratorT& {
+            _ptr -= n;
+            return *this;
+        }
+
+        [[nodiscard, gnu::always_inline]] constexpr auto operator*() const noexcept -> reference { return *_ptr; }
+        [[nodiscard, gnu::always_inline]] constexpr auto operator->() const noexcept -> pointer { return _ptr; }
+        [[nodiscard, gnu::always_inline]] constexpr auto operator[](size_type pos) const noexcept -> reference {
+            return *(_ptr + pos);
+        }
+
+        friend auto operator<=>(const IteratorT& lhs, const IteratorT& rhs) noexcept -> std::strong_ordering = default;
+        friend auto operator-(const IteratorT& lhs, const IteratorT& rhs) noexcept -> difference_type {
+            return lhs._ptr - rhs._ptr;
+        }
+        friend auto operator+(const IteratorT& lhs, difference_type offset) noexcept -> IteratorT {
+            return IteratorT{lhs._ptr + offset};
+        }
+        friend auto operator-(const IteratorT& lhs, difference_type offset) noexcept -> IteratorT {
+            return IteratorT{lhs._ptr - offset};
+        }
+        friend auto operator+(difference_type offset, const IteratorT& rhs) noexcept -> IteratorT {
+            return IteratorT{rhs._ptr + offset};
+        }
+    };
+
+    using iterator = IteratorT<false>;
+    using const_iterator = IteratorT<true>;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+    [[nodiscard]] auto begin() noexcept -> iterator { return iterator(data_ptr()); }
+    [[nodiscard]] auto begin() const noexcept -> const_iterator { return const_iterator(data_ptr()); }
+    [[nodiscard]] auto cbegin() const noexcept -> const_iterator { return const_iterator(data_ptr()); }
+    [[nodiscard]] auto end() noexcept -> iterator { return iterator(data_ptr() + _size); }
+    [[nodiscard]] auto end() const noexcept -> const_iterator { return const_iterator(data_ptr() + _size); }
+    [[nodiscard]] auto cend() const noexcept -> const_iterator { return const_iterator(data_ptr() + _size); }
+    [[nodiscard]] auto rbegin() noexcept -> reverse_iterator { return std::make_reverse_iterator(end()); }
+    [[nodiscard]] auto rbegin() const noexcept -> const_reverse_iterator { return std::make_reverse_iterator(end()); }
+    [[nodiscard]] auto crbegin() const noexcept -> const_reverse_iterator { return std::make_reverse_iterator(cend()); }
+    [[nodiscard]] auto rend() noexcept -> reverse_iterator { return std::make_reverse_iterator(begin()); }
+    [[nodiscard]] auto rend() const noexcept -> const_reverse_iterator { return std::make_reverse_iterator(begin()); }
+    [[nodiscard]] auto crend() const noexcept -> const_reverse_iterator { return std::make_reverse_iterator(cbegin()); }
+
+    // Modifiers
+    template <Safety safety = Safety::Safe>
+    void push_back(const value_type& value) {
+        if constexpr (safety == Safety::Safe) {
+            throw_if_full();
+        } else {
+            Assert(_size < N, "push_back on full container");
+            VECTRA_ASSUME(_size < N);
+        }
+        copy_cref(data_ptr() + _size, value);
+        ++_size;
+    }
+
+    template <Safety safety = Safety::Safe>
+    void push_back(value_type&& value) {
+        if constexpr (safety == Safety::Safe) {
+            throw_if_full();
+        } else {
+            Assert(_size < N, "push_back on full container");
+            VECTRA_ASSUME(_size < N);
+        }
+        copy_value(data_ptr() + _size, std::move(value));
+        ++_size;
+    }
+
+    template <Safety safety = Safety::Safe, typename... Args>
+    auto emplace_back(Args&&... args) -> reference {
+        if constexpr (safety == Safety::Safe) {
+            throw_if_full();
+        } else {
+            Assert(_size < N, "emplace_back on full container");
+            VECTRA_ASSUME(_size < N);
+        }
+        new (data_ptr() + _size) T(std::forward<Args>(args)...);
+        ++_size;
+        return data_ptr()[_size - 1];
+    }
+
+    void pop_back() noexcept {
+        Assert(_size > 0, "pop_back on empty container");
+        --_size;
+        destroy_ptr(data_ptr() + _size);
+    }
+
+    void clear() noexcept {
+        destroy_range(data_ptr(), data_ptr() + _size);
+        _size = 0;
+    }
+
+    void resize(size_type count) {
+        if (count > _size) {
+            throw_if_insufficient(count);
+            construct_range(data_ptr() + _size, data_ptr() + count);
+        } else if (count < _size) {
+            destroy_range(data_ptr() + count, data_ptr() + _size);
+        }
+        _size = count;
+    }
+
+    void resize(size_type count, const value_type& value) {
+        if (count > _size) {
+            throw_if_insufficient(count);
+            construct_range_with_cref(data_ptr() + _size, data_ptr() + count, value);
+        } else if (count < _size) {
+            destroy_range(data_ptr() + count, data_ptr() + _size);
+        }
+        _size = count;
+    }
+
+    void assign(size_type count, const value_type& value) {
+        throw_if_insufficient(count);
+        destroy_range(data_ptr(), data_ptr() + _size);
+        _size = count;
+        if (count > 0) {
+            construct_range_with_cref(data_ptr(), data_ptr() + count, value);
+        }
+    }
+
+    template <std::forward_iterator InputIt>
+    void assign(InputIt first, InputIt last) {
+        auto dist = std::distance(first, last);
+        Assert(dist >= 0, "invalid iterator range");
+        size_type count = static_cast<size_type>(dist);
+        throw_if_insufficient(count);
+        destroy_range(data_ptr(), data_ptr() + _size);
+        _size = count;
+        if (count > 0) {
+            copy_from_iterator(data_ptr(), first, last);
+        }
+    }
+
+    void assign(std::initializer_list<T> ilist) { assign(ilist.begin(), ilist.end()); }
+
+    // Erase operations
+    auto erase(const_iterator pos) -> iterator {
+        Assert(pos >= cbegin() && pos < cend(), "invalid iterator");
+        T* pos_ptr = const_cast<T*>(pos.operator->());
+        destroy_ptr(pos_ptr);
+        move_range_forward(pos_ptr, pos_ptr + 1, data_ptr() + _size);
+        --_size;
+        return iterator(pos_ptr);
+    }
+
+    auto erase(const_iterator first, const_iterator last) -> iterator {
+        Assert(first >= cbegin() && last <= cend(), "invalid range");
+        Assert(last >= first, "invalid range");
+        T* first_ptr = const_cast<T*>(first.operator->());
+        T* last_ptr = const_cast<T*>(last.operator->());
+        if (first_ptr != last_ptr) {
+            destroy_range(first_ptr, last_ptr);
+            move_range_forward(first_ptr, last_ptr, data_ptr() + _size);
+            _size -= static_cast<size_type>(last_ptr - first_ptr);
+        }
+        return iterator(first_ptr);
+    }
+
+    // Insert operations
+    template <Safety safety = Safety::Safe>
+    auto insert(const_iterator pos, const value_type& value) -> iterator {
+        if constexpr (safety == Safety::Safe) {
+            throw_if_full();
+        } else {
+            Assert(_size < N, "insert on full container");
+        }
+
+        T* pos_ptr = const_cast<T*>(pos.operator->());
+        T* end_ptr = data_ptr() + _size;
+
+        if (pos_ptr == end_ptr) {
+            copy_cref(end_ptr, value);
+            ++_size;
+            return iterator(pos_ptr);
+        }
+
+        // Move elements backward
+        if (pos_ptr < end_ptr - 1) {
+            move_backward(pos_ptr + 1, pos_ptr, end_ptr);
+        } else {
+            move_range_forward(pos_ptr + 1, pos_ptr, end_ptr);
+        }
+        copy_cref(pos_ptr, value);
+        ++_size;
+        return iterator(pos_ptr);
+    }
+
+    template <Safety safety = Safety::Safe>
+    auto insert(const_iterator pos, value_type&& value) -> iterator {
+        if constexpr (safety == Safety::Safe) {
+            throw_if_full();
+        } else {
+            Assert(_size < N, "insert on full container");
+        }
+
+        T* pos_ptr = const_cast<T*>(pos.operator->());
+        T* end_ptr = data_ptr() + _size;
+
+        if (pos_ptr == end_ptr) {
+            copy_value(end_ptr, std::move(value));
+            ++_size;
+            return iterator(pos_ptr);
+        }
+
+        if (pos_ptr < end_ptr - 1) {
+            move_backward(pos_ptr + 1, pos_ptr, end_ptr);
+        } else {
+            move_range_forward(pos_ptr + 1, pos_ptr, end_ptr);
+        }
+        copy_value(pos_ptr, std::move(value));
+        ++_size;
+        return iterator(pos_ptr);
+    }
+
+    template <Safety safety = Safety::Safe>
+    auto insert(const_iterator pos, size_type count, const value_type& value) -> iterator {
+        if constexpr (safety == Safety::Safe) {
+            throw_if_insufficient(_size + count);
+        } else {
+            Assert(_size + count <= N, "insert would exceed capacity");
+        }
+
+        T* pos_ptr = const_cast<T*>(pos.operator->());
+        T* end_ptr = data_ptr() + _size;
+
+        if (pos_ptr + count >= end_ptr) {
+            move_range_forward(pos_ptr + count, pos_ptr, end_ptr);
+        } else {
+            move_backward(pos_ptr + count, pos_ptr, end_ptr);
+        }
+        construct_range_with_cref(pos_ptr, pos_ptr + count, value);
+        _size += count;
+        return iterator(pos_ptr);
+    }
+
+    void swap(static_vectra& other) noexcept {
+        size_type min_size = std::min(_size, other._size);
+
+        // Swap common elements
+        for (size_type i = 0; i < min_size; ++i) {
+            std::swap(data_ptr()[i], other.data_ptr()[i]);
+        }
+
+        // Move extra elements
+        if (_size > other._size) {
+            (void)move_range_without_overlap(other.data_ptr() + min_size, data_ptr() + min_size, data_ptr() + _size);
+            destroy_range(data_ptr() + min_size, data_ptr() + _size);
+        } else if (other._size > _size) {
+            (void)move_range_without_overlap(data_ptr() + min_size, other.data_ptr() + min_size,
+                                             other.data_ptr() + other._size);
+            destroy_range(other.data_ptr() + min_size, other.data_ptr() + other._size);
+        }
+
+        std::swap(_size, other._size);
+    }
+
+   private:
+    void move_backward(T* dst, T* src, T* src_end) {
+        Assert(dst != nullptr && src != nullptr, "null pointers");
+        Assert(src < src_end, "invalid range");
+
+        size_type count = src_end - src;
+        T* dst_end = dst + count - 1;
+        T* src_ptr = src_end - 1;
+
+        if constexpr (IsRelocatable<T>) {
+            for (size_type i = 0; i < count; ++i) {
+                *(dst_end--) = *(src_ptr--);
+            }
+        } else if constexpr (std::is_move_constructible_v<T>) {
+            static_assert(std::is_nothrow_move_constructible_v<T>);
+            while (src_ptr >= src) {
+                new (dst_end--) T(std::move(*src_ptr));
+                if constexpr (NeedsCleanUp<T>) {
+                    src_ptr->~T();
+                }
+                --src_ptr;
+            }
+        } else {
+            static_assert(std::is_copy_constructible_v<T>);
+            while (src_ptr >= src) {
+                new (dst_end) T(*src_ptr);
+                src_ptr->~T();
+                --dst_end;
+                --src_ptr;
+            }
+        }
+    }
+};
+
+// Comparison operators
+template <typename T, std::size_t N>
+auto operator==(const static_vectra<T, N>& lhs, const static_vectra<T, N>& rhs) -> bool {
+    if (lhs.size() != rhs.size()) return false;
+    for (std::size_t i = 0; i < lhs.size(); ++i) {
+        if (lhs[i] != rhs[i]) return false;
+    }
+    return true;
+}
+
+template <typename T, std::size_t N>
+auto operator<=>(const static_vectra<T, N>& lhs, const static_vectra<T, N>& rhs) -> std::strong_ordering {
+    for (std::size_t i = 0; i < std::min(lhs.size(), rhs.size()); ++i) {
+        if (lhs[i] < rhs[i]) return std::strong_ordering::less;
+        if (lhs[i] > rhs[i]) return std::strong_ordering::greater;
+    }
+    if (lhs.size() < rhs.size()) return std::strong_ordering::less;
+    if (lhs.size() > rhs.size()) return std::strong_ordering::greater;
+    return std::strong_ordering::equal;
+}
+
+// Cross-size comparison (different N values)
+template <typename T, std::size_t N1, std::size_t N2>
+requires(N1 != N2)
+auto operator==(const static_vectra<T, N1>& lhs, const static_vectra<T, N2>& rhs) -> bool {
+    if (lhs.size() != rhs.size()) return false;
+    for (std::size_t i = 0; i < lhs.size(); ++i) {
+        if (lhs[i] != rhs[i]) return false;
+    }
+    return true;
+}
+
+}  // namespace stdb::container
+
+namespace std {
+
+template <typename T, std::size_t N>
+constexpr void swap(stdb::container::static_vectra<T, N>& lhs, stdb::container::static_vectra<T, N>& rhs) noexcept {
+    lhs.swap(rhs);
+}
+
+template <typename T, std::size_t N, typename U>
+constexpr auto erase(stdb::container::static_vectra<T, N>& vec, const U& value) -> std::size_t {
+    auto it = std::remove(vec.begin(), vec.end(), value);
+    auto count = vec.end() - it;
+    vec.erase(it, vec.end());
+    return count;
+}
+
+template <typename T, std::size_t N, typename Pred>
+constexpr auto erase_if(stdb::container::static_vectra<T, N>& vec, Pred pred) -> std::size_t {
+    auto it = std::remove_if(vec.begin(), vec.end(), pred);
+    auto count = vec.end() - it;
+    vec.erase(it, vec.end());
+    return count;
+}
+
+}  // namespace std

--- a/tests/devectra_test.cc
+++ b/tests/devectra_test.cc
@@ -1,0 +1,623 @@
+/*
+ * Copyright 2025 ClapDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "container/devectra.hpp"
+
+#include <doctest/doctest.h>
+
+#include <string>
+#include <vector>
+
+namespace stdb::container {
+// NOLINTBEGIN
+
+TEST_CASE("devectra::basic") {
+    SUBCASE("default constructor") {
+        devectra<int> dv;
+        CHECK_EQ(dv.empty(), true);
+        CHECK_EQ(dv.size(), 0);
+        CHECK_EQ(dv.capacity(), 0);
+    }
+
+    SUBCASE("push_back increases size") {
+        devectra<int> dv;
+        dv.push_back(1);
+        CHECK_EQ(dv.size(), 1);
+        dv.push_back(2);
+        CHECK_EQ(dv.size(), 2);
+        CHECK_EQ(dv[0], 1);
+        CHECK_EQ(dv[1], 2);
+    }
+
+    SUBCASE("push_front increases size") {
+        devectra<int> dv;
+        dv.push_front(1);
+        CHECK_EQ(dv.size(), 1);
+        dv.push_front(2);
+        CHECK_EQ(dv.size(), 2);
+        CHECK_EQ(dv[0], 2);  // 2 was pushed to front
+        CHECK_EQ(dv[1], 1);
+    }
+
+    SUBCASE("mixed push_front and push_back") {
+        devectra<int> dv;
+        dv.push_back(3);
+        dv.push_front(2);
+        dv.push_back(4);
+        dv.push_front(1);
+        // Should be [1, 2, 3, 4]
+        CHECK_EQ(dv.size(), 4);
+        CHECK_EQ(dv[0], 1);
+        CHECK_EQ(dv[1], 2);
+        CHECK_EQ(dv[2], 3);
+        CHECK_EQ(dv[3], 4);
+    }
+}
+
+TEST_CASE("devectra::constructors") {
+    SUBCASE("size constructor") {
+        devectra<int> dv(5);
+        CHECK_EQ(dv.size(), 5);
+        for (int i = 0; i < 5; ++i) {
+            CHECK_EQ(dv[i], 0);
+        }
+    }
+
+    SUBCASE("size and value constructor") {
+        devectra<int> dv(5, 42);
+        CHECK_EQ(dv.size(), 5);
+        for (int i = 0; i < 5; ++i) {
+            CHECK_EQ(dv[i], 42);
+        }
+    }
+
+    SUBCASE("initializer list") {
+        devectra<int> dv{1, 2, 3, 4, 5};
+        CHECK_EQ(dv.size(), 5);
+        CHECK_EQ(dv[0], 1);
+        CHECK_EQ(dv[4], 5);
+    }
+
+    SUBCASE("iterator constructor") {
+        std::vector<int> source{1, 2, 3, 4, 5};
+        devectra<int> dv(source.begin(), source.end());
+        CHECK_EQ(dv.size(), 5);
+        for (size_t i = 0; i < source.size(); ++i) {
+            CHECK_EQ(dv[i], source[i]);
+        }
+    }
+
+    SUBCASE("copy constructor") {
+        devectra<int> dv1{1, 2, 3, 4};
+        devectra<int> dv2(dv1);
+        CHECK_EQ(dv2.size(), 4);
+        CHECK_EQ(dv1, dv2);
+    }
+
+    SUBCASE("move constructor") {
+        devectra<int> dv1{1, 2, 3, 4};
+        auto* old_data = dv1.data();
+        devectra<int> dv2(std::move(dv1));
+        CHECK_EQ(dv2.size(), 4);
+        CHECK_EQ(dv2.data(), old_data);
+        CHECK_EQ(dv2[0], 1);
+        CHECK_EQ(dv1.size(), 0);
+    }
+}
+
+TEST_CASE("devectra::assignment") {
+    SUBCASE("copy assignment") {
+        devectra<int> dv1{1, 2, 3};
+        devectra<int> dv2{10, 20, 30, 40, 50};
+        dv2 = dv1;
+        CHECK_EQ(dv2.size(), 3);
+        CHECK_EQ(dv2, dv1);
+    }
+
+    SUBCASE("move assignment") {
+        devectra<int> dv1{1, 2, 3, 4};
+        devectra<int> dv2{10, 20};
+        auto* old_data = dv1.data();
+        dv2 = std::move(dv1);
+        CHECK_EQ(dv2.size(), 4);
+        CHECK_EQ(dv2.data(), old_data);
+        CHECK_EQ(dv1.size(), 0);
+    }
+
+    SUBCASE("self assignment") {
+        devectra<int> dv{1, 2, 3, 4};
+        auto* ptr = &dv;
+        dv = *ptr;
+        CHECK_EQ(dv.size(), 4);
+        CHECK_EQ(dv[0], 1);
+    }
+}
+
+TEST_CASE("devectra::element_access") {
+    devectra<int> dv{10, 20, 30, 40, 50};
+
+    SUBCASE("operator[]") {
+        CHECK_EQ(dv[0], 10);
+        CHECK_EQ(dv[4], 50);
+        dv[2] = 300;
+        CHECK_EQ(dv[2], 300);
+    }
+
+    SUBCASE("at() valid") {
+        CHECK_EQ(dv.at(0), 10);
+        CHECK_EQ(dv.at(4), 50);
+    }
+
+    SUBCASE("at() throws on out of range") {
+        CHECK_THROWS_AS(dv.at(5), std::out_of_range);
+        CHECK_THROWS_AS(dv.at(100), std::out_of_range);
+    }
+
+    SUBCASE("front() and back()") {
+        CHECK_EQ(dv.front(), 10);
+        CHECK_EQ(dv.back(), 50);
+        dv.front() = 100;
+        dv.back() = 500;
+        CHECK_EQ(dv.front(), 100);
+        CHECK_EQ(dv.back(), 500);
+    }
+
+    SUBCASE("data()") {
+        int* ptr = dv.data();
+        CHECK_NE(ptr, nullptr);
+        CHECK_EQ(ptr[0], 10);
+        CHECK_EQ(ptr[4], 50);
+    }
+}
+
+TEST_CASE("devectra::front_operations") {
+    SUBCASE("push_front multiple") {
+        devectra<int> dv;
+        for (int i = 5; i >= 1; --i) {
+            dv.push_front(i);
+        }
+        CHECK_EQ(dv.size(), 5);
+        for (int i = 0; i < 5; ++i) {
+            CHECK_EQ(dv[i], i + 1);
+        }
+    }
+
+    SUBCASE("emplace_front") {
+        devectra<std::pair<int, std::string>> dv;
+        dv.emplace_front(2, "two");
+        dv.emplace_front(1, "one");
+        CHECK_EQ(dv.size(), 2);
+        CHECK_EQ(dv[0].first, 1);
+        CHECK_EQ(dv[0].second, "one");
+        CHECK_EQ(dv[1].first, 2);
+    }
+
+    SUBCASE("pop_front") {
+        devectra<int> dv{1, 2, 3, 4, 5};
+        dv.pop_front();
+        CHECK_EQ(dv.size(), 4);
+        CHECK_EQ(dv.front(), 2);
+        dv.pop_front();
+        CHECK_EQ(dv.front(), 3);
+    }
+
+    SUBCASE("alternating push_front and pop_front") {
+        devectra<int> dv;
+        for (int i = 0; i < 100; ++i) {
+            dv.push_front(i);
+            if (i % 2 == 1) {
+                dv.pop_front();
+            }
+        }
+        CHECK_EQ(dv.size(), 50);
+    }
+}
+
+TEST_CASE("devectra::back_operations") {
+    SUBCASE("push_back multiple") {
+        devectra<int> dv;
+        for (int i = 1; i <= 5; ++i) {
+            dv.push_back(i);
+        }
+        CHECK_EQ(dv.size(), 5);
+        for (int i = 0; i < 5; ++i) {
+            CHECK_EQ(dv[i], i + 1);
+        }
+    }
+
+    SUBCASE("emplace_back") {
+        devectra<std::pair<int, std::string>> dv;
+        dv.emplace_back(1, "one");
+        dv.emplace_back(2, "two");
+        CHECK_EQ(dv.size(), 2);
+        CHECK_EQ(dv[0].first, 1);
+        CHECK_EQ(dv[1].second, "two");
+    }
+
+    SUBCASE("pop_back") {
+        devectra<int> dv{1, 2, 3, 4, 5};
+        dv.pop_back();
+        CHECK_EQ(dv.size(), 4);
+        CHECK_EQ(dv.back(), 4);
+        dv.pop_back();
+        CHECK_EQ(dv.back(), 3);
+    }
+}
+
+TEST_CASE("devectra::capacity") {
+    SUBCASE("reserve") {
+        devectra<int> dv;
+        dv.reserve(100);
+        CHECK_GE(dv.capacity(), 100);
+        CHECK_EQ(dv.size(), 0);
+    }
+
+    SUBCASE("reserve_front") {
+        devectra<int> dv{1, 2, 3};
+        dv.reserve_front(10);
+        CHECK_GE(dv.front_capacity(), 10);
+    }
+
+    SUBCASE("reserve_back") {
+        devectra<int> dv{1, 2, 3};
+        dv.reserve_back(10);
+        CHECK_GE(dv.back_capacity(), 10);
+    }
+
+    SUBCASE("shrink_to_fit") {
+        devectra<int> dv;
+        dv.reserve(100);
+        dv.push_back(1);
+        dv.push_back(2);
+        dv.push_back(3);
+        dv.shrink_to_fit();
+        CHECK_EQ(dv.capacity(), 3);
+        CHECK_EQ(dv.size(), 3);
+    }
+
+    SUBCASE("shrink_to_fit empty") {
+        devectra<int> dv;
+        dv.reserve(100);
+        dv.shrink_to_fit();
+        CHECK_EQ(dv.capacity(), 0);
+    }
+}
+
+TEST_CASE("devectra::modifiers") {
+    SUBCASE("clear") {
+        devectra<int> dv{1, 2, 3, 4, 5};
+        dv.clear();
+        CHECK_EQ(dv.empty(), true);
+        // After clear, should still be able to push
+        dv.push_front(10);
+        dv.push_back(20);
+        CHECK_EQ(dv.size(), 2);
+    }
+
+    SUBCASE("resize grow") {
+        devectra<int> dv{1, 2, 3};
+        dv.resize(6);
+        CHECK_EQ(dv.size(), 6);
+        CHECK_EQ(dv[0], 1);
+        CHECK_EQ(dv[3], 0);
+    }
+
+    SUBCASE("resize shrink") {
+        devectra<int> dv{1, 2, 3, 4, 5};
+        dv.resize(2);
+        CHECK_EQ(dv.size(), 2);
+        CHECK_EQ(dv[0], 1);
+        CHECK_EQ(dv[1], 2);
+    }
+
+    SUBCASE("resize with value") {
+        devectra<int> dv{1, 2, 3};
+        dv.resize(6, 42);
+        CHECK_EQ(dv.size(), 6);
+        CHECK_EQ(dv[0], 1);
+        CHECK_EQ(dv[3], 42);
+    }
+
+    SUBCASE("assign count and value") {
+        devectra<int> dv{1, 2, 3};
+        dv.assign(5, 42);
+        CHECK_EQ(dv.size(), 5);
+        for (int i = 0; i < 5; ++i) {
+            CHECK_EQ(dv[i], 42);
+        }
+    }
+
+    SUBCASE("assign from iterators") {
+        std::vector<int> source{10, 20, 30, 40, 50};
+        devectra<int> dv{1, 2, 3};
+        dv.assign(source.begin(), source.end());
+        CHECK_EQ(dv.size(), 5);
+        for (size_t i = 0; i < source.size(); ++i) {
+            CHECK_EQ(dv[i], source[i]);
+        }
+    }
+
+    SUBCASE("assign from initializer list") {
+        devectra<int> dv{1, 2, 3};
+        dv.assign({10, 20, 30, 40});
+        CHECK_EQ(dv.size(), 4);
+        CHECK_EQ(dv[0], 10);
+        CHECK_EQ(dv[3], 40);
+    }
+}
+
+TEST_CASE("devectra::iterators") {
+    devectra<int> dv{1, 2, 3, 4, 5};
+
+    SUBCASE("begin/end") {
+        int expected = 1;
+        for (auto it = dv.begin(); it != dv.end(); ++it) {
+            CHECK_EQ(*it, expected++);
+        }
+    }
+
+    SUBCASE("range-based for") {
+        int sum = 0;
+        for (int val : dv) {
+            sum += val;
+        }
+        CHECK_EQ(sum, 15);
+    }
+
+    SUBCASE("reverse iterators") {
+        int expected = 5;
+        for (auto it = dv.rbegin(); it != dv.rend(); ++it) {
+            CHECK_EQ(*it, expected--);
+        }
+    }
+
+    SUBCASE("const iterators") {
+        const devectra<int>& cdv = dv;
+        int expected = 1;
+        for (auto it = cdv.cbegin(); it != cdv.cend(); ++it) {
+            CHECK_EQ(*it, expected++);
+        }
+    }
+}
+
+TEST_CASE("devectra::erase") {
+    SUBCASE("erase single element") {
+        devectra<int> dv{1, 2, 3, 4, 5};
+        auto it = dv.erase(dv.begin() + 2);
+        CHECK_EQ(dv.size(), 4);
+        CHECK_EQ(*it, 4);
+        CHECK_EQ(dv[0], 1);
+        CHECK_EQ(dv[1], 2);
+        CHECK_EQ(dv[2], 4);
+        CHECK_EQ(dv[3], 5);
+    }
+
+    SUBCASE("erase range") {
+        devectra<int> dv{1, 2, 3, 4, 5};
+        auto it = dv.erase(dv.begin() + 1, dv.begin() + 4);
+        CHECK_EQ(dv.size(), 2);
+        CHECK_EQ(*it, 5);
+        CHECK_EQ(dv[0], 1);
+        CHECK_EQ(dv[1], 5);
+    }
+
+    SUBCASE("erase first element") {
+        devectra<int> dv{1, 2, 3};
+        dv.erase(dv.begin());
+        CHECK_EQ(dv.size(), 2);
+        CHECK_EQ(dv[0], 2);
+    }
+
+    SUBCASE("erase last element") {
+        devectra<int> dv{1, 2, 3};
+        dv.erase(dv.end() - 1);
+        CHECK_EQ(dv.size(), 2);
+        CHECK_EQ(dv[1], 2);
+    }
+}
+
+TEST_CASE("devectra::insert") {
+    SUBCASE("insert at beginning") {
+        devectra<int> dv{2, 3, 4};
+        dv.insert(dv.begin(), 1);
+        CHECK_EQ(dv.size(), 4);
+        CHECK_EQ(dv[0], 1);
+        CHECK_EQ(dv[1], 2);
+    }
+
+    SUBCASE("insert in middle") {
+        devectra<int> dv{1, 2, 4, 5};
+        dv.insert(dv.begin() + 2, 3);
+        CHECK_EQ(dv.size(), 5);
+        CHECK_EQ(dv[2], 3);
+    }
+
+    SUBCASE("insert at end") {
+        devectra<int> dv{1, 2, 3};
+        dv.insert(dv.end(), 4);
+        CHECK_EQ(dv.size(), 4);
+        CHECK_EQ(dv[3], 4);
+    }
+
+    SUBCASE("insert rvalue") {
+        devectra<std::string> dv{"a", "c"};
+        dv.insert(dv.begin() + 1, "b");
+        CHECK_EQ(dv.size(), 3);
+        CHECK_EQ(dv[1], "b");
+    }
+}
+
+TEST_CASE("devectra::swap") {
+    SUBCASE("swap") {
+        devectra<int> dv1{1, 2, 3};
+        devectra<int> dv2{10, 20};
+        dv1.swap(dv2);
+        CHECK_EQ(dv1.size(), 2);
+        CHECK_EQ(dv2.size(), 3);
+        CHECK_EQ(dv1[0], 10);
+        CHECK_EQ(dv2[0], 1);
+    }
+
+    SUBCASE("std::swap") {
+        devectra<int> dv1{1, 2, 3};
+        devectra<int> dv2{10, 20};
+        std::swap(dv1, dv2);
+        CHECK_EQ(dv1.size(), 2);
+        CHECK_EQ(dv2.size(), 3);
+    }
+}
+
+TEST_CASE("devectra::comparison") {
+    SUBCASE("equality") {
+        devectra<int> dv1{1, 2, 3};
+        devectra<int> dv2{1, 2, 3};
+        devectra<int> dv3{1, 2, 4};
+        CHECK_EQ(dv1 == dv2, true);
+        CHECK_EQ(dv1 == dv3, false);
+        CHECK_EQ(dv1 != dv3, true);
+    }
+
+    SUBCASE("ordering") {
+        devectra<int> dv1{1, 2, 3};
+        devectra<int> dv2{1, 2, 4};
+        devectra<int> dv3{1, 2};
+
+        CHECK_EQ(dv1 < dv2, true);
+        CHECK_EQ(dv2 > dv1, true);
+        CHECK_EQ(dv3 < dv1, true);
+        CHECK_EQ(dv1 <=> dv2, std::strong_ordering::less);
+    }
+}
+
+TEST_CASE("devectra::complex_types") {
+    SUBCASE("with std::string") {
+        devectra<std::string> dv;
+        dv.push_front("world");
+        dv.push_front("hello");
+        dv.push_back("!");
+
+        CHECK_EQ(dv.size(), 3);
+        CHECK_EQ(dv[0], "hello");
+        CHECK_EQ(dv[1], "world");
+        CHECK_EQ(dv[2], "!");
+    }
+
+    SUBCASE("move-only type") {
+        struct MoveOnly
+        {
+            int value;
+            MoveOnly(int v) : value(v) {}
+            MoveOnly(const MoveOnly&) = delete;
+            MoveOnly& operator=(const MoveOnly&) = delete;
+            MoveOnly(MoveOnly&& other) noexcept : value(other.value) { other.value = -1; }
+            MoveOnly& operator=(MoveOnly&& other) noexcept {
+                value = other.value;
+                other.value = -1;
+                return *this;
+            }
+        };
+
+        devectra<MoveOnly> dv;
+        dv.emplace_back(1);
+        dv.emplace_front(0);
+        dv.emplace_back(2);
+
+        CHECK_EQ(dv.size(), 3);
+        CHECK_EQ(dv[0].value, 0);
+        CHECK_EQ(dv[1].value, 1);
+        CHECK_EQ(dv[2].value, 2);
+    }
+}
+
+TEST_CASE("devectra::std_erase") {
+    SUBCASE("std::erase") {
+        devectra<int> dv{1, 2, 3, 2, 4, 2, 5};
+        auto count = std::erase(dv, 2);
+        CHECK_EQ(count, 3);
+        CHECK_EQ(dv.size(), 4);
+        CHECK_EQ(dv[0], 1);
+        CHECK_EQ(dv[1], 3);
+        CHECK_EQ(dv[2], 4);
+        CHECK_EQ(dv[3], 5);
+    }
+
+    SUBCASE("std::erase_if") {
+        devectra<int> dv{1, 2, 3, 4, 5, 6};
+        auto count = std::erase_if(dv, [](int x) { return x % 2 == 0; });
+        CHECK_EQ(count, 3);
+        CHECK_EQ(dv.size(), 3);
+        CHECK_EQ(dv[0], 1);
+        CHECK_EQ(dv[1], 3);
+        CHECK_EQ(dv[2], 5);
+    }
+}
+
+TEST_CASE("devectra::deque_like_usage") {
+    SUBCASE("as double-ended queue") {
+        devectra<int> dq;
+
+        // Enqueue at back
+        dq.push_back(1);
+        dq.push_back(2);
+        dq.push_back(3);
+
+        // Dequeue from front
+        CHECK_EQ(dq.front(), 1);
+        dq.pop_front();
+        CHECK_EQ(dq.front(), 2);
+        dq.pop_front();
+
+        // More enqueues
+        dq.push_back(4);
+        dq.push_back(5);
+
+        // Dequeue all
+        std::vector<int> result;
+        while (!dq.empty()) {
+            result.push_back(dq.front());
+            dq.pop_front();
+        }
+        CHECK_EQ(result, std::vector<int>{3, 4, 5});
+    }
+
+    SUBCASE("undo/redo stack pattern") {
+        devectra<std::string> history;
+
+        // Actions
+        history.push_back("action1");
+        history.push_back("action2");
+        history.push_back("action3");
+
+        // Undo (pop from back)
+        history.pop_back();
+        CHECK_EQ(history.back(), "action2");
+
+        // More actions
+        history.push_back("action4");
+
+        // Limit history size by removing oldest
+        while (history.size() > 2) {
+            history.pop_front();
+        }
+
+        CHECK_EQ(history.size(), 2);
+        CHECK_EQ(history[0], "action2");
+        CHECK_EQ(history[1], "action4");
+    }
+}
+
+// NOLINTEND
+}  // namespace stdb::container

--- a/tests/ring_buffer_test.cc
+++ b/tests/ring_buffer_test.cc
@@ -1,0 +1,532 @@
+/*
+ * Copyright 2025 ClapDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "container/ring_buffer.hpp"
+
+#include <doctest/doctest.h>
+
+#include <string>
+#include <vector>
+
+namespace stdb::container {
+// NOLINTBEGIN
+
+TEST_CASE("ring_buffer::basic") {
+    SUBCASE("default constructor") {
+        ring_buffer<int, 8> buf;
+        CHECK_EQ(buf.empty(), true);
+        CHECK_EQ(buf.size(), 0);
+        CHECK_EQ(buf.capacity(), 8);
+        CHECK_EQ(buf.full(), false);
+        CHECK_EQ(buf.available(), 8);
+    }
+
+    SUBCASE("static_capacity matches template parameter") {
+        CHECK_EQ(ring_buffer<int, 4>::static_capacity, 4);
+        CHECK_EQ(ring_buffer<int, 16>::static_capacity, 16);
+    }
+
+    SUBCASE("push_back increases size") {
+        ring_buffer<int, 4> buf;
+        buf.push_back(1);
+        CHECK_EQ(buf.size(), 1);
+        buf.push_back(2);
+        CHECK_EQ(buf.size(), 2);
+        buf.push_back(3);
+        buf.push_back(4);
+        CHECK_EQ(buf.size(), 4);
+        CHECK_EQ(buf.full(), true);
+    }
+
+    SUBCASE("overflow overwrites oldest") {
+        ring_buffer<int, 4> buf;
+        buf.push_back(1);
+        buf.push_back(2);
+        buf.push_back(3);
+        buf.push_back(4);
+        CHECK_EQ(buf.front(), 1);
+        CHECK_EQ(buf.back(), 4);
+
+        buf.push_back(5);          // Overwrites 1
+        CHECK_EQ(buf.size(), 4);   // Still 4
+        CHECK_EQ(buf.front(), 2);  // Now 2 is oldest
+        CHECK_EQ(buf.back(), 5);
+
+        buf.push_back(6);  // Overwrites 2
+        CHECK_EQ(buf.front(), 3);
+        CHECK_EQ(buf.back(), 6);
+    }
+}
+
+TEST_CASE("ring_buffer::constructors") {
+    SUBCASE("initializer list") {
+        ring_buffer<int, 8> buf{1, 2, 3, 4, 5};
+        CHECK_EQ(buf.size(), 5);
+        CHECK_EQ(buf[0], 1);
+        CHECK_EQ(buf[4], 5);
+    }
+
+    SUBCASE("initializer list overflow") {
+        ring_buffer<int, 4> buf{1, 2, 3, 4, 5, 6};
+        CHECK_EQ(buf.size(), 4);
+        CHECK_EQ(buf[0], 3);  // 1, 2 were overwritten
+        CHECK_EQ(buf[3], 6);
+    }
+
+    SUBCASE("copy constructor") {
+        ring_buffer<int, 8> buf1{1, 2, 3, 4};
+        ring_buffer<int, 8> buf2(buf1);
+        CHECK_EQ(buf2.size(), 4);
+        CHECK_EQ(buf1, buf2);
+    }
+
+    SUBCASE("move constructor") {
+        ring_buffer<int, 8> buf1{1, 2, 3, 4};
+        ring_buffer<int, 8> buf2(std::move(buf1));
+        CHECK_EQ(buf2.size(), 4);
+        CHECK_EQ(buf2[0], 1);
+        CHECK_EQ(buf2[3], 4);
+        CHECK_EQ(buf1.size(), 0);
+    }
+
+    SUBCASE("copy assignment") {
+        ring_buffer<int, 8> buf1{1, 2, 3};
+        ring_buffer<int, 8> buf2{10, 20, 30, 40, 50};
+        buf2 = buf1;
+        CHECK_EQ(buf2.size(), 3);
+        CHECK_EQ(buf2, buf1);
+    }
+
+    SUBCASE("move assignment") {
+        ring_buffer<int, 8> buf1{1, 2, 3, 4};
+        ring_buffer<int, 8> buf2{10, 20};
+        buf2 = std::move(buf1);
+        CHECK_EQ(buf2.size(), 4);
+        CHECK_EQ(buf2[0], 1);
+        CHECK_EQ(buf1.size(), 0);
+    }
+}
+
+TEST_CASE("ring_buffer::element_access") {
+    ring_buffer<int, 8> buf{10, 20, 30, 40, 50};
+
+    SUBCASE("operator[]") {
+        CHECK_EQ(buf[0], 10);
+        CHECK_EQ(buf[4], 50);
+        buf[2] = 300;
+        CHECK_EQ(buf[2], 300);
+    }
+
+    SUBCASE("at() valid") {
+        CHECK_EQ(buf.at(0), 10);
+        CHECK_EQ(buf.at(4), 50);
+    }
+
+    SUBCASE("at() throws on out of range") {
+        CHECK_THROWS_AS(buf.at(5), std::out_of_range);
+        CHECK_THROWS_AS(buf.at(100), std::out_of_range);
+    }
+
+    SUBCASE("front() and back()") {
+        CHECK_EQ(buf.front(), 10);
+        CHECK_EQ(buf.back(), 50);
+        buf.front() = 100;
+        buf.back() = 500;
+        CHECK_EQ(buf.front(), 100);
+        CHECK_EQ(buf.back(), 500);
+    }
+}
+
+TEST_CASE("ring_buffer::modifiers") {
+    SUBCASE("push_back lvalue") {
+        ring_buffer<int, 8> buf;
+        for (int i = 0; i < 5; ++i) {
+            int val = i * 10;
+            buf.push_back(val);
+        }
+        CHECK_EQ(buf.size(), 5);
+        for (int i = 0; i < 5; ++i) {
+            CHECK_EQ(buf[i], i * 10);
+        }
+    }
+
+    SUBCASE("push_back rvalue") {
+        ring_buffer<std::string, 4> buf;
+        buf.push_back("hello");
+        buf.push_back("world");
+        CHECK_EQ(buf.size(), 2);
+        CHECK_EQ(buf[0], "hello");
+        CHECK_EQ(buf[1], "world");
+    }
+
+    SUBCASE("emplace_back") {
+        ring_buffer<std::pair<int, std::string>, 4> buf;
+        buf.emplace_back(1, "one");
+        buf.emplace_back(2, "two");
+        CHECK_EQ(buf.size(), 2);
+        CHECK_EQ(buf[0].first, 1);
+        CHECK_EQ(buf[0].second, "one");
+    }
+
+    SUBCASE("emplace_back with overflow") {
+        ring_buffer<std::pair<int, std::string>, 2> buf;
+        buf.emplace_back(1, "one");
+        buf.emplace_back(2, "two");
+        buf.emplace_back(3, "three");  // Overwrites (1, "one")
+        CHECK_EQ(buf.size(), 2);
+        CHECK_EQ(buf[0].first, 2);
+        CHECK_EQ(buf[1].first, 3);
+    }
+
+    SUBCASE("try_push_back") {
+        ring_buffer<int, 4> buf;
+        CHECK_EQ(buf.try_push_back(1), true);
+        CHECK_EQ(buf.try_push_back(2), true);
+        CHECK_EQ(buf.try_push_back(3), true);
+        CHECK_EQ(buf.try_push_back(4), true);
+        CHECK_EQ(buf.try_push_back(5), false);  // Full, doesn't overwrite
+        CHECK_EQ(buf.size(), 4);
+        CHECK_EQ(buf.back(), 4);
+    }
+
+    SUBCASE("pop_front") {
+        ring_buffer<int, 8> buf{1, 2, 3, 4, 5};
+        buf.pop_front();
+        CHECK_EQ(buf.size(), 4);
+        CHECK_EQ(buf.front(), 2);
+    }
+
+    SUBCASE("pop_back") {
+        ring_buffer<int, 8> buf{1, 2, 3, 4, 5};
+        buf.pop_back();
+        CHECK_EQ(buf.size(), 4);
+        CHECK_EQ(buf.back(), 4);
+    }
+
+    SUBCASE("try_pop_front") {
+        ring_buffer<int, 4> buf{1, 2, 3};
+        auto val = buf.try_pop_front();
+        CHECK_EQ(val.has_value(), true);
+        CHECK_EQ(val.value(), 1);
+        CHECK_EQ(buf.size(), 2);
+
+        buf.try_pop_front();
+        buf.try_pop_front();
+        val = buf.try_pop_front();
+        CHECK_EQ(val.has_value(), false);
+    }
+
+    SUBCASE("clear") {
+        ring_buffer<int, 8> buf{1, 2, 3, 4, 5};
+        buf.clear();
+        CHECK_EQ(buf.empty(), true);
+        CHECK_EQ(buf.size(), 0);
+    }
+}
+
+TEST_CASE("ring_buffer::wrap_around") {
+    SUBCASE("wrap around access") {
+        ring_buffer<int, 4> buf;
+        // Fill buffer
+        buf.push_back(1);
+        buf.push_back(2);
+        buf.push_back(3);
+        buf.push_back(4);
+
+        // Pop two from front
+        buf.pop_front();
+        buf.pop_front();
+        CHECK_EQ(buf.front(), 3);
+
+        // Push two more (will wrap around)
+        buf.push_back(5);
+        buf.push_back(6);
+        CHECK_EQ(buf.size(), 4);
+        CHECK_EQ(buf[0], 3);
+        CHECK_EQ(buf[1], 4);
+        CHECK_EQ(buf[2], 5);
+        CHECK_EQ(buf[3], 6);
+    }
+
+    SUBCASE("iteration after wrap around") {
+        ring_buffer<int, 4> buf;
+        buf.push_back(1);
+        buf.push_back(2);
+        buf.push_back(3);
+        buf.push_back(4);
+        buf.pop_front();
+        buf.pop_front();
+        buf.push_back(5);
+        buf.push_back(6);
+
+        std::vector<int> result;
+        for (int val : buf) {
+            result.push_back(val);
+        }
+        CHECK_EQ(result, std::vector<int>{3, 4, 5, 6});
+    }
+}
+
+TEST_CASE("ring_buffer::iterators") {
+    ring_buffer<int, 8> buf{1, 2, 3, 4, 5};
+
+    SUBCASE("begin/end") {
+        int expected = 1;
+        for (auto it = buf.begin(); it != buf.end(); ++it) {
+            CHECK_EQ(*it, expected++);
+        }
+    }
+
+    SUBCASE("range-based for") {
+        int sum = 0;
+        for (int val : buf) {
+            sum += val;
+        }
+        CHECK_EQ(sum, 15);
+    }
+
+    SUBCASE("reverse iterators") {
+        int expected = 5;
+        for (auto it = buf.rbegin(); it != buf.rend(); ++it) {
+            CHECK_EQ(*it, expected--);
+        }
+    }
+
+    SUBCASE("const iterators") {
+        const ring_buffer<int, 8>& cbuf = buf;
+        int expected = 1;
+        for (auto it = cbuf.cbegin(); it != cbuf.cend(); ++it) {
+            CHECK_EQ(*it, expected++);
+        }
+    }
+
+    SUBCASE("iterator arithmetic") {
+        auto it = buf.begin();
+        CHECK_EQ(*(it + 2), 3);
+        CHECK_EQ(it[3], 4);
+        auto it2 = buf.end();
+        CHECK_EQ(it2 - it, 5);
+    }
+
+    SUBCASE("iterator comparison") {
+        auto it1 = buf.begin();
+        auto it2 = buf.begin() + 2;
+        CHECK_EQ(it1 < it2, true);
+        CHECK_EQ(it1 <= it2, true);
+        CHECK_EQ(it2 > it1, true);
+        CHECK_EQ(it2 >= it1, true);
+    }
+}
+
+TEST_CASE("ring_buffer::comparison") {
+    SUBCASE("equality") {
+        ring_buffer<int, 8> buf1{1, 2, 3};
+        ring_buffer<int, 8> buf2{1, 2, 3};
+        ring_buffer<int, 8> buf3{1, 2, 4};
+        CHECK_EQ(buf1 == buf2, true);
+        CHECK_EQ(buf1 == buf3, false);
+        CHECK_EQ(buf1 != buf3, true);
+    }
+
+    SUBCASE("equality after wrap around") {
+        ring_buffer<int, 4> buf1{1, 2, 3, 4};
+        buf1.pop_front();
+        buf1.push_back(5);  // Contains [2,3,4,5]
+
+        ring_buffer<int, 4> buf2{2, 3, 4, 5};
+        CHECK_EQ(buf1 == buf2, true);
+    }
+}
+
+TEST_CASE("ring_buffer::complex_types") {
+    SUBCASE("with std::string") {
+        ring_buffer<std::string, 4> buf;
+        buf.push_back("hello");
+        buf.push_back("world");
+        buf.emplace_back("test");
+
+        CHECK_EQ(buf.size(), 3);
+        CHECK_EQ(buf[0], "hello");
+        CHECK_EQ(buf[1], "world");
+        CHECK_EQ(buf[2], "test");
+
+        // Overflow
+        buf.push_back("a");
+        buf.push_back("b");  // Overwrites "hello"
+        CHECK_EQ(buf.front(), "world");
+        CHECK_EQ(buf.back(), "b");
+    }
+
+    SUBCASE("move-only type") {
+        struct MoveOnly
+        {
+            int value;
+            MoveOnly(int v) : value(v) {}
+            MoveOnly(const MoveOnly&) = delete;
+            MoveOnly& operator=(const MoveOnly&) = delete;
+            MoveOnly(MoveOnly&& other) noexcept : value(other.value) { other.value = -1; }
+            MoveOnly& operator=(MoveOnly&& other) noexcept {
+                value = other.value;
+                other.value = -1;
+                return *this;
+            }
+        };
+
+        ring_buffer<MoveOnly, 4> buf;
+        buf.emplace_back(1);
+        buf.emplace_back(2);
+        buf.push_back(MoveOnly(3));
+
+        CHECK_EQ(buf.size(), 3);
+        CHECK_EQ(buf[0].value, 1);
+        CHECK_EQ(buf[1].value, 2);
+        CHECK_EQ(buf[2].value, 3);
+    }
+}
+
+TEST_CASE("ring_buffer::utility") {
+    SUBCASE("contains") {
+        ring_buffer<int, 8> buf{1, 2, 3, 4, 5};
+        CHECK_EQ(buf.contains(3), true);
+        CHECK_EQ(buf.contains(10), false);
+    }
+
+    SUBCASE("copy_to") {
+        ring_buffer<int, 4> buf{1, 2, 3, 4};
+        buf.pop_front();
+        buf.push_back(5);  // [2, 3, 4, 5]
+
+        std::vector<int> result;
+        buf.copy_to(std::back_inserter(result));
+        CHECK_EQ(result, std::vector<int>{2, 3, 4, 5});
+    }
+
+    SUBCASE("swap") {
+        ring_buffer<int, 8> buf1{1, 2, 3};
+        ring_buffer<int, 8> buf2{10, 20};
+        buf1.swap(buf2);
+        CHECK_EQ(buf1.size(), 2);
+        CHECK_EQ(buf2.size(), 3);
+        CHECK_EQ(buf1[0], 10);
+        CHECK_EQ(buf2[0], 1);
+    }
+
+    SUBCASE("std::swap") {
+        ring_buffer<int, 8> buf1{1, 2, 3};
+        ring_buffer<int, 8> buf2{10, 20};
+        std::swap(buf1, buf2);
+        CHECK_EQ(buf1.size(), 2);
+        CHECK_EQ(buf2.size(), 3);
+    }
+}
+
+TEST_CASE("ring_buffer::fifo_usage") {
+    SUBCASE("producer-consumer pattern") {
+        ring_buffer<int, 4> buf;
+
+        // Producer adds items
+        buf.push_back(1);
+        buf.push_back(2);
+
+        // Consumer takes item
+        CHECK_EQ(buf.front(), 1);
+        buf.pop_front();
+
+        // Producer adds more
+        buf.push_back(3);
+        buf.push_back(4);
+
+        // Consumer processes all
+        std::vector<int> consumed;
+        while (!buf.empty()) {
+            consumed.push_back(buf.front());
+            buf.pop_front();
+        }
+        CHECK_EQ(consumed, std::vector<int>{2, 3, 4});
+    }
+
+    SUBCASE("sliding window") {
+        ring_buffer<int, 3> window;
+
+        // Simulate sliding window sum
+        std::vector<int> data{1, 2, 3, 4, 5, 6};
+        std::vector<int> window_sums;
+
+        for (int val : data) {
+            window.push_back(val);  // Automatically maintains window of 3
+            if (window.size() == 3) {
+                int sum = 0;
+                for (int w : window) sum += w;
+                window_sums.push_back(sum);
+            }
+        }
+
+        // Windows: [1,2,3]=6, [2,3,4]=9, [3,4,5]=12, [4,5,6]=15
+        CHECK_EQ(window_sums, std::vector<int>{6, 9, 12, 15});
+    }
+
+    SUBCASE("logging buffer - keep last N entries") {
+        ring_buffer<std::string, 3> log;
+
+        log.push_back("event1");
+        log.push_back("event2");
+        log.push_back("event3");
+        log.push_back("event4");  // Overwrites event1
+        log.push_back("event5");  // Overwrites event2
+
+        std::vector<std::string> recent_logs;
+        log.copy_to(std::back_inserter(recent_logs));
+        CHECK_EQ(recent_logs, std::vector<std::string>{"event3", "event4", "event5"});
+    }
+}
+
+TEST_CASE("ring_buffer::edge_cases") {
+    SUBCASE("size 1 buffer") {
+        ring_buffer<int, 1> buf;
+        buf.push_back(1);
+        CHECK_EQ(buf.front(), 1);
+        CHECK_EQ(buf.back(), 1);
+        CHECK_EQ(buf.full(), true);
+
+        buf.push_back(2);  // Overwrites 1
+        CHECK_EQ(buf.front(), 2);
+        CHECK_EQ(buf.size(), 1);
+    }
+
+    SUBCASE("alternating push/pop") {
+        ring_buffer<int, 4> buf;
+        for (int i = 0; i < 100; ++i) {
+            buf.push_back(i);
+            if (buf.size() > 2) {
+                buf.pop_front();
+            }
+        }
+        // Should have last 2 elements
+        CHECK_EQ(buf.size(), 2);
+        CHECK_EQ(buf[0], 98);
+        CHECK_EQ(buf[1], 99);
+    }
+
+    SUBCASE("empty buffer operations") {
+        ring_buffer<int, 4> buf;
+        auto val = buf.try_pop_front();
+        CHECK_EQ(val.has_value(), false);
+        CHECK_EQ(buf.empty(), true);
+    }
+}
+
+// NOLINTEND
+}  // namespace stdb::container

--- a/tests/small_vectra_test.cc
+++ b/tests/small_vectra_test.cc
@@ -1,0 +1,705 @@
+/*
+ * Copyright 2025 ClapDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "container/small_vectra.hpp"
+
+#include <doctest/doctest.h>
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace stdb::container {
+// NOLINTBEGIN
+
+TEST_CASE("small_vectra::basic") {
+    SUBCASE("default constructor uses inline storage") {
+        small_vectra<int, 8> vec;
+        CHECK_EQ(vec.empty(), true);
+        CHECK_EQ(vec.size(), 0);
+        CHECK_EQ(vec.capacity(), 8);
+        CHECK_EQ(vec.is_small(), true);
+        CHECK_NE(vec.data(), nullptr);
+    }
+
+    SUBCASE("inline_capacity matches template parameter") {
+        CHECK_EQ(small_vectra<int, 4>::inline_capacity, 4);
+        CHECK_EQ(small_vectra<int, 16>::inline_capacity, 16);
+        CHECK_EQ(small_vectra<double, 8>::inline_capacity, 8);
+    }
+
+    SUBCASE("stays inline when size <= N") {
+        small_vectra<int, 8> vec;
+        for (int i = 0; i < 8; ++i) {
+            vec.push_back(i);
+            CHECK_EQ(vec.is_small(), true);
+        }
+        CHECK_EQ(vec.size(), 8);
+        CHECK_EQ(vec.capacity(), 8);
+    }
+
+    SUBCASE("transitions to heap when size > N") {
+        small_vectra<int, 4> vec;
+        for (int i = 0; i < 4; ++i) {
+            vec.push_back(i);
+        }
+        CHECK_EQ(vec.is_small(), true);
+
+        vec.push_back(4);  // This should trigger heap allocation
+        CHECK_EQ(vec.is_small(), false);
+        CHECK_EQ(vec.size(), 5);
+        CHECK_GT(vec.capacity(), 4);
+
+        // Verify data integrity
+        for (int i = 0; i < 5; ++i) {
+            CHECK_EQ(vec[i], i);
+        }
+    }
+}
+
+TEST_CASE("small_vectra::constructors") {
+    SUBCASE("size constructor - inline") {
+        small_vectra<int, 8> vec(5);
+        CHECK_EQ(vec.size(), 5);
+        CHECK_EQ(vec.is_small(), true);
+        for (int i = 0; i < 5; ++i) {
+            CHECK_EQ(vec[i], 0);
+        }
+    }
+
+    SUBCASE("size constructor - heap") {
+        small_vectra<int, 4> vec(10);
+        CHECK_EQ(vec.size(), 10);
+        CHECK_EQ(vec.is_small(), false);
+        for (int i = 0; i < 10; ++i) {
+            CHECK_EQ(vec[i], 0);
+        }
+    }
+
+    SUBCASE("size and value constructor - inline") {
+        small_vectra<int, 8> vec(5, 42);
+        CHECK_EQ(vec.size(), 5);
+        CHECK_EQ(vec.is_small(), true);
+        for (int i = 0; i < 5; ++i) {
+            CHECK_EQ(vec[i], 42);
+        }
+    }
+
+    SUBCASE("size and value constructor - heap") {
+        small_vectra<int, 4> vec(10, 42);
+        CHECK_EQ(vec.size(), 10);
+        CHECK_EQ(vec.is_small(), false);
+        for (int i = 0; i < 10; ++i) {
+            CHECK_EQ(vec[i], 42);
+        }
+    }
+
+    SUBCASE("initializer list - inline") {
+        small_vectra<int, 8> vec{1, 2, 3, 4, 5};
+        CHECK_EQ(vec.size(), 5);
+        CHECK_EQ(vec.is_small(), true);
+        CHECK_EQ(vec[0], 1);
+        CHECK_EQ(vec[4], 5);
+    }
+
+    SUBCASE("initializer list - heap") {
+        small_vectra<int, 4> vec{1, 2, 3, 4, 5, 6, 7, 8};
+        CHECK_EQ(vec.size(), 8);
+        CHECK_EQ(vec.is_small(), false);
+        CHECK_EQ(vec[0], 1);
+        CHECK_EQ(vec[7], 8);
+    }
+
+    SUBCASE("iterator constructor") {
+        std::vector<int> source{1, 2, 3, 4, 5};
+        small_vectra<int, 8> vec(source.begin(), source.end());
+        CHECK_EQ(vec.size(), 5);
+        CHECK_EQ(vec.is_small(), true);
+        for (size_t i = 0; i < source.size(); ++i) {
+            CHECK_EQ(vec[i], source[i]);
+        }
+    }
+}
+
+TEST_CASE("small_vectra::copy_and_move") {
+    SUBCASE("copy constructor - inline to inline") {
+        small_vectra<int, 8> vec1{1, 2, 3, 4};
+        small_vectra<int, 8> vec2(vec1);
+        CHECK_EQ(vec2.size(), 4);
+        CHECK_EQ(vec2.is_small(), true);
+        CHECK_EQ(vec1, vec2);
+    }
+
+    SUBCASE("copy constructor - heap to heap") {
+        small_vectra<int, 4> vec1{1, 2, 3, 4, 5, 6, 7, 8};
+        small_vectra<int, 4> vec2(vec1);
+        CHECK_EQ(vec2.size(), 8);
+        CHECK_EQ(vec2.is_small(), false);
+        CHECK_EQ(vec1, vec2);
+    }
+
+    SUBCASE("move constructor - inline") {
+        small_vectra<int, 8> vec1{1, 2, 3, 4};
+        auto* original_data = vec1.data();
+        small_vectra<int, 8> vec2(std::move(vec1));
+
+        CHECK_EQ(vec2.size(), 4);
+        CHECK_EQ(vec2.is_small(), true);
+        // Inline storage means different addresses
+        CHECK_NE(vec2.data(), original_data);
+        CHECK_EQ(vec2[0], 1);
+        CHECK_EQ(vec2[3], 4);
+        CHECK_EQ(vec1.size(), 0);  // Source should be empty
+    }
+
+    SUBCASE("move constructor - heap") {
+        small_vectra<int, 4> vec1{1, 2, 3, 4, 5, 6, 7, 8};
+        auto* original_data = vec1.data();
+        small_vectra<int, 4> vec2(std::move(vec1));
+
+        CHECK_EQ(vec2.size(), 8);
+        CHECK_EQ(vec2.is_small(), false);
+        // Heap storage means pointer is stolen
+        CHECK_EQ(vec2.data(), original_data);
+        CHECK_EQ(vec2[0], 1);
+        CHECK_EQ(vec2[7], 8);
+        CHECK_EQ(vec1.is_small(), true);  // Source should be reset to inline
+    }
+
+    SUBCASE("copy assignment - smaller to larger capacity") {
+        small_vectra<int, 8> vec1{1, 2, 3};
+        small_vectra<int, 8> vec2{10, 20, 30, 40, 50};
+        vec2 = vec1;
+        CHECK_EQ(vec2.size(), 3);
+        CHECK_EQ(vec2, vec1);
+    }
+
+    SUBCASE("copy assignment - larger to smaller capacity") {
+        small_vectra<int, 8> vec1{1, 2, 3, 4, 5, 6, 7};
+        small_vectra<int, 8> vec2{10, 20};
+        vec2 = vec1;
+        CHECK_EQ(vec2.size(), 7);
+        CHECK_EQ(vec2, vec1);
+    }
+
+    SUBCASE("move assignment - inline to inline") {
+        small_vectra<int, 8> vec1{1, 2, 3, 4};
+        small_vectra<int, 8> vec2{10, 20};
+        vec2 = std::move(vec1);
+        CHECK_EQ(vec2.size(), 4);
+        CHECK_EQ(vec2.is_small(), true);
+        CHECK_EQ(vec2[0], 1);
+    }
+
+    SUBCASE("move assignment - heap to heap") {
+        small_vectra<int, 4> vec1{1, 2, 3, 4, 5, 6, 7, 8};
+        small_vectra<int, 4> vec2{10, 20, 30, 40, 50, 60};
+        auto* original_data = vec1.data();
+        vec2 = std::move(vec1);
+        CHECK_EQ(vec2.size(), 8);
+        CHECK_EQ(vec2.is_small(), false);
+        CHECK_EQ(vec2.data(), original_data);
+    }
+
+    SUBCASE("self assignment") {
+        small_vectra<int, 8> vec{1, 2, 3, 4};
+        auto* ptr = &vec;
+        vec = *ptr;
+        CHECK_EQ(vec.size(), 4);
+        CHECK_EQ(vec[0], 1);
+    }
+}
+
+TEST_CASE("small_vectra::modifiers") {
+    SUBCASE("push_back lvalue") {
+        small_vectra<int, 4> vec;
+        for (int i = 0; i < 10; ++i) {
+            int val = i * 10;
+            vec.push_back(val);
+        }
+        CHECK_EQ(vec.size(), 10);
+        CHECK_EQ(vec.is_small(), false);
+        for (int i = 0; i < 10; ++i) {
+            CHECK_EQ(vec[i], i * 10);
+        }
+    }
+
+    SUBCASE("push_back rvalue") {
+        small_vectra<std::string, 4> vec;
+        vec.push_back("hello");
+        vec.push_back("world");
+        CHECK_EQ(vec.size(), 2);
+        CHECK_EQ(vec[0], "hello");
+        CHECK_EQ(vec[1], "world");
+    }
+
+    SUBCASE("emplace_back") {
+        small_vectra<std::pair<int, std::string>, 4> vec;
+        vec.emplace_back(1, "one");
+        vec.emplace_back(2, "two");
+        CHECK_EQ(vec.size(), 2);
+        CHECK_EQ(vec[0].first, 1);
+        CHECK_EQ(vec[0].second, "one");
+    }
+
+    SUBCASE("pop_back") {
+        small_vectra<int, 8> vec{1, 2, 3, 4, 5};
+        vec.pop_back();
+        CHECK_EQ(vec.size(), 4);
+        CHECK_EQ(vec.back(), 4);
+    }
+
+    SUBCASE("clear") {
+        small_vectra<int, 8> vec{1, 2, 3, 4, 5};
+        vec.clear();
+        CHECK_EQ(vec.empty(), true);
+        CHECK_EQ(vec.is_small(), true);  // Should still be inline
+        CHECK_EQ(vec.capacity(), 8);
+    }
+
+    SUBCASE("resize - grow inline") {
+        small_vectra<int, 8> vec{1, 2, 3};
+        vec.resize(6);
+        CHECK_EQ(vec.size(), 6);
+        CHECK_EQ(vec.is_small(), true);
+        CHECK_EQ(vec[0], 1);
+        CHECK_EQ(vec[3], 0);
+    }
+
+    SUBCASE("resize - grow to heap") {
+        small_vectra<int, 4> vec{1, 2, 3};
+        vec.resize(10);
+        CHECK_EQ(vec.size(), 10);
+        CHECK_EQ(vec.is_small(), false);
+        CHECK_EQ(vec[0], 1);
+        CHECK_EQ(vec[5], 0);
+    }
+
+    SUBCASE("resize - shrink") {
+        small_vectra<int, 8> vec{1, 2, 3, 4, 5};
+        vec.resize(2);
+        CHECK_EQ(vec.size(), 2);
+        CHECK_EQ(vec[0], 1);
+        CHECK_EQ(vec[1], 2);
+    }
+
+    SUBCASE("resize with value") {
+        small_vectra<int, 8> vec{1, 2, 3};
+        vec.resize(6, 42);
+        CHECK_EQ(vec.size(), 6);
+        CHECK_EQ(vec[0], 1);
+        CHECK_EQ(vec[3], 42);
+        CHECK_EQ(vec[5], 42);
+    }
+}
+
+TEST_CASE("small_vectra::reserve_and_shrink") {
+    SUBCASE("reserve - stay inline") {
+        small_vectra<int, 8> vec{1, 2, 3};
+        vec.reserve(6);
+        CHECK_EQ(vec.is_small(), true);
+        CHECK_EQ(vec.capacity(), 8);
+        CHECK_EQ(vec.size(), 3);
+    }
+
+    SUBCASE("reserve - transition to heap") {
+        small_vectra<int, 4> vec{1, 2, 3};
+        vec.reserve(10);
+        CHECK_EQ(vec.is_small(), false);
+        CHECK_GE(vec.capacity(), 10);
+        CHECK_EQ(vec.size(), 3);
+        CHECK_EQ(vec[0], 1);
+    }
+
+    SUBCASE("shrink_to_fit - heap to inline") {
+        small_vectra<int, 8> vec;
+        vec.reserve(100);  // Force heap allocation
+        vec.push_back(1);
+        vec.push_back(2);
+        CHECK_EQ(vec.is_small(), false);
+
+        vec.shrink_to_fit();
+        CHECK_EQ(vec.is_small(), true);
+        CHECK_EQ(vec.size(), 2);
+        CHECK_EQ(vec[0], 1);
+        CHECK_EQ(vec[1], 2);
+    }
+
+    SUBCASE("shrink_to_fit - heap stays heap") {
+        small_vectra<int, 4> vec;
+        vec.reserve(100);
+        for (int i = 0; i < 10; ++i) {
+            vec.push_back(i);
+        }
+        CHECK_EQ(vec.is_small(), false);
+
+        vec.shrink_to_fit();
+        CHECK_EQ(vec.is_small(), false);
+        CHECK_EQ(vec.capacity(), 10);
+        CHECK_EQ(vec.size(), 10);
+    }
+}
+
+TEST_CASE("small_vectra::element_access") {
+    small_vectra<int, 8> vec{10, 20, 30, 40, 50};
+
+    SUBCASE("operator[]") {
+        CHECK_EQ(vec[0], 10);
+        CHECK_EQ(vec[4], 50);
+        vec[2] = 300;
+        CHECK_EQ(vec[2], 300);
+    }
+
+    SUBCASE("at()") {
+        CHECK_EQ(vec.at(0), 10);
+        CHECK_EQ(vec.at(4), 50);
+    }
+
+    SUBCASE("front() and back()") {
+        CHECK_EQ(vec.front(), 10);
+        CHECK_EQ(vec.back(), 50);
+        vec.front() = 100;
+        vec.back() = 500;
+        CHECK_EQ(vec.front(), 100);
+        CHECK_EQ(vec.back(), 500);
+    }
+
+    SUBCASE("data()") {
+        int* ptr = vec.data();
+        CHECK_NE(ptr, nullptr);
+        CHECK_EQ(ptr[0], 10);
+        CHECK_EQ(ptr[4], 50);
+    }
+}
+
+TEST_CASE("small_vectra::iterators") {
+    small_vectra<int, 8> vec{1, 2, 3, 4, 5};
+
+    SUBCASE("begin/end") {
+        int expected = 1;
+        for (auto it = vec.begin(); it != vec.end(); ++it) {
+            CHECK_EQ(*it, expected++);
+        }
+    }
+
+    SUBCASE("range-based for") {
+        int sum = 0;
+        for (int val : vec) {
+            sum += val;
+        }
+        CHECK_EQ(sum, 15);
+    }
+
+    SUBCASE("reverse iterators") {
+        int expected = 5;
+        for (auto it = vec.rbegin(); it != vec.rend(); ++it) {
+            CHECK_EQ(*it, expected--);
+        }
+    }
+
+    SUBCASE("const iterators") {
+        const small_vectra<int, 8>& cvec = vec;
+        int expected = 1;
+        for (auto it = cvec.cbegin(); it != cvec.cend(); ++it) {
+            CHECK_EQ(*it, expected++);
+        }
+    }
+}
+
+TEST_CASE("small_vectra::erase") {
+    SUBCASE("erase single element") {
+        small_vectra<int, 8> vec{1, 2, 3, 4, 5};
+        auto it = vec.erase(vec.begin() + 2);
+        CHECK_EQ(vec.size(), 4);
+        CHECK_EQ(*it, 4);
+        CHECK_EQ(vec[0], 1);
+        CHECK_EQ(vec[1], 2);
+        CHECK_EQ(vec[2], 4);
+        CHECK_EQ(vec[3], 5);
+    }
+
+    SUBCASE("erase range") {
+        small_vectra<int, 8> vec{1, 2, 3, 4, 5};
+        auto it = vec.erase(vec.begin() + 1, vec.begin() + 4);
+        CHECK_EQ(vec.size(), 2);
+        CHECK_EQ(*it, 5);
+        CHECK_EQ(vec[0], 1);
+        CHECK_EQ(vec[1], 5);
+    }
+
+    SUBCASE("erase first element") {
+        small_vectra<int, 8> vec{1, 2, 3};
+        vec.erase(vec.begin());
+        CHECK_EQ(vec.size(), 2);
+        CHECK_EQ(vec[0], 2);
+        CHECK_EQ(vec[1], 3);
+    }
+
+    SUBCASE("erase last element") {
+        small_vectra<int, 8> vec{1, 2, 3};
+        vec.erase(vec.end() - 1);
+        CHECK_EQ(vec.size(), 2);
+        CHECK_EQ(vec[0], 1);
+        CHECK_EQ(vec[1], 2);
+    }
+}
+
+TEST_CASE("small_vectra::insert") {
+    SUBCASE("insert at beginning") {
+        small_vectra<int, 8> vec{2, 3, 4};
+        vec.insert(vec.begin(), 1);
+        CHECK_EQ(vec.size(), 4);
+        CHECK_EQ(vec[0], 1);
+        CHECK_EQ(vec[1], 2);
+    }
+
+    SUBCASE("insert in middle") {
+        small_vectra<int, 8> vec{1, 2, 4, 5};
+        vec.insert(vec.begin() + 2, 3);
+        CHECK_EQ(vec.size(), 5);
+        CHECK_EQ(vec[2], 3);
+    }
+
+    SUBCASE("insert at end") {
+        small_vectra<int, 8> vec{1, 2, 3};
+        vec.insert(vec.end(), 4);
+        CHECK_EQ(vec.size(), 4);
+        CHECK_EQ(vec[3], 4);
+    }
+
+    SUBCASE("insert triggers reallocation") {
+        small_vectra<int, 4> vec{1, 2, 3, 4};
+        CHECK_EQ(vec.is_small(), true);
+        vec.insert(vec.begin() + 2, 100);
+        CHECK_EQ(vec.is_small(), false);
+        CHECK_EQ(vec.size(), 5);
+        CHECK_EQ(vec[0], 1);
+        CHECK_EQ(vec[1], 2);
+        CHECK_EQ(vec[2], 100);
+        CHECK_EQ(vec[3], 3);
+        CHECK_EQ(vec[4], 4);
+    }
+}
+
+TEST_CASE("small_vectra::assign") {
+    SUBCASE("assign count and value - inline") {
+        small_vectra<int, 8> vec{1, 2, 3};
+        vec.assign(5, 42);
+        CHECK_EQ(vec.size(), 5);
+        CHECK_EQ(vec.is_small(), true);
+        for (int i = 0; i < 5; ++i) {
+            CHECK_EQ(vec[i], 42);
+        }
+    }
+
+    SUBCASE("assign count and value - to heap") {
+        small_vectra<int, 4> vec{1, 2, 3};
+        vec.assign(10, 42);
+        CHECK_EQ(vec.size(), 10);
+        CHECK_EQ(vec.is_small(), false);
+        for (int i = 0; i < 10; ++i) {
+            CHECK_EQ(vec[i], 42);
+        }
+    }
+
+    SUBCASE("assign from iterators") {
+        std::vector<int> source{10, 20, 30, 40, 50};
+        small_vectra<int, 8> vec{1, 2, 3};
+        vec.assign(source.begin(), source.end());
+        CHECK_EQ(vec.size(), 5);
+        for (size_t i = 0; i < source.size(); ++i) {
+            CHECK_EQ(vec[i], source[i]);
+        }
+    }
+
+    SUBCASE("assign from initializer list") {
+        small_vectra<int, 8> vec{1, 2, 3};
+        vec.assign({10, 20, 30, 40});
+        CHECK_EQ(vec.size(), 4);
+        CHECK_EQ(vec[0], 10);
+        CHECK_EQ(vec[3], 40);
+    }
+}
+
+TEST_CASE("small_vectra::swap") {
+    SUBCASE("swap inline with inline") {
+        small_vectra<int, 8> vec1{1, 2, 3};
+        small_vectra<int, 8> vec2{10, 20, 30, 40};
+        vec1.swap(vec2);
+        CHECK_EQ(vec1.size(), 4);
+        CHECK_EQ(vec2.size(), 3);
+        CHECK_EQ(vec1[0], 10);
+        CHECK_EQ(vec2[0], 1);
+    }
+
+    SUBCASE("swap heap with heap") {
+        small_vectra<int, 4> vec1{1, 2, 3, 4, 5, 6};
+        small_vectra<int, 4> vec2{10, 20, 30, 40, 50, 60, 70, 80};
+        auto* ptr1 = vec1.data();
+        auto* ptr2 = vec2.data();
+        vec1.swap(vec2);
+        CHECK_EQ(vec1.data(), ptr2);
+        CHECK_EQ(vec2.data(), ptr1);
+        CHECK_EQ(vec1.size(), 8);
+        CHECK_EQ(vec2.size(), 6);
+    }
+
+    SUBCASE("swap inline with heap") {
+        small_vectra<int, 4> vec1{1, 2, 3};
+        small_vectra<int, 4> vec2{10, 20, 30, 40, 50, 60};
+        CHECK_EQ(vec1.is_small(), true);
+        CHECK_EQ(vec2.is_small(), false);
+        vec1.swap(vec2);
+        CHECK_EQ(vec1.is_small(), false);
+        CHECK_EQ(vec2.is_small(), true);
+        CHECK_EQ(vec1.size(), 6);
+        CHECK_EQ(vec2.size(), 3);
+        CHECK_EQ(vec1[0], 10);
+        CHECK_EQ(vec2[0], 1);
+    }
+
+    SUBCASE("std::swap") {
+        small_vectra<int, 8> vec1{1, 2, 3};
+        small_vectra<int, 8> vec2{10, 20};
+        std::swap(vec1, vec2);
+        CHECK_EQ(vec1.size(), 2);
+        CHECK_EQ(vec2.size(), 3);
+    }
+}
+
+TEST_CASE("small_vectra::comparison") {
+    SUBCASE("equality") {
+        small_vectra<int, 8> vec1{1, 2, 3};
+        small_vectra<int, 8> vec2{1, 2, 3};
+        small_vectra<int, 8> vec3{1, 2, 4};
+        CHECK_EQ(vec1 == vec2, true);
+        CHECK_EQ(vec1 == vec3, false);
+        CHECK_EQ(vec1 != vec3, true);
+    }
+
+    SUBCASE("ordering") {
+        small_vectra<int, 8> vec1{1, 2, 3};
+        small_vectra<int, 8> vec2{1, 2, 4};
+        small_vectra<int, 8> vec3{1, 2};
+
+        CHECK_EQ(vec1 < vec2, true);
+        CHECK_EQ(vec2 > vec1, true);
+        CHECK_EQ(vec3 < vec1, true);
+        CHECK_EQ(vec1 <=> vec2, std::strong_ordering::less);
+    }
+}
+
+TEST_CASE("small_vectra::complex_types") {
+    SUBCASE("with std::string") {
+        small_vectra<std::string, 4> vec;
+        vec.push_back("hello");
+        vec.push_back("world");
+        vec.emplace_back("test");
+
+        CHECK_EQ(vec.size(), 3);
+        CHECK_EQ(vec[0], "hello");
+        CHECK_EQ(vec[1], "world");
+        CHECK_EQ(vec[2], "test");
+
+        // Test move to heap
+        vec.push_back("a");
+        vec.push_back("b");
+        CHECK_EQ(vec.is_small(), false);
+        CHECK_EQ(vec[0], "hello");
+        CHECK_EQ(vec[4], "b");
+    }
+
+    SUBCASE("move-only type") {
+        struct MoveOnly
+        {
+            int value;
+            MoveOnly(int v) : value(v) {}
+            MoveOnly(const MoveOnly&) = delete;
+            MoveOnly& operator=(const MoveOnly&) = delete;
+            MoveOnly(MoveOnly&& other) noexcept : value(other.value) { other.value = -1; }
+            MoveOnly& operator=(MoveOnly&& other) noexcept {
+                value = other.value;
+                other.value = -1;
+                return *this;
+            }
+        };
+
+        small_vectra<MoveOnly, 4> vec;
+        vec.emplace_back(1);
+        vec.emplace_back(2);
+        vec.push_back(MoveOnly(3));
+
+        CHECK_EQ(vec.size(), 3);
+        CHECK_EQ(vec[0].value, 1);
+        CHECK_EQ(vec[1].value, 2);
+        CHECK_EQ(vec[2].value, 3);
+
+        // Move to another vector
+        small_vectra<MoveOnly, 4> vec2(std::move(vec));
+        CHECK_EQ(vec2.size(), 3);
+        CHECK_EQ(vec2[0].value, 1);
+    }
+}
+
+TEST_CASE("small_vectra::unsafe_mode") {
+    SUBCASE("unsafe push_back") {
+        small_vectra<int, 8> vec;
+        vec.reserve(5);
+        for (int i = 0; i < 5; ++i) {
+            vec.push_back<Safety::Unsafe>(i);
+        }
+        CHECK_EQ(vec.size(), 5);
+        for (int i = 0; i < 5; ++i) {
+            CHECK_EQ(vec[i], i);
+        }
+    }
+
+    SUBCASE("unsafe emplace_back") {
+        small_vectra<std::pair<int, int>, 8> vec;
+        vec.reserve(3);
+        vec.emplace_back<Safety::Unsafe>(1, 2);
+        vec.emplace_back<Safety::Unsafe>(3, 4);
+        CHECK_EQ(vec.size(), 2);
+        CHECK_EQ(vec[0].first, 1);
+        CHECK_EQ(vec[1].second, 4);
+    }
+}
+
+TEST_CASE("small_vectra::std_erase") {
+    SUBCASE("std::erase") {
+        small_vectra<int, 8> vec{1, 2, 3, 2, 4, 2, 5};
+        auto count = std::erase(vec, 2);
+        CHECK_EQ(count, 3);
+        CHECK_EQ(vec.size(), 4);
+        CHECK_EQ(vec[0], 1);
+        CHECK_EQ(vec[1], 3);
+        CHECK_EQ(vec[2], 4);
+        CHECK_EQ(vec[3], 5);
+    }
+
+    SUBCASE("std::erase_if") {
+        small_vectra<int, 8> vec{1, 2, 3, 4, 5, 6};
+        auto count = std::erase_if(vec, [](int x) { return x % 2 == 0; });
+        CHECK_EQ(count, 3);
+        CHECK_EQ(vec.size(), 3);
+        CHECK_EQ(vec[0], 1);
+        CHECK_EQ(vec[1], 3);
+        CHECK_EQ(vec[2], 5);
+    }
+}
+
+// NOLINTEND
+}  // namespace stdb::container

--- a/tests/static_vectra_test.cc
+++ b/tests/static_vectra_test.cc
@@ -1,0 +1,620 @@
+/*
+ * Copyright 2025 ClapDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "container/static_vectra.hpp"
+
+#include <doctest/doctest.h>
+
+#include <string>
+#include <vector>
+
+namespace stdb::container {
+// NOLINTBEGIN
+
+TEST_CASE("static_vectra::basic") {
+    SUBCASE("default constructor") {
+        static_vectra<int, 8> vec;
+        CHECK_EQ(vec.empty(), true);
+        CHECK_EQ(vec.size(), 0);
+        CHECK_EQ(vec.capacity(), 8);
+        CHECK_EQ(vec.max_size(), 8);
+        CHECK_EQ(vec.full(), false);
+        CHECK_EQ(vec.available(), 8);
+        CHECK_NE(vec.data(), nullptr);
+    }
+
+    SUBCASE("static_capacity matches template parameter") {
+        CHECK_EQ(static_vectra<int, 4>::static_capacity, 4);
+        CHECK_EQ(static_vectra<int, 16>::static_capacity, 16);
+        CHECK_EQ(static_vectra<double, 8>::static_capacity, 8);
+    }
+
+    SUBCASE("capacity is constexpr") {
+        constexpr auto cap = static_vectra<int, 10>::capacity();
+        CHECK_EQ(cap, 10);
+    }
+
+    SUBCASE("fills to capacity") {
+        static_vectra<int, 4> vec;
+        for (int i = 0; i < 4; ++i) {
+            vec.push_back(i);
+            CHECK_EQ(vec.available(), 3 - i);
+        }
+        CHECK_EQ(vec.size(), 4);
+        CHECK_EQ(vec.full(), true);
+        CHECK_EQ(vec.available(), 0);
+    }
+
+    SUBCASE("throws on overflow") {
+        static_vectra<int, 4> vec{1, 2, 3, 4};
+        CHECK_EQ(vec.full(), true);
+        CHECK_THROWS_AS(vec.push_back(5), std::length_error);
+    }
+}
+
+TEST_CASE("static_vectra::constructors") {
+    SUBCASE("size constructor") {
+        static_vectra<int, 8> vec(5);
+        CHECK_EQ(vec.size(), 5);
+        for (int i = 0; i < 5; ++i) {
+            CHECK_EQ(vec[i], 0);
+        }
+    }
+
+    SUBCASE("size constructor - at capacity") {
+        static_vectra<int, 4> vec(4);
+        CHECK_EQ(vec.size(), 4);
+        CHECK_EQ(vec.full(), true);
+    }
+
+    SUBCASE("size constructor - exceeds capacity throws") {
+        CHECK_THROWS_AS((static_vectra<int, 4>(5)), std::length_error);
+    }
+
+    SUBCASE("size and value constructor") {
+        static_vectra<int, 8> vec(5, 42);
+        CHECK_EQ(vec.size(), 5);
+        for (int i = 0; i < 5; ++i) {
+            CHECK_EQ(vec[i], 42);
+        }
+    }
+
+    SUBCASE("initializer list") {
+        static_vectra<int, 8> vec{1, 2, 3, 4, 5};
+        CHECK_EQ(vec.size(), 5);
+        CHECK_EQ(vec[0], 1);
+        CHECK_EQ(vec[4], 5);
+    }
+
+    SUBCASE("initializer list - exceeds capacity throws") {
+        CHECK_THROWS_AS((static_vectra<int, 4>{1, 2, 3, 4, 5}), std::length_error);
+    }
+
+    SUBCASE("iterator constructor") {
+        std::vector<int> source{1, 2, 3, 4, 5};
+        static_vectra<int, 8> vec(source.begin(), source.end());
+        CHECK_EQ(vec.size(), 5);
+        for (size_t i = 0; i < source.size(); ++i) {
+            CHECK_EQ(vec[i], source[i]);
+        }
+    }
+}
+
+TEST_CASE("static_vectra::copy_and_move") {
+    SUBCASE("copy constructor") {
+        static_vectra<int, 8> vec1{1, 2, 3, 4};
+        static_vectra<int, 8> vec2(vec1);
+        CHECK_EQ(vec2.size(), 4);
+        CHECK_EQ(vec1, vec2);
+    }
+
+    SUBCASE("move constructor") {
+        static_vectra<int, 8> vec1{1, 2, 3, 4};
+        static_vectra<int, 8> vec2(std::move(vec1));
+        CHECK_EQ(vec2.size(), 4);
+        CHECK_EQ(vec2[0], 1);
+        CHECK_EQ(vec2[3], 4);
+        CHECK_EQ(vec1.size(), 0);  // Source should be empty
+    }
+
+    SUBCASE("copy assignment") {
+        static_vectra<int, 8> vec1{1, 2, 3};
+        static_vectra<int, 8> vec2{10, 20, 30, 40, 50};
+        vec2 = vec1;
+        CHECK_EQ(vec2.size(), 3);
+        CHECK_EQ(vec2, vec1);
+    }
+
+    SUBCASE("move assignment") {
+        static_vectra<int, 8> vec1{1, 2, 3, 4};
+        static_vectra<int, 8> vec2{10, 20};
+        vec2 = std::move(vec1);
+        CHECK_EQ(vec2.size(), 4);
+        CHECK_EQ(vec2[0], 1);
+        CHECK_EQ(vec1.size(), 0);
+    }
+
+    SUBCASE("self assignment") {
+        static_vectra<int, 8> vec{1, 2, 3, 4};
+        auto* ptr = &vec;
+        vec = *ptr;
+        CHECK_EQ(vec.size(), 4);
+        CHECK_EQ(vec[0], 1);
+    }
+}
+
+TEST_CASE("static_vectra::modifiers") {
+    SUBCASE("push_back lvalue") {
+        static_vectra<int, 8> vec;
+        for (int i = 0; i < 5; ++i) {
+            int val = i * 10;
+            vec.push_back(val);
+        }
+        CHECK_EQ(vec.size(), 5);
+        for (int i = 0; i < 5; ++i) {
+            CHECK_EQ(vec[i], i * 10);
+        }
+    }
+
+    SUBCASE("push_back rvalue") {
+        static_vectra<std::string, 4> vec;
+        vec.push_back("hello");
+        vec.push_back("world");
+        CHECK_EQ(vec.size(), 2);
+        CHECK_EQ(vec[0], "hello");
+        CHECK_EQ(vec[1], "world");
+    }
+
+    SUBCASE("emplace_back") {
+        static_vectra<std::pair<int, std::string>, 4> vec;
+        vec.emplace_back(1, "one");
+        vec.emplace_back(2, "two");
+        CHECK_EQ(vec.size(), 2);
+        CHECK_EQ(vec[0].first, 1);
+        CHECK_EQ(vec[0].second, "one");
+    }
+
+    SUBCASE("pop_back") {
+        static_vectra<int, 8> vec{1, 2, 3, 4, 5};
+        vec.pop_back();
+        CHECK_EQ(vec.size(), 4);
+        CHECK_EQ(vec.back(), 4);
+    }
+
+    SUBCASE("clear") {
+        static_vectra<int, 8> vec{1, 2, 3, 4, 5};
+        vec.clear();
+        CHECK_EQ(vec.empty(), true);
+        CHECK_EQ(vec.capacity(), 8);
+    }
+
+    SUBCASE("resize - grow") {
+        static_vectra<int, 8> vec{1, 2, 3};
+        vec.resize(6);
+        CHECK_EQ(vec.size(), 6);
+        CHECK_EQ(vec[0], 1);
+        CHECK_EQ(vec[3], 0);
+    }
+
+    SUBCASE("resize - shrink") {
+        static_vectra<int, 8> vec{1, 2, 3, 4, 5};
+        vec.resize(2);
+        CHECK_EQ(vec.size(), 2);
+        CHECK_EQ(vec[0], 1);
+        CHECK_EQ(vec[1], 2);
+    }
+
+    SUBCASE("resize - exceeds capacity throws") {
+        static_vectra<int, 4> vec{1, 2};
+        CHECK_THROWS_AS(vec.resize(5), std::length_error);
+    }
+
+    SUBCASE("resize with value") {
+        static_vectra<int, 8> vec{1, 2, 3};
+        vec.resize(6, 42);
+        CHECK_EQ(vec.size(), 6);
+        CHECK_EQ(vec[0], 1);
+        CHECK_EQ(vec[3], 42);
+        CHECK_EQ(vec[5], 42);
+    }
+}
+
+TEST_CASE("static_vectra::reserve_noop") {
+    SUBCASE("reserve within capacity is noop") {
+        static_vectra<int, 8> vec{1, 2, 3};
+        vec.reserve(6);  // Should not throw
+        CHECK_EQ(vec.size(), 3);
+        CHECK_EQ(vec.capacity(), 8);
+    }
+
+    SUBCASE("reserve exceeds capacity throws") {
+        static_vectra<int, 4> vec{1, 2};
+        CHECK_THROWS_AS(vec.reserve(10), std::length_error);
+    }
+
+    SUBCASE("shrink_to_fit is noop") {
+        static_vectra<int, 8> vec{1, 2, 3};
+        vec.shrink_to_fit();
+        CHECK_EQ(vec.capacity(), 8);  // Unchanged
+    }
+}
+
+TEST_CASE("static_vectra::element_access") {
+    static_vectra<int, 8> vec{10, 20, 30, 40, 50};
+
+    SUBCASE("operator[]") {
+        CHECK_EQ(vec[0], 10);
+        CHECK_EQ(vec[4], 50);
+        vec[2] = 300;
+        CHECK_EQ(vec[2], 300);
+    }
+
+    SUBCASE("at() valid") {
+        CHECK_EQ(vec.at(0), 10);
+        CHECK_EQ(vec.at(4), 50);
+    }
+
+    SUBCASE("at() throws on out of range") {
+        CHECK_THROWS_AS(vec.at(5), std::out_of_range);
+        CHECK_THROWS_AS(vec.at(100), std::out_of_range);
+    }
+
+    SUBCASE("front() and back()") {
+        CHECK_EQ(vec.front(), 10);
+        CHECK_EQ(vec.back(), 50);
+        vec.front() = 100;
+        vec.back() = 500;
+        CHECK_EQ(vec.front(), 100);
+        CHECK_EQ(vec.back(), 500);
+    }
+
+    SUBCASE("data()") {
+        int* ptr = vec.data();
+        CHECK_NE(ptr, nullptr);
+        CHECK_EQ(ptr[0], 10);
+        CHECK_EQ(ptr[4], 50);
+    }
+}
+
+TEST_CASE("static_vectra::iterators") {
+    static_vectra<int, 8> vec{1, 2, 3, 4, 5};
+
+    SUBCASE("begin/end") {
+        int expected = 1;
+        for (auto it = vec.begin(); it != vec.end(); ++it) {
+            CHECK_EQ(*it, expected++);
+        }
+    }
+
+    SUBCASE("range-based for") {
+        int sum = 0;
+        for (int val : vec) {
+            sum += val;
+        }
+        CHECK_EQ(sum, 15);
+    }
+
+    SUBCASE("reverse iterators") {
+        int expected = 5;
+        for (auto it = vec.rbegin(); it != vec.rend(); ++it) {
+            CHECK_EQ(*it, expected--);
+        }
+    }
+
+    SUBCASE("const iterators") {
+        const static_vectra<int, 8>& cvec = vec;
+        int expected = 1;
+        for (auto it = cvec.cbegin(); it != cvec.cend(); ++it) {
+            CHECK_EQ(*it, expected++);
+        }
+    }
+}
+
+TEST_CASE("static_vectra::erase") {
+    SUBCASE("erase single element") {
+        static_vectra<int, 8> vec{1, 2, 3, 4, 5};
+        auto it = vec.erase(vec.begin() + 2);
+        CHECK_EQ(vec.size(), 4);
+        CHECK_EQ(*it, 4);
+        CHECK_EQ(vec[0], 1);
+        CHECK_EQ(vec[1], 2);
+        CHECK_EQ(vec[2], 4);
+        CHECK_EQ(vec[3], 5);
+    }
+
+    SUBCASE("erase range") {
+        static_vectra<int, 8> vec{1, 2, 3, 4, 5};
+        auto it = vec.erase(vec.begin() + 1, vec.begin() + 4);
+        CHECK_EQ(vec.size(), 2);
+        CHECK_EQ(*it, 5);
+        CHECK_EQ(vec[0], 1);
+        CHECK_EQ(vec[1], 5);
+    }
+
+    SUBCASE("erase first element") {
+        static_vectra<int, 8> vec{1, 2, 3};
+        vec.erase(vec.begin());
+        CHECK_EQ(vec.size(), 2);
+        CHECK_EQ(vec[0], 2);
+        CHECK_EQ(vec[1], 3);
+    }
+
+    SUBCASE("erase last element") {
+        static_vectra<int, 8> vec{1, 2, 3};
+        vec.erase(vec.end() - 1);
+        CHECK_EQ(vec.size(), 2);
+        CHECK_EQ(vec[0], 1);
+        CHECK_EQ(vec[1], 2);
+    }
+}
+
+TEST_CASE("static_vectra::insert") {
+    SUBCASE("insert at beginning") {
+        static_vectra<int, 8> vec{2, 3, 4};
+        vec.insert(vec.begin(), 1);
+        CHECK_EQ(vec.size(), 4);
+        CHECK_EQ(vec[0], 1);
+        CHECK_EQ(vec[1], 2);
+    }
+
+    SUBCASE("insert in middle") {
+        static_vectra<int, 8> vec{1, 2, 4, 5};
+        vec.insert(vec.begin() + 2, 3);
+        CHECK_EQ(vec.size(), 5);
+        CHECK_EQ(vec[2], 3);
+    }
+
+    SUBCASE("insert at end") {
+        static_vectra<int, 8> vec{1, 2, 3};
+        vec.insert(vec.end(), 4);
+        CHECK_EQ(vec.size(), 4);
+        CHECK_EQ(vec[3], 4);
+    }
+
+    SUBCASE("insert on full container throws") {
+        static_vectra<int, 4> vec{1, 2, 3, 4};
+        CHECK_THROWS_AS(vec.insert(vec.begin(), 0), std::length_error);
+    }
+
+    SUBCASE("insert count and value") {
+        static_vectra<int, 8> vec{1, 5};
+        vec.insert(vec.begin() + 1, 3, 3);
+        CHECK_EQ(vec.size(), 5);
+        CHECK_EQ(vec[0], 1);
+        CHECK_EQ(vec[1], 3);
+        CHECK_EQ(vec[2], 3);
+        CHECK_EQ(vec[3], 3);
+        CHECK_EQ(vec[4], 5);
+    }
+}
+
+TEST_CASE("static_vectra::assign") {
+    SUBCASE("assign count and value") {
+        static_vectra<int, 8> vec{1, 2, 3};
+        vec.assign(5, 42);
+        CHECK_EQ(vec.size(), 5);
+        for (int i = 0; i < 5; ++i) {
+            CHECK_EQ(vec[i], 42);
+        }
+    }
+
+    SUBCASE("assign exceeds capacity throws") {
+        static_vectra<int, 4> vec{1, 2, 3};
+        CHECK_THROWS_AS(vec.assign(10, 42), std::length_error);
+    }
+
+    SUBCASE("assign from iterators") {
+        std::vector<int> source{10, 20, 30, 40, 50};
+        static_vectra<int, 8> vec{1, 2, 3};
+        vec.assign(source.begin(), source.end());
+        CHECK_EQ(vec.size(), 5);
+        for (size_t i = 0; i < source.size(); ++i) {
+            CHECK_EQ(vec[i], source[i]);
+        }
+    }
+
+    SUBCASE("assign from initializer list") {
+        static_vectra<int, 8> vec{1, 2, 3};
+        vec.assign({10, 20, 30, 40});
+        CHECK_EQ(vec.size(), 4);
+        CHECK_EQ(vec[0], 10);
+        CHECK_EQ(vec[3], 40);
+    }
+}
+
+TEST_CASE("static_vectra::swap") {
+    SUBCASE("swap same size") {
+        static_vectra<int, 8> vec1{1, 2, 3};
+        static_vectra<int, 8> vec2{10, 20, 30};
+        vec1.swap(vec2);
+        CHECK_EQ(vec1[0], 10);
+        CHECK_EQ(vec2[0], 1);
+    }
+
+    SUBCASE("swap different sizes") {
+        static_vectra<int, 8> vec1{1, 2, 3, 4, 5};
+        static_vectra<int, 8> vec2{10, 20};
+        vec1.swap(vec2);
+        CHECK_EQ(vec1.size(), 2);
+        CHECK_EQ(vec2.size(), 5);
+        CHECK_EQ(vec1[0], 10);
+        CHECK_EQ(vec2[0], 1);
+        CHECK_EQ(vec2[4], 5);
+    }
+
+    SUBCASE("std::swap") {
+        static_vectra<int, 8> vec1{1, 2, 3};
+        static_vectra<int, 8> vec2{10, 20};
+        std::swap(vec1, vec2);
+        CHECK_EQ(vec1.size(), 2);
+        CHECK_EQ(vec2.size(), 3);
+    }
+}
+
+TEST_CASE("static_vectra::comparison") {
+    SUBCASE("equality - same type") {
+        static_vectra<int, 8> vec1{1, 2, 3};
+        static_vectra<int, 8> vec2{1, 2, 3};
+        static_vectra<int, 8> vec3{1, 2, 4};
+        CHECK_EQ(vec1 == vec2, true);
+        CHECK_EQ(vec1 == vec3, false);
+        CHECK_EQ(vec1 != vec3, true);
+    }
+
+    SUBCASE("equality - different capacity") {
+        static_vectra<int, 4> vec1{1, 2, 3};
+        static_vectra<int, 8> vec2{1, 2, 3};
+        CHECK_EQ(vec1 == vec2, true);
+    }
+
+    SUBCASE("ordering") {
+        static_vectra<int, 8> vec1{1, 2, 3};
+        static_vectra<int, 8> vec2{1, 2, 4};
+        static_vectra<int, 8> vec3{1, 2};
+
+        CHECK_EQ(vec1 < vec2, true);
+        CHECK_EQ(vec2 > vec1, true);
+        CHECK_EQ(vec3 < vec1, true);
+        CHECK_EQ(vec1 <=> vec2, std::strong_ordering::less);
+    }
+}
+
+TEST_CASE("static_vectra::complex_types") {
+    SUBCASE("with std::string") {
+        static_vectra<std::string, 4> vec;
+        vec.push_back("hello");
+        vec.push_back("world");
+        vec.emplace_back("test");
+
+        CHECK_EQ(vec.size(), 3);
+        CHECK_EQ(vec[0], "hello");
+        CHECK_EQ(vec[1], "world");
+        CHECK_EQ(vec[2], "test");
+    }
+
+    SUBCASE("move-only type") {
+        struct MoveOnly
+        {
+            int value;
+            MoveOnly(int v) : value(v) {}
+            MoveOnly(const MoveOnly&) = delete;
+            MoveOnly& operator=(const MoveOnly&) = delete;
+            MoveOnly(MoveOnly&& other) noexcept : value(other.value) { other.value = -1; }
+            MoveOnly& operator=(MoveOnly&& other) noexcept {
+                value = other.value;
+                other.value = -1;
+                return *this;
+            }
+        };
+
+        static_vectra<MoveOnly, 4> vec;
+        vec.emplace_back(1);
+        vec.emplace_back(2);
+        vec.push_back(MoveOnly(3));
+
+        CHECK_EQ(vec.size(), 3);
+        CHECK_EQ(vec[0].value, 1);
+        CHECK_EQ(vec[1].value, 2);
+        CHECK_EQ(vec[2].value, 3);
+
+        // Move to another vector
+        static_vectra<MoveOnly, 4> vec2(std::move(vec));
+        CHECK_EQ(vec2.size(), 3);
+        CHECK_EQ(vec2[0].value, 1);
+        CHECK_EQ(vec.size(), 0);
+    }
+}
+
+TEST_CASE("static_vectra::unsafe_mode") {
+    SUBCASE("unsafe push_back") {
+        static_vectra<int, 8> vec;
+        for (int i = 0; i < 5; ++i) {
+            vec.push_back<Safety::Unsafe>(i);
+        }
+        CHECK_EQ(vec.size(), 5);
+        for (int i = 0; i < 5; ++i) {
+            CHECK_EQ(vec[i], i);
+        }
+    }
+
+    SUBCASE("unsafe emplace_back") {
+        static_vectra<std::pair<int, int>, 8> vec;
+        vec.emplace_back<Safety::Unsafe>(1, 2);
+        vec.emplace_back<Safety::Unsafe>(3, 4);
+        CHECK_EQ(vec.size(), 2);
+        CHECK_EQ(vec[0].first, 1);
+        CHECK_EQ(vec[1].second, 4);
+    }
+
+    SUBCASE("unsafe insert") {
+        static_vectra<int, 8> vec{1, 2, 4};
+        vec.insert<Safety::Unsafe>(vec.begin() + 2, 3);
+        CHECK_EQ(vec.size(), 4);
+        CHECK_EQ(vec[2], 3);
+    }
+}
+
+TEST_CASE("static_vectra::std_erase") {
+    SUBCASE("std::erase") {
+        static_vectra<int, 8> vec{1, 2, 3, 2, 4, 2, 5};
+        auto count = std::erase(vec, 2);
+        CHECK_EQ(count, 3);
+        CHECK_EQ(vec.size(), 4);
+        CHECK_EQ(vec[0], 1);
+        CHECK_EQ(vec[1], 3);
+        CHECK_EQ(vec[2], 4);
+        CHECK_EQ(vec[3], 5);
+    }
+
+    SUBCASE("std::erase_if") {
+        static_vectra<int, 8> vec{1, 2, 3, 4, 5, 6};
+        auto count = std::erase_if(vec, [](int x) { return x % 2 == 0; });
+        CHECK_EQ(count, 3);
+        CHECK_EQ(vec.size(), 3);
+        CHECK_EQ(vec[0], 1);
+        CHECK_EQ(vec[1], 3);
+        CHECK_EQ(vec[2], 5);
+    }
+}
+
+TEST_CASE("static_vectra::no_heap_allocation") {
+    // This test verifies the design - static_vectra should not have any heap allocation
+    // by checking sizeof and ensuring data is stored inline
+
+    SUBCASE("sizeof includes storage") {
+        // sizeof(static_vectra<T,N>) should be approximately N*sizeof(T) + sizeof(size_type)
+        // plus alignment padding
+        constexpr size_t expected_min = 8 * sizeof(int) + sizeof(size_t);
+        CHECK_GE(sizeof(static_vectra<int, 8>), expected_min);
+
+        // Should be much smaller than a heap-allocated vector would need
+        CHECK_LE(sizeof(static_vectra<int, 8>), expected_min + 16);  // Allow some padding
+    }
+
+    SUBCASE("data pointer is within object") {
+        static_vectra<int, 8> vec{1, 2, 3};
+        auto* obj_start = reinterpret_cast<const char*>(&vec);
+        auto* obj_end = obj_start + sizeof(vec);
+        auto* data_ptr = reinterpret_cast<const char*>(vec.data());
+
+        // Data should be stored within the object itself
+        CHECK_GE(data_ptr, obj_start);
+        CHECK_LT(data_ptr, obj_end);
+    }
+}
+
+// NOLINTEND
+}  // namespace stdb::container


### PR DESCRIPTION
## Summary

Add four new container variants to reduce external dependencies on libraries like Abseil, Boost, and LLVM:

- **small_vectra**: Inline storage with heap fallback (like LLVM SmallVector)
- **static_vectra**: Fixed capacity, zero heap allocation (like Boost static_vector)
- **ring_buffer**: Fixed-size circular buffer with auto-overwrite
- **devectra**: Double-ended vector with O(1) push_front/push_back (like Boost devector)

## Benchmark Results

| Container | Operation | vs std baseline |
|-----------|-----------|-----------------|
| **small_vectra** | create/destroy cycle | 3-4x faster vs std::vector |
| **static_vectra** | push_back | 3.8x faster vs std::vector |
| **ring_buffer** | FIFO queue pattern | 15x faster vs std::deque |
| **devectra** | push_front | 2.8x faster vs std::deque |
| **devectra** | push_back | 2.9x faster vs std::deque |
| **devectra** | random access | 32x faster vs std::deque |

## Test plan

- [x] All containers have comprehensive test suites
- [x] Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)