### PR TITLE
Add PMR (Polymorphic Memory Resource) support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "nanobench"]
 	path = nanobench
 	url = https://github.com/martinus/nanobench.git
+[submodule "arena"]
+	path = arena
+	url = git@github.com:clapdb/Arena.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "nanobench"]
 	path = nanobench
 	url = https://github.com/martinus/nanobench.git
-[submodule "arena"]
-	path = arena
-	url = git@github.com:clapdb/Arena.git

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -45,35 +45,38 @@ if(ENABLE_ABSL_BENCH)
     message(STATUS "Building Abseil btree comparison benchmarks")
 endif()
 
-# PMR + Arena allocator benchmark
-option(ENABLE_PMR_BENCH "Enable PMR/Arena allocator benchmark" ON)
+# PMR allocator benchmark
+option(ENABLE_PMR_BENCH "Enable PMR allocator benchmark" ON)
 if(ENABLE_PMR_BENCH)
-    # Fetch fmt for arena dependency
-    include(FetchContent)
-    FetchContent_Declare(
-        fmt
-        GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-        GIT_TAG 11.1.4
-        GIT_SHALLOW TRUE
-    )
-    FetchContent_MakeAvailable(fmt)
-
-    # Build arena library
-    set(ARENA_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../arena/src)
-    add_library(arena_lib STATIC ${ARENA_SRC_DIR}/arena.cc)
-    target_include_directories(arena_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../arena/include)
-    target_compile_options(arena_lib PRIVATE -frtti)
-    target_link_libraries(arena_lib fmt::fmt)
-
     add_executable(pmr_bench pmr_bench.cc)
     target_compile_definitions(pmr_bench PRIVATE NDEBUG)
-    target_include_directories(pmr_bench PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/../arena/include
-    )
-    target_link_libraries(pmr_bench nanobench arena_lib fmt::fmt)
+    target_link_libraries(pmr_bench nanobench)
     if(ENABLE_ASAN OR ENABLE_UBSAN)
         target_compile_options(pmr_bench PRIVATE ${SANITIZER_FLAGS})
         target_link_options(pmr_bench PRIVATE ${SANITIZER_LINK_FLAGS})
     endif()
-    message(STATUS "Building PMR/Arena allocator benchmark")
+
+    # Optional Arena allocator support (user provides ARENA_DIR)
+    if(DEFINED ARENA_DIR)
+        include(FetchContent)
+        FetchContent_Declare(
+            fmt
+            GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+            GIT_TAG 11.1.4
+            GIT_SHALLOW TRUE
+        )
+        FetchContent_MakeAvailable(fmt)
+
+        add_library(arena_lib STATIC ${ARENA_DIR}/src/arena.cc)
+        target_include_directories(arena_lib PUBLIC ${ARENA_DIR}/include)
+        target_compile_options(arena_lib PRIVATE -frtti)
+        target_link_libraries(arena_lib fmt::fmt)
+
+        target_compile_definitions(pmr_bench PRIVATE ENABLE_ARENA_BENCH)
+        target_include_directories(pmr_bench PRIVATE ${ARENA_DIR}/include)
+        target_link_libraries(pmr_bench arena_lib fmt::fmt)
+        message(STATUS "Building PMR benchmark with Arena support (ARENA_DIR=${ARENA_DIR})")
+    else()
+        message(STATUS "Building PMR benchmark without Arena (set ARENA_DIR to enable)")
+    endif()
 endif()

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -44,3 +44,36 @@ if(ENABLE_ABSL_BENCH)
     )
     message(STATUS "Building Abseil btree comparison benchmarks")
 endif()
+
+# PMR + Arena allocator benchmark
+option(ENABLE_PMR_BENCH "Enable PMR/Arena allocator benchmark" ON)
+if(ENABLE_PMR_BENCH)
+    # Fetch fmt for arena dependency
+    include(FetchContent)
+    FetchContent_Declare(
+        fmt
+        GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+        GIT_TAG 11.1.4
+        GIT_SHALLOW TRUE
+    )
+    FetchContent_MakeAvailable(fmt)
+
+    # Build arena library
+    set(ARENA_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../arena/src)
+    add_library(arena_lib STATIC ${ARENA_SRC_DIR}/arena.cc)
+    target_include_directories(arena_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../arena/include)
+    target_compile_options(arena_lib PRIVATE -frtti)
+    target_link_libraries(arena_lib fmt::fmt)
+
+    add_executable(pmr_bench pmr_bench.cc)
+    target_compile_definitions(pmr_bench PRIVATE NDEBUG)
+    target_include_directories(pmr_bench PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../arena/include
+    )
+    target_link_libraries(pmr_bench nanobench arena_lib fmt::fmt)
+    if(ENABLE_ASAN OR ENABLE_UBSAN)
+        target_compile_options(pmr_bench PRIVATE ${SANITIZER_FLAGS})
+        target_link_options(pmr_bench PRIVATE ${SANITIZER_LINK_FLAGS})
+    endif()
+    message(STATUS "Building PMR/Arena allocator benchmark")
+endif()

--- a/bench/pmr_bench.cc
+++ b/bench/pmr_bench.cc
@@ -1,0 +1,429 @@
+/*
+ * Copyright 2025 ClapDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define ANKERL_NANOBENCH_IMPLEMENT
+#include "../nanobench/src/include/nanobench.h"
+
+#include <algorithm>
+#include <array>
+#include <iostream>
+#include <memory_resource>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "container/btree_map.hpp"
+#include "arena/arena.hpp"
+
+using namespace stdb::container;
+
+// =============================================================================
+// Benchmark: btree_map with different allocators
+// =============================================================================
+
+template <size_t N>
+void run_btree_map_insert_benchmark() {
+    std::vector<int> random_keys(N);
+    for (size_t i = 0; i < N; ++i) random_keys[i] = static_cast<int>(i);
+    std::mt19937 rng(42);
+    std::shuffle(random_keys.begin(), random_keys.end(), rng);
+
+    ankerl::nanobench::Bench bench;
+    bench.warmup(3).epochs(5).relative(true);
+
+    std::cout << "\n=== btree_map<int,int> Insert: " << N << " elements ===\n";
+
+    // 1. std::allocator (baseline)
+    bench.run("std::allocator", [&] {
+        btree_map<int, int> map;
+        for (int k : random_keys) map[k] = k;
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+    // 2. std::pmr::monotonic_buffer_resource
+    bench.run("pmr::monotonic", [&] {
+        // Pre-allocate buffer large enough for the btree nodes
+        std::vector<std::byte> buffer(N * 64);  // ~64 bytes per element estimate
+        std::pmr::monotonic_buffer_resource pool{buffer.data(), buffer.size()};
+        stdb::pmr::btree_map<int, int> map{&pool};
+        for (int k : random_keys) map[k] = k;
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+    // 3. std::pmr::unsynchronized_pool_resource
+    bench.run("pmr::unsync_pool", [&] {
+        std::pmr::unsynchronized_pool_resource pool;
+        stdb::pmr::btree_map<int, int> map{&pool};
+        for (int k : random_keys) map[k] = k;
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+    // 4. ClapDB Arena
+    bench.run("arena::Arena", [&] {
+        auto opts = arena::Arena::Options::GetDefaultOptions();
+        opts.suggested_init_block_size = N * 64;  // Pre-size for better performance
+        arena::Arena arena{opts};
+        stdb::pmr::btree_map<int, int> map{arena.get_memory_resource()};
+        for (int k : random_keys) map[k] = k;
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+}
+
+template <size_t N>
+void run_btree_map_find_benchmark() {
+    std::vector<int> random_keys(N);
+    for (size_t i = 0; i < N; ++i) random_keys[i] = static_cast<int>(i);
+    std::mt19937 rng(42);
+    std::shuffle(random_keys.begin(), random_keys.end(), rng);
+
+    ankerl::nanobench::Bench bench;
+    bench.warmup(3).epochs(5).relative(true);
+
+    std::cout << "\n=== btree_map<int,int> Find: " << N << " elements ===\n";
+
+    // Prepare maps for find benchmark
+    btree_map<int, int> std_map;
+    for (int k : random_keys) std_map[k] = k;
+
+    std::vector<std::byte> mono_buffer(N * 64);
+    std::pmr::monotonic_buffer_resource mono_pool{mono_buffer.data(), mono_buffer.size()};
+    stdb::pmr::btree_map<int, int> mono_map{&mono_pool};
+    for (int k : random_keys) mono_map[k] = k;
+
+    std::pmr::unsynchronized_pool_resource unsync_pool;
+    stdb::pmr::btree_map<int, int> unsync_map{&unsync_pool};
+    for (int k : random_keys) unsync_map[k] = k;
+
+    auto opts = arena::Arena::Options::GetDefaultOptions();
+    opts.suggested_init_block_size = N * 64;
+    arena::Arena arena{opts};
+    stdb::pmr::btree_map<int, int> arena_map{arena.get_memory_resource()};
+    for (int k : random_keys) arena_map[k] = k;
+
+    // Find benchmarks (allocation strategy shouldn't affect find performance much)
+    bench.run("std::allocator", [&] {
+        int sum = 0;
+        for (int k : random_keys) {
+            auto it = std_map.find(k);
+            if (it != std_map.end()) sum += it->second;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+    bench.run("pmr::monotonic", [&] {
+        int sum = 0;
+        for (int k : random_keys) {
+            auto it = mono_map.find(k);
+            if (it != mono_map.end()) sum += it->second;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+    bench.run("pmr::unsync_pool", [&] {
+        int sum = 0;
+        for (int k : random_keys) {
+            auto it = unsync_map.find(k);
+            if (it != unsync_map.end()) sum += it->second;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+    bench.run("arena::Arena", [&] {
+        int sum = 0;
+        for (int k : random_keys) {
+            auto it = arena_map.find(k);
+            if (it != arena_map.end()) sum += it->second;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+}
+
+template <size_t N>
+void run_btree_map_mixed_benchmark() {
+    std::vector<int> keys(N);
+    for (size_t i = 0; i < N; ++i) keys[i] = static_cast<int>(i);
+    std::mt19937 rng(42);
+    std::shuffle(keys.begin(), keys.end(), rng);
+
+    ankerl::nanobench::Bench bench;
+    bench.warmup(3).epochs(5).relative(true);
+
+    std::cout << "\n=== btree_map<int,int> Mixed (insert + find + erase): " << N << " elements ===\n";
+
+    // Mixed workload: insert N, find N, erase N/2
+    bench.run("std::allocator", [&] {
+        btree_map<int, int> map;
+        for (int k : keys) map[k] = k;
+        int sum = 0;
+        for (int k : keys) {
+            auto it = map.find(k);
+            if (it != map.end()) sum += it->second;
+        }
+        for (size_t i = 0; i < N / 2; ++i) map.erase(keys[i]);
+        ankerl::nanobench::doNotOptimizeAway(sum);
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+    bench.run("pmr::monotonic", [&] {
+        std::vector<std::byte> buffer(N * 128);
+        std::pmr::monotonic_buffer_resource pool{buffer.data(), buffer.size()};
+        stdb::pmr::btree_map<int, int> map{&pool};
+        for (int k : keys) map[k] = k;
+        int sum = 0;
+        for (int k : keys) {
+            auto it = map.find(k);
+            if (it != map.end()) sum += it->second;
+        }
+        for (size_t i = 0; i < N / 2; ++i) map.erase(keys[i]);
+        ankerl::nanobench::doNotOptimizeAway(sum);
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+    bench.run("pmr::unsync_pool", [&] {
+        std::pmr::unsynchronized_pool_resource pool;
+        stdb::pmr::btree_map<int, int> map{&pool};
+        for (int k : keys) map[k] = k;
+        int sum = 0;
+        for (int k : keys) {
+            auto it = map.find(k);
+            if (it != map.end()) sum += it->second;
+        }
+        for (size_t i = 0; i < N / 2; ++i) map.erase(keys[i]);
+        ankerl::nanobench::doNotOptimizeAway(sum);
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+    bench.run("arena::Arena", [&] {
+        auto opts = arena::Arena::Options::GetDefaultOptions();
+        opts.suggested_init_block_size = N * 128;
+        arena::Arena arena{opts};
+        stdb::pmr::btree_map<int, int> map{arena.get_memory_resource()};
+        for (int k : keys) map[k] = k;
+        int sum = 0;
+        for (int k : keys) {
+            auto it = map.find(k);
+            if (it != map.end()) sum += it->second;
+        }
+        for (size_t i = 0; i < N / 2; ++i) map.erase(keys[i]);
+        ankerl::nanobench::doNotOptimizeAway(sum);
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+}
+
+// =============================================================================
+// Benchmark: btree_set with different allocators
+// =============================================================================
+
+template <size_t N>
+void run_btree_set_insert_benchmark() {
+    std::vector<int> random_keys(N);
+    for (size_t i = 0; i < N; ++i) random_keys[i] = static_cast<int>(i);
+    std::mt19937 rng(42);
+    std::shuffle(random_keys.begin(), random_keys.end(), rng);
+
+    ankerl::nanobench::Bench bench;
+    bench.warmup(3).epochs(5).relative(true);
+
+    std::cout << "\n=== btree_set<int> Insert: " << N << " elements ===\n";
+
+    bench.run("std::allocator", [&] {
+        btree_set<int> set;
+        for (int k : random_keys) set.insert(k);
+        ankerl::nanobench::doNotOptimizeAway(set);
+    });
+
+    bench.run("pmr::monotonic", [&] {
+        std::vector<std::byte> buffer(N * 32);
+        std::pmr::monotonic_buffer_resource pool{buffer.data(), buffer.size()};
+        stdb::pmr::btree_set<int> set{&pool};
+        for (int k : random_keys) set.insert(k);
+        ankerl::nanobench::doNotOptimizeAway(set);
+    });
+
+    bench.run("pmr::unsync_pool", [&] {
+        std::pmr::unsynchronized_pool_resource pool;
+        stdb::pmr::btree_set<int> set{&pool};
+        for (int k : random_keys) set.insert(k);
+        ankerl::nanobench::doNotOptimizeAway(set);
+    });
+
+    bench.run("arena::Arena", [&] {
+        auto opts = arena::Arena::Options::GetDefaultOptions();
+        opts.suggested_init_block_size = N * 32;
+        arena::Arena arena{opts};
+        stdb::pmr::btree_set<int> set{arena.get_memory_resource()};
+        for (int k : random_keys) set.insert(k);
+        ankerl::nanobench::doNotOptimizeAway(set);
+    });
+}
+
+// =============================================================================
+// Benchmark: String keys with PMR allocators
+// =============================================================================
+
+template <size_t N>
+void run_btree_map_string_benchmark() {
+    std::vector<std::string> keys(N);
+    for (size_t i = 0; i < N; ++i) {
+        keys[i] = "key_" + std::to_string(i);
+    }
+    std::mt19937 rng(42);
+    std::shuffle(keys.begin(), keys.end(), rng);
+
+    ankerl::nanobench::Bench bench;
+    bench.warmup(3).epochs(5).relative(true);
+
+    std::cout << "\n=== btree_map<string,int> Insert: " << N << " elements ===\n";
+
+    bench.run("std::allocator", [&] {
+        btree_map<std::string, int> map;
+        int i = 0;
+        for (const auto& k : keys) map[k] = i++;
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+    bench.run("pmr::monotonic", [&] {
+        std::vector<std::byte> buffer(N * 128);
+        std::pmr::monotonic_buffer_resource pool{buffer.data(), buffer.size()};
+        stdb::pmr::btree_map<std::string, int> map{&pool};
+        int i = 0;
+        for (const auto& k : keys) map[k] = i++;
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+    bench.run("pmr::unsync_pool", [&] {
+        std::pmr::unsynchronized_pool_resource pool;
+        stdb::pmr::btree_map<std::string, int> map{&pool};
+        int i = 0;
+        for (const auto& k : keys) map[k] = i++;
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+    bench.run("arena::Arena", [&] {
+        auto opts = arena::Arena::Options::GetDefaultOptions();
+        opts.suggested_init_block_size = N * 128;
+        arena::Arena arena{opts};
+        stdb::pmr::btree_map<std::string, int> map{arena.get_memory_resource()};
+        int i = 0;
+        for (const auto& k : keys) map[k] = i++;
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+}
+
+// =============================================================================
+// Benchmark: Repeated create/destroy cycles (arena reset advantage)
+// =============================================================================
+
+template <size_t N>
+void run_lifecycle_benchmark() {
+    std::vector<int> keys(N);
+    for (size_t i = 0; i < N; ++i) keys[i] = static_cast<int>(i);
+    std::mt19937 rng(42);
+    std::shuffle(keys.begin(), keys.end(), rng);
+
+    constexpr size_t cycles = 100;
+
+    ankerl::nanobench::Bench bench;
+    bench.warmup(2).epochs(3).relative(true);
+
+    std::cout << "\n=== Lifecycle: " << cycles << " create/destroy cycles, " << N << " elements each ===\n";
+
+    bench.run("std::allocator", [&] {
+        for (size_t c = 0; c < cycles; ++c) {
+            btree_map<int, int> map;
+            for (int k : keys) map[k] = k;
+            ankerl::nanobench::doNotOptimizeAway(map);
+        }
+    });
+
+    bench.run("pmr::monotonic (reuse)", [&] {
+        std::vector<std::byte> buffer(N * 64);
+        for (size_t c = 0; c < cycles; ++c) {
+            std::pmr::monotonic_buffer_resource pool{buffer.data(), buffer.size()};
+            stdb::pmr::btree_map<int, int> map{&pool};
+            for (int k : keys) map[k] = k;
+            ankerl::nanobench::doNotOptimizeAway(map);
+            // pool destroyed and buffer reused
+        }
+    });
+
+    bench.run("pmr::unsync_pool", [&] {
+        std::pmr::unsynchronized_pool_resource pool;
+        for (size_t c = 0; c < cycles; ++c) {
+            stdb::pmr::btree_map<int, int> map{&pool};
+            for (int k : keys) map[k] = k;
+            ankerl::nanobench::doNotOptimizeAway(map);
+        }
+    });
+
+    bench.run("arena::Arena (reset)", [&] {
+        auto opts = arena::Arena::Options::GetDefaultOptions();
+        opts.suggested_init_block_size = N * 64;
+        arena::Arena arena{opts};
+        for (size_t c = 0; c < cycles; ++c) {
+            stdb::pmr::btree_map<int, int> map{arena.get_memory_resource()};
+            for (int k : keys) map[k] = k;
+            ankerl::nanobench::doNotOptimizeAway(map);
+            arena.Reset();  // Fast reset without deallocation
+        }
+    });
+}
+
+int main(int argc, char** argv) {
+    bool run_large = (argc > 1 && std::string(argv[1]) == "--large");
+
+    std::cout << "============================================================\n";
+    std::cout << "PMR + Arena Allocator Benchmark for btree_map/btree_set\n";
+    std::cout << "============================================================\n";
+    std::cout << "Allocators tested:\n";
+    std::cout << "  - std::allocator (baseline)\n";
+    std::cout << "  - std::pmr::monotonic_buffer_resource\n";
+    std::cout << "  - std::pmr::unsynchronized_pool_resource\n";
+    std::cout << "  - arena::Arena (ClapDB Arena)\n";
+    std::cout << "============================================================\n";
+
+    // btree_map insert benchmarks
+    run_btree_map_insert_benchmark<1000>();
+    run_btree_map_insert_benchmark<10000>();
+    run_btree_map_insert_benchmark<100000>();
+
+    // btree_map find benchmarks
+    run_btree_map_find_benchmark<10000>();
+    run_btree_map_find_benchmark<100000>();
+
+    // btree_map mixed workload
+    run_btree_map_mixed_benchmark<10000>();
+
+    // btree_set benchmarks
+    run_btree_set_insert_benchmark<10000>();
+    run_btree_set_insert_benchmark<100000>();
+
+    // String key benchmarks
+    run_btree_map_string_benchmark<10000>();
+
+    // Lifecycle benchmarks (arena reset advantage)
+    run_lifecycle_benchmark<1000>();
+    run_lifecycle_benchmark<10000>();
+
+    if (run_large) {
+        std::cout << "\n=== Large Scale Benchmarks ===\n";
+        run_btree_map_insert_benchmark<1000000>();
+        run_btree_map_find_benchmark<1000000>();
+        run_btree_set_insert_benchmark<1000000>();
+    }
+
+    return 0;
+}

--- a/bench/pmr_bench.cc
+++ b/bench/pmr_bench.cc
@@ -26,7 +26,10 @@
 #include <vector>
 
 #include "container/btree_map.hpp"
+
+#ifdef ENABLE_ARENA_BENCH
 #include "arena/arena.hpp"
+#endif
 
 using namespace stdb::container;
 
@@ -71,6 +74,7 @@ void run_btree_map_insert_benchmark() {
         ankerl::nanobench::doNotOptimizeAway(map);
     });
 
+#ifdef ENABLE_ARENA_BENCH
     // 4. ClapDB Arena
     bench.run("arena::Arena", [&] {
         auto opts = arena::Arena::Options::GetDefaultOptions();
@@ -80,6 +84,7 @@ void run_btree_map_insert_benchmark() {
         for (int k : random_keys) map[k] = k;
         ankerl::nanobench::doNotOptimizeAway(map);
     });
+#endif
 }
 
 template <size_t N>
@@ -107,11 +112,13 @@ void run_btree_map_find_benchmark() {
     stdb::pmr::btree_map<int, int> unsync_map{&unsync_pool};
     for (int k : random_keys) unsync_map[k] = k;
 
+#ifdef ENABLE_ARENA_BENCH
     auto opts = arena::Arena::Options::GetDefaultOptions();
     opts.suggested_init_block_size = N * 64;
     arena::Arena arena{opts};
     stdb::pmr::btree_map<int, int> arena_map{arena.get_memory_resource()};
     for (int k : random_keys) arena_map[k] = k;
+#endif
 
     // Find benchmarks (allocation strategy shouldn't affect find performance much)
     bench.run("std::allocator", [&] {
@@ -141,6 +148,7 @@ void run_btree_map_find_benchmark() {
         ankerl::nanobench::doNotOptimizeAway(sum);
     });
 
+#ifdef ENABLE_ARENA_BENCH
     bench.run("arena::Arena", [&] {
         int sum = 0;
         for (int k : random_keys) {
@@ -149,6 +157,7 @@ void run_btree_map_find_benchmark() {
         }
         ankerl::nanobench::doNotOptimizeAway(sum);
     });
+#endif
 }
 
 template <size_t N>
@@ -206,6 +215,7 @@ void run_btree_map_mixed_benchmark() {
         ankerl::nanobench::doNotOptimizeAway(map);
     });
 
+#ifdef ENABLE_ARENA_BENCH
     bench.run("arena::Arena", [&] {
         auto opts = arena::Arena::Options::GetDefaultOptions();
         opts.suggested_init_block_size = N * 128;
@@ -221,6 +231,7 @@ void run_btree_map_mixed_benchmark() {
         ankerl::nanobench::doNotOptimizeAway(sum);
         ankerl::nanobench::doNotOptimizeAway(map);
     });
+#endif
 }
 
 // =============================================================================
@@ -260,6 +271,7 @@ void run_btree_set_insert_benchmark() {
         ankerl::nanobench::doNotOptimizeAway(set);
     });
 
+#ifdef ENABLE_ARENA_BENCH
     bench.run("arena::Arena", [&] {
         auto opts = arena::Arena::Options::GetDefaultOptions();
         opts.suggested_init_block_size = N * 32;
@@ -268,6 +280,7 @@ void run_btree_set_insert_benchmark() {
         for (int k : random_keys) set.insert(k);
         ankerl::nanobench::doNotOptimizeAway(set);
     });
+#endif
 }
 
 // =============================================================================
@@ -312,6 +325,7 @@ void run_btree_map_string_benchmark() {
         ankerl::nanobench::doNotOptimizeAway(map);
     });
 
+#ifdef ENABLE_ARENA_BENCH
     bench.run("arena::Arena", [&] {
         auto opts = arena::Arena::Options::GetDefaultOptions();
         opts.suggested_init_block_size = N * 128;
@@ -321,6 +335,7 @@ void run_btree_map_string_benchmark() {
         for (const auto& k : keys) map[k] = i++;
         ankerl::nanobench::doNotOptimizeAway(map);
     });
+#endif
 }
 
 // =============================================================================
@@ -369,6 +384,7 @@ void run_lifecycle_benchmark() {
         }
     });
 
+#ifdef ENABLE_ARENA_BENCH
     bench.run("arena::Arena (reset)", [&] {
         auto opts = arena::Arena::Options::GetDefaultOptions();
         opts.suggested_init_block_size = N * 64;
@@ -380,19 +396,22 @@ void run_lifecycle_benchmark() {
             arena.Reset();  // Fast reset without deallocation
         }
     });
+#endif
 }
 
 int main(int argc, char** argv) {
     bool run_large = (argc > 1 && std::string(argv[1]) == "--large");
 
     std::cout << "============================================================\n";
-    std::cout << "PMR + Arena Allocator Benchmark for btree_map/btree_set\n";
+    std::cout << "PMR Allocator Benchmark for btree_map/btree_set\n";
     std::cout << "============================================================\n";
     std::cout << "Allocators tested:\n";
     std::cout << "  - std::allocator (baseline)\n";
     std::cout << "  - std::pmr::monotonic_buffer_resource\n";
     std::cout << "  - std::pmr::unsynchronized_pool_resource\n";
+#ifdef ENABLE_ARENA_BENCH
     std::cout << "  - arena::Arena (ClapDB Arena)\n";
+#endif
     std::cout << "============================================================\n";
 
     // btree_map insert benchmarks

--- a/container/btree_map.hpp
+++ b/container/btree_map.hpp
@@ -29,6 +29,12 @@
 #include <compare>
 #endif
 
+// PMR support requires C++17
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+#include <memory_resource>
+#define BTREE_HAS_PMR 1
+#endif
+
 #include "vectra.hpp"
 
 #define BTREE_DEBUG 0
@@ -5314,3 +5320,40 @@ template <typename Key, typename Compare = std::less<Key>,
 using btree_set_compact = btree_set<Key, Compare, Allocator, 256>;
 
 }  // namespace stdb::container
+
+// =============================================================================
+// PMR (Polymorphic Memory Resource) support
+// =============================================================================
+#ifdef BTREE_HAS_PMR
+
+namespace stdb::pmr {
+
+// btree_map with polymorphic allocator
+template <typename Key, typename Value, typename Compare = std::less<Key>,
+          std::size_t TargetNodeSize = container::optimal_node_size<Key, Value>()>
+using btree_map = container::btree_map<Key, Value, Compare,
+                                       std::pmr::polymorphic_allocator<std::pair<const Key, Value>>,
+                                       TargetNodeSize>;
+
+// btree_map_compact with polymorphic allocator (256-byte node size)
+template <typename Key, typename Value, typename Compare = std::less<Key>>
+using btree_map_compact = container::btree_map<Key, Value, Compare,
+                                               std::pmr::polymorphic_allocator<std::pair<const Key, Value>>,
+                                               256>;
+
+// btree_set with polymorphic allocator
+template <typename Key, typename Compare = std::less<Key>,
+          std::size_t TargetNodeSize = container::optimal_node_size<Key, container::btree_set_empty_value>()>
+using btree_set = container::btree_set<Key, Compare,
+                                       std::pmr::polymorphic_allocator<std::pair<const Key, container::btree_set_empty_value>>,
+                                       TargetNodeSize>;
+
+// btree_set_compact with polymorphic allocator (256-byte node size)
+template <typename Key, typename Compare = std::less<Key>>
+using btree_set_compact = container::btree_set<Key, Compare,
+                                               std::pmr::polymorphic_allocator<std::pair<const Key, container::btree_set_empty_value>>,
+                                               256>;
+
+}  // namespace stdb::pmr
+
+#endif  // BTREE_HAS_PMR

--- a/tests/btree_map_test.cc
+++ b/tests/btree_map_test.cc
@@ -1980,4 +1980,160 @@ TEST_CASE("btree_map::fuzz_merge_and_swap") {
     }
 }
 
+// =============================================================================
+// PMR (Polymorphic Memory Resource) Tests
+// =============================================================================
+#ifdef BTREE_HAS_PMR
+
+TEST_CASE("btree_map::pmr") {
+    SUBCASE("basic operations with monotonic_buffer_resource") {
+        std::array<std::byte, 4096> buffer;
+        std::pmr::monotonic_buffer_resource pool{buffer.data(), buffer.size()};
+
+        stdb::pmr::btree_map<int, int> map{&pool};
+
+        // Insert
+        map[1] = 10;
+        map[2] = 20;
+        map[3] = 30;
+
+        CHECK_EQ(map.size(), 3);
+        CHECK_EQ(map.at(1), 10);
+        CHECK_EQ(map.at(2), 20);
+        CHECK_EQ(map.at(3), 30);
+
+        // Find
+        auto it = map.find(2);
+        CHECK(it != map.end());
+        CHECK_EQ(it->second, 20);
+
+        // Erase
+        map.erase(2);
+        CHECK_EQ(map.size(), 2);
+        CHECK(!map.contains(2));
+    }
+
+    SUBCASE("with unsynchronized_pool_resource") {
+        std::pmr::unsynchronized_pool_resource pool;
+
+        stdb::pmr::btree_map<int, std::pmr::string> map{&pool};
+
+        map[1] = "one";
+        map[2] = "two";
+        map[3] = "three";
+
+        CHECK_EQ(map.size(), 3);
+        CHECK_EQ(map.at(1), "one");
+        CHECK_EQ(map.at(2), "two");
+        CHECK_EQ(map.at(3), "three");
+    }
+
+    SUBCASE("copy and move with pmr") {
+        std::pmr::unsynchronized_pool_resource pool1;
+        std::pmr::unsynchronized_pool_resource pool2;
+
+        stdb::pmr::btree_map<int, int> map1{&pool1};
+        for (int i = 0; i < 100; ++i) {
+            map1[i] = i * 10;
+        }
+
+        // Copy (uses same allocator)
+        stdb::pmr::btree_map<int, int> map2{map1};
+        CHECK_EQ(map2.size(), 100);
+        CHECK_EQ(map2.at(50), 500);
+
+        // Move
+        stdb::pmr::btree_map<int, int> map3{std::move(map1)};
+        CHECK_EQ(map3.size(), 100);
+        CHECK_EQ(map3.at(50), 500);
+    }
+
+    SUBCASE("initializer list with pmr") {
+        std::pmr::unsynchronized_pool_resource pool;
+
+        stdb::pmr::btree_map<int, int> map{{1, 10}, {2, 20}, {3, 30}};
+
+        CHECK_EQ(map.size(), 3);
+        CHECK_EQ(map.at(1), 10);
+    }
+
+    SUBCASE("pmr btree_map_compact") {
+        std::array<std::byte, 8192> buffer;
+        std::pmr::monotonic_buffer_resource pool{buffer.data(), buffer.size()};
+
+        stdb::pmr::btree_map_compact<int, int> map{&pool};
+
+        for (int i = 0; i < 50; ++i) {
+            map[i] = i;
+        }
+
+        CHECK_EQ(map.size(), 50);
+        for (int i = 0; i < 50; ++i) {
+            CHECK_EQ(map.at(i), i);
+        }
+    }
+}
+
+TEST_CASE("btree_set::pmr") {
+    SUBCASE("basic operations with monotonic_buffer_resource") {
+        std::array<std::byte, 4096> buffer;
+        std::pmr::monotonic_buffer_resource pool{buffer.data(), buffer.size()};
+
+        stdb::pmr::btree_set<int> set{&pool};
+
+        // Insert
+        set.insert(1);
+        set.insert(2);
+        set.insert(3);
+
+        CHECK_EQ(set.size(), 3);
+        CHECK(set.contains(1));
+        CHECK(set.contains(2));
+        CHECK(set.contains(3));
+
+        // Find
+        auto it = set.find(2);
+        CHECK(it != set.end());
+        CHECK_EQ(*it, 2);
+
+        // Erase
+        set.erase(2);
+        CHECK_EQ(set.size(), 2);
+        CHECK(!set.contains(2));
+    }
+
+    SUBCASE("with unsynchronized_pool_resource") {
+        std::pmr::unsynchronized_pool_resource pool;
+
+        stdb::pmr::btree_set<std::pmr::string> set{&pool};
+
+        set.insert("one");
+        set.insert("two");
+        set.insert("three");
+
+        CHECK_EQ(set.size(), 3);
+        CHECK(set.contains("one"));
+        CHECK(set.contains("two"));
+        CHECK(set.contains("three"));
+    }
+
+    SUBCASE("pmr btree_set_compact") {
+        std::array<std::byte, 8192> buffer;
+        std::pmr::monotonic_buffer_resource pool{buffer.data(), buffer.size()};
+
+        stdb::pmr::btree_set_compact<int> set{&pool};
+
+        for (int i = 0; i < 50; ++i) {
+            set.insert(i);
+        }
+
+        CHECK_EQ(set.size(), 50);
+        for (int i = 0; i < 50; ++i) {
+            CHECK(set.contains(i));
+        }
+    }
+}
+
+#endif  // BTREE_HAS_PMR
+
 }  // namespace stdb::container


### PR DESCRIPTION
## Summary

- Add `stdb::pmr` namespace with PMR-enabled type aliases (`btree_map`, `btree_map_compact`, `btree_set`, `btree_set_compact`) that use `std::pmr::polymorphic_allocator`
- Add comprehensive PMR tests covering `monotonic_buffer_resource`, `unsynchronized_pool_resource`, and copy/move semantics
- Add `pmr_bench.cc` benchmarking different allocator strategies: `std::allocator`, `pmr::monotonic`, `pmr::unsync_pool`, and ClapDB `arena::Arena`
- Integrate Arena submodule for arena allocator benchmarks

## Test plan

- [ ] Run `btree_map_test` to verify PMR tests pass
- [ ] Build and run `pmr_bench` to verify benchmark correctness
- [ ] Test with different memory resource configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)