### PR TITLE
Add high-performance SIMD bitmap implementation

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -18,6 +18,9 @@ add_bench_target(vb vector_bench.cc)
 # Skiplist benchmarks
 add_bench_target(skiplist_bench skiplist_bench.cc)
 
+# Bitmap benchmarks
+add_bench_target(bitmap_bench bitmap_bench.cc)
+
 # Concurrent benchmark (skiplist vs btree)
 add_executable(skiplist_concurrent_bench skiplist_concurrent_bench.cc)
 target_compile_definitions(skiplist_concurrent_bench PRIVATE NDEBUG)

--- a/bench/bitmap_bench.cc
+++ b/bench/bitmap_bench.cc
@@ -1,0 +1,519 @@
+/*
+ * Copyright 2025 ClapDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+#include <bitset>
+#include <iostream>
+#include <random>
+#include <vector>
+
+#include "../nanobench/src/include/nanobench.h"
+#include "container/bitmap.hpp"
+
+using namespace stdb::container;
+
+// NOLINTBEGIN
+
+// Bitmap sizes for testing
+constexpr size_t SMALL_SIZE = 1024;            // 1K bits
+constexpr size_t MEDIUM_SIZE = 64 * 1024;      // 64K bits
+constexpr size_t LARGE_SIZE = 1024 * 1024;     // 1M bits
+
+// =============================================================================
+// Helper: fill vector<bool>
+// =============================================================================
+
+void fill_random_vector_bool(std::vector<bool>& b, double density, std::mt19937& rng) {
+    std::uniform_real_distribution<double> dist(0.0, 1.0);
+    for (size_t i = 0; i < b.size(); ++i) {
+        if (dist(rng) < density) {
+            b[i] = true;
+        }
+    }
+}
+
+// =============================================================================
+// Helper: fill with random bits
+// =============================================================================
+
+template <size_t Size>
+void fill_random_bitmap(bitmap& b, double density, std::mt19937& rng) {
+    std::uniform_real_distribution<double> dist(0.0, 1.0);
+    for (size_t i = 0; i < Size; ++i) {
+        if (dist(rng) < density) {
+            b.set(static_cast<uint32_t>(i));
+        }
+    }
+}
+
+template <size_t Size>
+void fill_random_bitset(std::bitset<Size>& b, double density, std::mt19937& rng) {
+    std::uniform_real_distribution<double> dist(0.0, 1.0);
+    for (size_t i = 0; i < Size; ++i) {
+        if (dist(rng) < density) {
+            b.set(i);
+        }
+    }
+}
+
+// =============================================================================
+// Comparison benchmarks: bitmap vs std::bitset
+// =============================================================================
+
+template <size_t Size>
+void bench_set_comparison(ankerl::nanobench::Bench& bench, const std::string& size_label) {
+    std::vector<uint32_t> positions(1000);
+    std::mt19937 rng(42);
+    for (size_t i = 0; i < 1000; ++i) {
+        positions[i] = rng() % Size;
+    }
+
+    bench.run(size_label + " bitmap::set", [&]() {
+        bitmap b(Size);
+        for (uint32_t pos : positions) {
+            b.set(pos);
+        }
+        ankerl::nanobench::doNotOptimizeAway(b);
+    });
+
+    bench.run(size_label + " std::bitset::set", [&]() {
+        std::bitset<Size> b;
+        for (uint32_t pos : positions) {
+            b.set(pos);
+        }
+        ankerl::nanobench::doNotOptimizeAway(b);
+    });
+}
+
+template <size_t Size>
+void bench_test_comparison(ankerl::nanobench::Bench& bench, const std::string& size_label) {
+    std::mt19937 rng(42);
+
+    bitmap bm(Size);
+    fill_random_bitmap<Size>(bm, 0.5, rng);
+
+    rng.seed(42);
+    std::bitset<Size> bs;
+    fill_random_bitset<Size>(bs, 0.5, rng);
+
+    std::vector<uint32_t> queries(1000);
+    for (size_t i = 0; i < 1000; ++i) {
+        queries[i] = rng() % Size;
+    }
+
+    bench.run(size_label + " bitmap::test", [&]() {
+        size_t count = 0;
+        for (uint32_t q : queries) {
+            count += bm.test(q);
+        }
+        ankerl::nanobench::doNotOptimizeAway(count);
+    });
+
+    bench.run(size_label + " std::bitset::test", [&]() {
+        size_t count = 0;
+        for (uint32_t q : queries) {
+            count += bs.test(q);
+        }
+        ankerl::nanobench::doNotOptimizeAway(count);
+    });
+}
+
+template <size_t Size>
+void bench_popcount_comparison(ankerl::nanobench::Bench& bench, const std::string& size_label) {
+    std::mt19937 rng(42);
+
+    bitmap bm(Size);
+    fill_random_bitmap<Size>(bm, 0.5, rng);
+
+    rng.seed(42);
+    std::bitset<Size> bs;
+    fill_random_bitset<Size>(bs, 0.5, rng);
+
+    bench.run(size_label + " bitmap::popcount", [&]() {
+        size_t count = bm.popcount();
+        ankerl::nanobench::doNotOptimizeAway(count);
+    });
+
+    bench.run(size_label + " std::bitset::count", [&]() {
+        size_t count = bs.count();
+        ankerl::nanobench::doNotOptimizeAway(count);
+    });
+}
+
+template <size_t Size>
+void bench_and_comparison(ankerl::nanobench::Bench& bench, const std::string& size_label) {
+    std::mt19937 rng(42);
+
+    bitmap bm_a(Size), bm_b(Size);
+    fill_random_bitmap<Size>(bm_a, 0.5, rng);
+    fill_random_bitmap<Size>(bm_b, 0.5, rng);
+
+    rng.seed(42);
+    std::bitset<Size> bs_a, bs_b;
+    fill_random_bitset<Size>(bs_a, 0.5, rng);
+    fill_random_bitset<Size>(bs_b, 0.5, rng);
+
+    bench.run(size_label + " bitmap AND", [&]() {
+        bitmap c = bm_a;
+        c.and_(bm_b);
+        ankerl::nanobench::doNotOptimizeAway(c);
+    });
+
+    bench.run(size_label + " std::bitset AND", [&]() {
+        std::bitset<Size> c = bs_a & bs_b;
+        ankerl::nanobench::doNotOptimizeAway(c);
+    });
+}
+
+template <size_t Size>
+void bench_or_comparison(ankerl::nanobench::Bench& bench, const std::string& size_label) {
+    std::mt19937 rng(42);
+
+    bitmap bm_a(Size), bm_b(Size);
+    fill_random_bitmap<Size>(bm_a, 0.5, rng);
+    fill_random_bitmap<Size>(bm_b, 0.5, rng);
+
+    rng.seed(42);
+    std::bitset<Size> bs_a, bs_b;
+    fill_random_bitset<Size>(bs_a, 0.5, rng);
+    fill_random_bitset<Size>(bs_b, 0.5, rng);
+
+    bench.run(size_label + " bitmap OR", [&]() {
+        bitmap c = bm_a;
+        c.or_(bm_b);
+        ankerl::nanobench::doNotOptimizeAway(c);
+    });
+
+    bench.run(size_label + " std::bitset OR", [&]() {
+        std::bitset<Size> c = bs_a | bs_b;
+        ankerl::nanobench::doNotOptimizeAway(c);
+    });
+}
+
+template <size_t Size>
+void bench_xor_comparison(ankerl::nanobench::Bench& bench, const std::string& size_label) {
+    std::mt19937 rng(42);
+
+    bitmap bm_a(Size), bm_b(Size);
+    fill_random_bitmap<Size>(bm_a, 0.5, rng);
+    fill_random_bitmap<Size>(bm_b, 0.5, rng);
+
+    rng.seed(42);
+    std::bitset<Size> bs_a, bs_b;
+    fill_random_bitset<Size>(bs_a, 0.5, rng);
+    fill_random_bitset<Size>(bs_b, 0.5, rng);
+
+    bench.run(size_label + " bitmap XOR", [&]() {
+        bitmap c = bm_a;
+        c.xor_(bm_b);
+        ankerl::nanobench::doNotOptimizeAway(c);
+    });
+
+    bench.run(size_label + " std::bitset XOR", [&]() {
+        std::bitset<Size> c = bs_a ^ bs_b;
+        ankerl::nanobench::doNotOptimizeAway(c);
+    });
+}
+
+template <size_t Size>
+void bench_flip_comparison(ankerl::nanobench::Bench& bench, const std::string& size_label) {
+    std::vector<uint32_t> positions(1000);
+    std::mt19937 rng(42);
+    for (size_t i = 0; i < 1000; ++i) {
+        positions[i] = rng() % Size;
+    }
+
+    bitmap bm(Size);
+    std::bitset<Size> bs;
+
+    bench.run(size_label + " bitmap::flip", [&]() {
+        for (uint32_t pos : positions) {
+            bm.flip(pos);
+        }
+        ankerl::nanobench::doNotOptimizeAway(bm);
+    });
+
+    bench.run(size_label + " std::bitset::flip", [&]() {
+        for (uint32_t pos : positions) {
+            bs.flip(pos);
+        }
+        ankerl::nanobench::doNotOptimizeAway(bs);
+    });
+}
+
+template <size_t Size>
+void bench_any_none_comparison(ankerl::nanobench::Bench& bench, const std::string& size_label) {
+    std::mt19937 rng(42);
+
+    bitmap bm(Size);
+    fill_random_bitmap<Size>(bm, 0.5, rng);
+
+    rng.seed(42);
+    std::bitset<Size> bs;
+    fill_random_bitset<Size>(bs, 0.5, rng);
+
+    // bitmap uses find_first() != -1 for "any"
+    bench.run(size_label + " bitmap any()", [&]() {
+        bool has_any = bm.find_first() != -1;
+        ankerl::nanobench::doNotOptimizeAway(has_any);
+    });
+
+    bench.run(size_label + " std::bitset::any", [&]() {
+        bool has_any = bs.any();
+        ankerl::nanobench::doNotOptimizeAway(has_any);
+    });
+
+    // Test with empty bitmap
+    bitmap bm_empty(Size);
+    std::bitset<Size> bs_empty;
+
+    bench.run(size_label + " bitmap any() [empty]", [&]() {
+        bool has_any = bm_empty.find_first() != -1;
+        ankerl::nanobench::doNotOptimizeAway(has_any);
+    });
+
+    bench.run(size_label + " std::bitset::any [empty]", [&]() {
+        bool has_any = bs_empty.any();
+        ankerl::nanobench::doNotOptimizeAway(has_any);
+    });
+}
+
+// =============================================================================
+// vector<bool> comparison
+// =============================================================================
+
+template <size_t Size>
+void bench_vector_bool_set(ankerl::nanobench::Bench& bench, const std::string& size_label) {
+    std::vector<uint32_t> positions(1000);
+    std::mt19937 rng(42);
+    for (size_t i = 0; i < 1000; ++i) {
+        positions[i] = rng() % Size;
+    }
+
+    bench.run(size_label + " bitmap::set", [&]() {
+        bitmap b(Size);
+        for (uint32_t pos : positions) {
+            b.set(pos);
+        }
+        ankerl::nanobench::doNotOptimizeAway(b);
+    });
+
+    bench.run(size_label + " vector<bool>::set", [&]() {
+        std::vector<bool> b(Size, false);
+        for (uint32_t pos : positions) {
+            b[pos] = true;
+        }
+        ankerl::nanobench::doNotOptimizeAway(b);
+    });
+}
+
+template <size_t Size>
+void bench_vector_bool_test(ankerl::nanobench::Bench& bench, const std::string& size_label) {
+    std::mt19937 rng(42);
+
+    bitmap bm(Size);
+    fill_random_bitmap<Size>(bm, 0.5, rng);
+
+    rng.seed(42);
+    std::vector<bool> vb(Size, false);
+    fill_random_vector_bool(vb, 0.5, rng);
+
+    std::vector<uint32_t> queries(1000);
+    for (size_t i = 0; i < 1000; ++i) {
+        queries[i] = rng() % Size;
+    }
+
+    bench.run(size_label + " bitmap::test", [&]() {
+        size_t count = 0;
+        for (uint32_t q : queries) {
+            count += bm.test(q);
+        }
+        ankerl::nanobench::doNotOptimizeAway(count);
+    });
+
+    bench.run(size_label + " vector<bool>::test", [&]() {
+        size_t count = 0;
+        for (uint32_t q : queries) {
+            count += vb[q];
+        }
+        ankerl::nanobench::doNotOptimizeAway(count);
+    });
+}
+
+template <size_t Size>
+void bench_vector_bool_popcount(ankerl::nanobench::Bench& bench, const std::string& size_label) {
+    std::mt19937 rng(42);
+
+    bitmap bm(Size);
+    fill_random_bitmap<Size>(bm, 0.5, rng);
+
+    rng.seed(42);
+    std::vector<bool> vb(Size, false);
+    fill_random_vector_bool(vb, 0.5, rng);
+
+    bench.run(size_label + " bitmap::popcount", [&]() {
+        size_t count = bm.popcount();
+        ankerl::nanobench::doNotOptimizeAway(count);
+    });
+
+    bench.run(size_label + " vector<bool> count", [&]() {
+        size_t count = std::count(vb.begin(), vb.end(), true);
+        ankerl::nanobench::doNotOptimizeAway(count);
+    });
+}
+
+template <size_t Size>
+void bench_vector_bool_iterate(ankerl::nanobench::Bench& bench, const std::string& size_label) {
+    std::mt19937 rng(42);
+
+    bitmap bm(Size);
+    fill_random_bitmap<Size>(bm, 0.01, rng);  // 1% density
+
+    rng.seed(42);
+    std::vector<bool> vb(Size, false);
+    fill_random_vector_bool(vb, 0.01, rng);
+
+    bench.run(size_label + " bitmap iterate", [&]() {
+        size_t sum = 0;
+        for (uint32_t bit : bm) {
+            sum += bit;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+    bench.run(size_label + " vector<bool> iterate", [&]() {
+        size_t sum = 0;
+        for (size_t i = 0; i < vb.size(); ++i) {
+            if (vb[i]) sum += i;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+}
+
+// =============================================================================
+// bitmap-only benchmarks (features not in std::bitset)
+// =============================================================================
+
+template <size_t Size>
+void bench_find_first(ankerl::nanobench::Bench& bench, const std::string& size_label) {
+    std::mt19937 rng(42);
+    bitmap b(Size);
+    fill_random_bitmap<Size>(b, 0.01, rng);  // Sparse
+
+    bench.run(size_label + " bitmap::find_first", [&]() {
+        int64_t pos = b.find_first();
+        ankerl::nanobench::doNotOptimizeAway(pos);
+    });
+}
+
+template <size_t Size>
+void bench_iterate(ankerl::nanobench::Bench& bench, const std::string& size_label) {
+    std::mt19937 rng(42);
+    bitmap b(Size);
+    fill_random_bitmap<Size>(b, 0.01, rng);  // ~1% density
+
+    bench.run(size_label + " bitmap iterate", [&]() {
+        size_t sum = 0;
+        for (uint32_t bit : b) {
+            sum += bit;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+}
+
+template <size_t Size>
+void bench_in_operation(ankerl::nanobench::Bench& bench, const std::string& size_label) {
+    std::mt19937 rng(42);
+    bitmap b(Size);
+    fill_random_bitmap<Size>(b, 0.5, rng);
+
+    std::vector<uint32_t> ids(10000);
+    for (size_t i = 0; i < ids.size(); ++i) {
+        ids[i] = rng() % Size;
+    }
+    std::vector<uint32_t> result(ids.size());
+
+    bench.run(size_label + " bitmap::in 10K", [&]() {
+        size_t count = b.in(ids.data(), ids.size(), result.data());
+        ankerl::nanobench::doNotOptimizeAway(count);
+    });
+}
+
+int main() {
+    ankerl::nanobench::Bench bench;
+    bench.title("bitmap vs std::bitset").unit("op").warmup(100).epochs(500).minEpochIterations(100);
+
+    std::cout << "\n";
+    std::cout << "================================================================================\n";
+    std::cout << "                        bitmap vs std::bitset Comparison\n";
+    std::cout << "================================================================================\n";
+
+    // 1K bits
+    std::cout << "\n=== 1K bits ===\n";
+    bench_set_comparison<SMALL_SIZE>(bench, "1K");
+    bench_test_comparison<SMALL_SIZE>(bench, "1K");
+    bench_popcount_comparison<SMALL_SIZE>(bench, "1K");
+    bench_and_comparison<SMALL_SIZE>(bench, "1K");
+    bench_or_comparison<SMALL_SIZE>(bench, "1K");
+    bench_xor_comparison<SMALL_SIZE>(bench, "1K");
+
+    // 64K bits
+    std::cout << "\n=== 64K bits ===\n";
+    bench_set_comparison<MEDIUM_SIZE>(bench, "64K");
+    bench_test_comparison<MEDIUM_SIZE>(bench, "64K");
+    bench_popcount_comparison<MEDIUM_SIZE>(bench, "64K");
+    bench_and_comparison<MEDIUM_SIZE>(bench, "64K");
+    bench_or_comparison<MEDIUM_SIZE>(bench, "64K");
+    bench_xor_comparison<MEDIUM_SIZE>(bench, "64K");
+    bench_flip_comparison<MEDIUM_SIZE>(bench, "64K");
+    bench_any_none_comparison<MEDIUM_SIZE>(bench, "64K");
+
+    // 1M bits
+    std::cout << "\n=== 1M bits ===\n";
+    bench_set_comparison<LARGE_SIZE>(bench, "1M");
+    bench_test_comparison<LARGE_SIZE>(bench, "1M");
+    bench_popcount_comparison<LARGE_SIZE>(bench, "1M");
+    bench_and_comparison<LARGE_SIZE>(bench, "1M");
+    bench_or_comparison<LARGE_SIZE>(bench, "1M");
+    bench_xor_comparison<LARGE_SIZE>(bench, "1M");
+
+    // bitmap-only features
+    std::cout << "\n=== bitmap-only features ===\n";
+    bench_find_first<LARGE_SIZE>(bench, "1M");
+    bench_iterate<LARGE_SIZE>(bench, "1M");
+    bench_in_operation<MEDIUM_SIZE>(bench, "64K");
+    bench_in_operation<LARGE_SIZE>(bench, "1M");
+
+    std::cout << "\n";
+    std::cout << "================================================================================\n";
+    std::cout << "                        bitmap vs vector<bool> Comparison\n";
+    std::cout << "================================================================================\n";
+
+    std::cout << "\n=== 64K bits ===\n";
+    bench_vector_bool_set<MEDIUM_SIZE>(bench, "64K");
+    bench_vector_bool_test<MEDIUM_SIZE>(bench, "64K");
+    bench_vector_bool_popcount<MEDIUM_SIZE>(bench, "64K");
+
+    std::cout << "\n=== 1M bits ===\n";
+    bench_vector_bool_set<LARGE_SIZE>(bench, "1M");
+    bench_vector_bool_test<LARGE_SIZE>(bench, "1M");
+    bench_vector_bool_popcount<LARGE_SIZE>(bench, "1M");
+    bench_vector_bool_iterate<LARGE_SIZE>(bench, "1M");
+
+    return 0;
+}
+
+// NOLINTEND

--- a/container/bitmap.hpp
+++ b/container/bitmap.hpp
@@ -1,0 +1,1269 @@
+/*
+ * Copyright 2025 ClapDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+#include <new>
+#include <span>
+#include <stdexcept>
+#include <type_traits>
+
+// SIMD detection
+#if defined(__x86_64__) || defined(_M_X64)
+#include <immintrin.h>
+#define BITMAP_HAS_SSE2 1
+#if defined(__SSE4_2__) || defined(__POPCNT__)
+#define BITMAP_HAS_POPCNT 1
+#endif
+#if defined(__AVX2__)
+#define BITMAP_HAS_AVX2 1
+#endif
+#if defined(__AVX512F__) && defined(__AVX512BW__)
+#define BITMAP_HAS_AVX512 1
+#endif
+#if defined(__AVX512VPOPCNTDQ__)
+#define BITMAP_HAS_AVX512_VPOPCNT 1
+#endif
+#elif defined(__aarch64__) || defined(_M_ARM64)
+#include <arm_neon.h>
+#define BITMAP_HAS_NEON 1
+#if defined(__ARM_FEATURE_SVE)
+#include <arm_sve.h>
+#define BITMAP_HAS_SVE 1
+#endif
+#endif
+
+#ifndef BITMAP_ASSERT
+#include <cassert>
+#define BITMAP_ASSERT(expr, msg) assert((expr) && (msg))
+#endif
+
+namespace stdb::container {
+
+namespace bitmap_detail {
+
+// Cache line size for alignment
+constexpr size_t kCacheLineSize = 64;
+
+// Number of bits per word
+constexpr size_t kBitsPerWord = 64;
+
+// Calculate number of words needed for n bits
+[[nodiscard]] constexpr size_t words_for_bits(size_t n) noexcept {
+    return (n + kBitsPerWord - 1) / kBitsPerWord;
+}
+
+// Aligned memory allocation
+[[nodiscard]] inline uint64_t* allocate_aligned(size_t num_words) {
+    if (num_words == 0) return nullptr;
+    size_t bytes = num_words * sizeof(uint64_t);
+    // Round up to cache line boundary
+    bytes = (bytes + kCacheLineSize - 1) & ~(kCacheLineSize - 1);
+    void* ptr = std::aligned_alloc(kCacheLineSize, bytes);
+    if (!ptr) throw std::bad_alloc();
+    return static_cast<uint64_t*>(ptr);
+}
+
+inline void deallocate_aligned(uint64_t* ptr) noexcept {
+    std::free(ptr);
+}
+
+// =============================================================================
+// Scalar implementations
+// =============================================================================
+
+[[gnu::always_inline]] inline size_t popcount_scalar(const uint64_t* data, size_t word_count) noexcept {
+    size_t count = 0;
+    for (size_t i = 0; i < word_count; ++i) {
+        count += __builtin_popcountll(data[i]);
+    }
+    return count;
+}
+
+[[gnu::always_inline]] inline void and_scalar(uint64_t* __restrict__ dst, const uint64_t* __restrict__ src,
+                                               size_t word_count) noexcept {
+    for (size_t i = 0; i < word_count; ++i) {
+        dst[i] &= src[i];
+    }
+}
+
+[[gnu::always_inline]] inline void or_scalar(uint64_t* __restrict__ dst, const uint64_t* __restrict__ src,
+                                              size_t word_count) noexcept {
+    for (size_t i = 0; i < word_count; ++i) {
+        dst[i] |= src[i];
+    }
+}
+
+[[gnu::always_inline]] inline void xor_scalar(uint64_t* __restrict__ dst, const uint64_t* __restrict__ src,
+                                               size_t word_count) noexcept {
+    for (size_t i = 0; i < word_count; ++i) {
+        dst[i] ^= src[i];
+    }
+}
+
+[[gnu::always_inline]] inline void andnot_scalar(uint64_t* __restrict__ dst, const uint64_t* __restrict__ src,
+                                                  size_t word_count) noexcept {
+    for (size_t i = 0; i < word_count; ++i) {
+        dst[i] &= ~src[i];
+    }
+}
+
+// =============================================================================
+// x86 SIMD implementations
+// =============================================================================
+
+#if defined(BITMAP_HAS_SSE2)
+
+[[gnu::always_inline]] inline void and_sse2(uint64_t* __restrict__ dst, const uint64_t* __restrict__ src,
+                                             size_t word_count) noexcept {
+    size_t i = 0;
+    // Process 2 words (128 bits) at a time
+    for (; i + 2 <= word_count; i += 2) {
+        __m128i a = _mm_load_si128(reinterpret_cast<const __m128i*>(dst + i));
+        __m128i b = _mm_load_si128(reinterpret_cast<const __m128i*>(src + i));
+        _mm_store_si128(reinterpret_cast<__m128i*>(dst + i), _mm_and_si128(a, b));
+    }
+    // Scalar tail
+    for (; i < word_count; ++i) {
+        dst[i] &= src[i];
+    }
+}
+
+[[gnu::always_inline]] inline void or_sse2(uint64_t* __restrict__ dst, const uint64_t* __restrict__ src,
+                                            size_t word_count) noexcept {
+    size_t i = 0;
+    for (; i + 2 <= word_count; i += 2) {
+        __m128i a = _mm_load_si128(reinterpret_cast<const __m128i*>(dst + i));
+        __m128i b = _mm_load_si128(reinterpret_cast<const __m128i*>(src + i));
+        _mm_store_si128(reinterpret_cast<__m128i*>(dst + i), _mm_or_si128(a, b));
+    }
+    for (; i < word_count; ++i) {
+        dst[i] |= src[i];
+    }
+}
+
+[[gnu::always_inline]] inline void xor_sse2(uint64_t* __restrict__ dst, const uint64_t* __restrict__ src,
+                                             size_t word_count) noexcept {
+    size_t i = 0;
+    for (; i + 2 <= word_count; i += 2) {
+        __m128i a = _mm_load_si128(reinterpret_cast<const __m128i*>(dst + i));
+        __m128i b = _mm_load_si128(reinterpret_cast<const __m128i*>(src + i));
+        _mm_store_si128(reinterpret_cast<__m128i*>(dst + i), _mm_xor_si128(a, b));
+    }
+    for (; i < word_count; ++i) {
+        dst[i] ^= src[i];
+    }
+}
+
+[[gnu::always_inline]] inline void andnot_sse2(uint64_t* __restrict__ dst, const uint64_t* __restrict__ src,
+                                                size_t word_count) noexcept {
+    size_t i = 0;
+    for (; i + 2 <= word_count; i += 2) {
+        __m128i a = _mm_load_si128(reinterpret_cast<const __m128i*>(dst + i));
+        __m128i b = _mm_load_si128(reinterpret_cast<const __m128i*>(src + i));
+        // andnot: ~b & a, but we want a & ~b, so swap operands
+        _mm_store_si128(reinterpret_cast<__m128i*>(dst + i), _mm_andnot_si128(b, a));
+    }
+    for (; i < word_count; ++i) {
+        dst[i] &= ~src[i];
+    }
+}
+
+#endif  // BITMAP_HAS_SSE2
+
+#if defined(BITMAP_HAS_AVX2)
+
+[[gnu::always_inline]] inline void and_avx2(uint64_t* __restrict__ dst, const uint64_t* __restrict__ src,
+                                             size_t word_count) noexcept {
+    size_t i = 0;
+    // Process 4 words (256 bits) at a time
+    for (; i + 4 <= word_count; i += 4) {
+        __m256i a = _mm256_load_si256(reinterpret_cast<const __m256i*>(dst + i));
+        __m256i b = _mm256_load_si256(reinterpret_cast<const __m256i*>(src + i));
+        _mm256_store_si256(reinterpret_cast<__m256i*>(dst + i), _mm256_and_si256(a, b));
+    }
+    // SSE2 for 2-word chunks
+    for (; i + 2 <= word_count; i += 2) {
+        __m128i a = _mm_load_si128(reinterpret_cast<const __m128i*>(dst + i));
+        __m128i b = _mm_load_si128(reinterpret_cast<const __m128i*>(src + i));
+        _mm_store_si128(reinterpret_cast<__m128i*>(dst + i), _mm_and_si128(a, b));
+    }
+    // Scalar tail
+    for (; i < word_count; ++i) {
+        dst[i] &= src[i];
+    }
+}
+
+[[gnu::always_inline]] inline void or_avx2(uint64_t* __restrict__ dst, const uint64_t* __restrict__ src,
+                                            size_t word_count) noexcept {
+    size_t i = 0;
+    for (; i + 4 <= word_count; i += 4) {
+        __m256i a = _mm256_load_si256(reinterpret_cast<const __m256i*>(dst + i));
+        __m256i b = _mm256_load_si256(reinterpret_cast<const __m256i*>(src + i));
+        _mm256_store_si256(reinterpret_cast<__m256i*>(dst + i), _mm256_or_si256(a, b));
+    }
+    for (; i + 2 <= word_count; i += 2) {
+        __m128i a = _mm_load_si128(reinterpret_cast<const __m128i*>(dst + i));
+        __m128i b = _mm_load_si128(reinterpret_cast<const __m128i*>(src + i));
+        _mm_store_si128(reinterpret_cast<__m128i*>(dst + i), _mm_or_si128(a, b));
+    }
+    for (; i < word_count; ++i) {
+        dst[i] |= src[i];
+    }
+}
+
+[[gnu::always_inline]] inline void xor_avx2(uint64_t* __restrict__ dst, const uint64_t* __restrict__ src,
+                                             size_t word_count) noexcept {
+    size_t i = 0;
+    for (; i + 4 <= word_count; i += 4) {
+        __m256i a = _mm256_load_si256(reinterpret_cast<const __m256i*>(dst + i));
+        __m256i b = _mm256_load_si256(reinterpret_cast<const __m256i*>(src + i));
+        _mm256_store_si256(reinterpret_cast<__m256i*>(dst + i), _mm256_xor_si256(a, b));
+    }
+    for (; i + 2 <= word_count; i += 2) {
+        __m128i a = _mm_load_si128(reinterpret_cast<const __m128i*>(dst + i));
+        __m128i b = _mm_load_si128(reinterpret_cast<const __m128i*>(src + i));
+        _mm_store_si128(reinterpret_cast<__m128i*>(dst + i), _mm_xor_si128(a, b));
+    }
+    for (; i < word_count; ++i) {
+        dst[i] ^= src[i];
+    }
+}
+
+[[gnu::always_inline]] inline void andnot_avx2(uint64_t* __restrict__ dst, const uint64_t* __restrict__ src,
+                                                size_t word_count) noexcept {
+    size_t i = 0;
+    for (; i + 4 <= word_count; i += 4) {
+        __m256i a = _mm256_load_si256(reinterpret_cast<const __m256i*>(dst + i));
+        __m256i b = _mm256_load_si256(reinterpret_cast<const __m256i*>(src + i));
+        _mm256_store_si256(reinterpret_cast<__m256i*>(dst + i), _mm256_andnot_si256(b, a));
+    }
+    for (; i + 2 <= word_count; i += 2) {
+        __m128i a = _mm_load_si128(reinterpret_cast<const __m128i*>(dst + i));
+        __m128i b = _mm_load_si128(reinterpret_cast<const __m128i*>(src + i));
+        _mm_store_si128(reinterpret_cast<__m128i*>(dst + i), _mm_andnot_si128(b, a));
+    }
+    for (; i < word_count; ++i) {
+        dst[i] &= ~src[i];
+    }
+}
+
+// AVX2 popcount using lookup table (Harley-Seal style)
+[[gnu::always_inline]] inline size_t popcount_avx2(const uint64_t* data, size_t word_count) noexcept {
+    // Lookup table for 4-bit popcount
+    const __m256i lookup = _mm256_setr_epi8(
+        0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4,
+        0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4);
+    const __m256i low_mask = _mm256_set1_epi8(0x0f);
+
+    size_t i = 0;
+    __m256i acc = _mm256_setzero_si256();
+    size_t total = 0;
+
+    // Process 32 bytes (4 words) at a time
+    for (; i + 4 <= word_count; i += 4) {
+        __m256i v = _mm256_load_si256(reinterpret_cast<const __m256i*>(data + i));
+        __m256i lo = _mm256_and_si256(v, low_mask);
+        __m256i hi = _mm256_and_si256(_mm256_srli_epi16(v, 4), low_mask);
+        __m256i popcnt_lo = _mm256_shuffle_epi8(lookup, lo);
+        __m256i popcnt_hi = _mm256_shuffle_epi8(lookup, hi);
+        acc = _mm256_add_epi8(acc, popcnt_lo);
+        acc = _mm256_add_epi8(acc, popcnt_hi);
+
+        // Prevent overflow: accumulate every 31 iterations (255/8 = 31)
+        if ((i & 0x7C) == 0x7C) {
+            // Sum bytes horizontally
+            acc = _mm256_sad_epu8(acc, _mm256_setzero_si256());
+            total += _mm256_extract_epi64(acc, 0) + _mm256_extract_epi64(acc, 1) +
+                     _mm256_extract_epi64(acc, 2) + _mm256_extract_epi64(acc, 3);
+            acc = _mm256_setzero_si256();
+        }
+    }
+
+    // Final horizontal sum
+    acc = _mm256_sad_epu8(acc, _mm256_setzero_si256());
+    total += _mm256_extract_epi64(acc, 0) + _mm256_extract_epi64(acc, 1) +
+             _mm256_extract_epi64(acc, 2) + _mm256_extract_epi64(acc, 3);
+
+    // Scalar tail
+    for (; i < word_count; ++i) {
+        total += __builtin_popcountll(data[i]);
+    }
+
+    return total;
+}
+
+#endif  // BITMAP_HAS_AVX2
+
+#if defined(BITMAP_HAS_AVX512)
+
+[[gnu::always_inline]] inline void and_avx512(uint64_t* __restrict__ dst, const uint64_t* __restrict__ src,
+                                               size_t word_count) noexcept {
+    size_t i = 0;
+    // Process 8 words (512 bits) at a time
+    for (; i + 8 <= word_count; i += 8) {
+        __m512i a = _mm512_load_si512(dst + i);
+        __m512i b = _mm512_load_si512(src + i);
+        _mm512_store_si512(dst + i, _mm512_and_si512(a, b));
+    }
+    // AVX2 for 4-word chunks
+    for (; i + 4 <= word_count; i += 4) {
+        __m256i a = _mm256_load_si256(reinterpret_cast<const __m256i*>(dst + i));
+        __m256i b = _mm256_load_si256(reinterpret_cast<const __m256i*>(src + i));
+        _mm256_store_si256(reinterpret_cast<__m256i*>(dst + i), _mm256_and_si256(a, b));
+    }
+    // Scalar tail
+    for (; i < word_count; ++i) {
+        dst[i] &= src[i];
+    }
+}
+
+[[gnu::always_inline]] inline void or_avx512(uint64_t* __restrict__ dst, const uint64_t* __restrict__ src,
+                                              size_t word_count) noexcept {
+    size_t i = 0;
+    for (; i + 8 <= word_count; i += 8) {
+        __m512i a = _mm512_load_si512(dst + i);
+        __m512i b = _mm512_load_si512(src + i);
+        _mm512_store_si512(dst + i, _mm512_or_si512(a, b));
+    }
+    for (; i + 4 <= word_count; i += 4) {
+        __m256i a = _mm256_load_si256(reinterpret_cast<const __m256i*>(dst + i));
+        __m256i b = _mm256_load_si256(reinterpret_cast<const __m256i*>(src + i));
+        _mm256_store_si256(reinterpret_cast<__m256i*>(dst + i), _mm256_or_si256(a, b));
+    }
+    for (; i < word_count; ++i) {
+        dst[i] |= src[i];
+    }
+}
+
+[[gnu::always_inline]] inline void xor_avx512(uint64_t* __restrict__ dst, const uint64_t* __restrict__ src,
+                                               size_t word_count) noexcept {
+    size_t i = 0;
+    for (; i + 8 <= word_count; i += 8) {
+        __m512i a = _mm512_load_si512(dst + i);
+        __m512i b = _mm512_load_si512(src + i);
+        _mm512_store_si512(dst + i, _mm512_xor_si512(a, b));
+    }
+    for (; i + 4 <= word_count; i += 4) {
+        __m256i a = _mm256_load_si256(reinterpret_cast<const __m256i*>(dst + i));
+        __m256i b = _mm256_load_si256(reinterpret_cast<const __m256i*>(src + i));
+        _mm256_store_si256(reinterpret_cast<__m256i*>(dst + i), _mm256_xor_si256(a, b));
+    }
+    for (; i < word_count; ++i) {
+        dst[i] ^= src[i];
+    }
+}
+
+[[gnu::always_inline]] inline void andnot_avx512(uint64_t* __restrict__ dst, const uint64_t* __restrict__ src,
+                                                  size_t word_count) noexcept {
+    size_t i = 0;
+    for (; i + 8 <= word_count; i += 8) {
+        __m512i a = _mm512_load_si512(dst + i);
+        __m512i b = _mm512_load_si512(src + i);
+        _mm512_store_si512(dst + i, _mm512_andnot_si512(b, a));
+    }
+    for (; i + 4 <= word_count; i += 4) {
+        __m256i a = _mm256_load_si256(reinterpret_cast<const __m256i*>(dst + i));
+        __m256i b = _mm256_load_si256(reinterpret_cast<const __m256i*>(src + i));
+        _mm256_store_si256(reinterpret_cast<__m256i*>(dst + i), _mm256_andnot_si256(b, a));
+    }
+    for (; i < word_count; ++i) {
+        dst[i] &= ~src[i];
+    }
+}
+
+#if defined(BITMAP_HAS_AVX512_VPOPCNT)
+[[gnu::always_inline]] inline size_t popcount_avx512(const uint64_t* data, size_t word_count) noexcept {
+    size_t i = 0;
+    __m512i acc = _mm512_setzero_si512();
+
+    // Process 8 words at a time using VPOPCNT
+    for (; i + 8 <= word_count; i += 8) {
+        __m512i v = _mm512_load_si512(data + i);
+        acc = _mm512_add_epi64(acc, _mm512_popcnt_epi64(v));
+    }
+
+    // Horizontal sum of 8 x 64-bit values
+    size_t total = _mm512_reduce_add_epi64(acc);
+
+    // Scalar tail
+    for (; i < word_count; ++i) {
+        total += __builtin_popcountll(data[i]);
+    }
+
+    return total;
+}
+#endif  // BITMAP_HAS_AVX512_VPOPCNT
+
+#endif  // BITMAP_HAS_AVX512
+
+// =============================================================================
+// ARM NEON implementations
+// =============================================================================
+
+#if defined(BITMAP_HAS_NEON)
+
+[[gnu::always_inline]] inline void and_neon(uint64_t* __restrict__ dst, const uint64_t* __restrict__ src,
+                                             size_t word_count) noexcept {
+    size_t i = 0;
+    // Process 2 words (128 bits) at a time
+    for (; i + 2 <= word_count; i += 2) {
+        uint64x2_t a = vld1q_u64(dst + i);
+        uint64x2_t b = vld1q_u64(src + i);
+        vst1q_u64(dst + i, vandq_u64(a, b));
+    }
+    // Scalar tail
+    for (; i < word_count; ++i) {
+        dst[i] &= src[i];
+    }
+}
+
+[[gnu::always_inline]] inline void or_neon(uint64_t* __restrict__ dst, const uint64_t* __restrict__ src,
+                                            size_t word_count) noexcept {
+    size_t i = 0;
+    for (; i + 2 <= word_count; i += 2) {
+        uint64x2_t a = vld1q_u64(dst + i);
+        uint64x2_t b = vld1q_u64(src + i);
+        vst1q_u64(dst + i, vorrq_u64(a, b));
+    }
+    for (; i < word_count; ++i) {
+        dst[i] |= src[i];
+    }
+}
+
+[[gnu::always_inline]] inline void xor_neon(uint64_t* __restrict__ dst, const uint64_t* __restrict__ src,
+                                             size_t word_count) noexcept {
+    size_t i = 0;
+    for (; i + 2 <= word_count; i += 2) {
+        uint64x2_t a = vld1q_u64(dst + i);
+        uint64x2_t b = vld1q_u64(src + i);
+        vst1q_u64(dst + i, veorq_u64(a, b));
+    }
+    for (; i < word_count; ++i) {
+        dst[i] ^= src[i];
+    }
+}
+
+[[gnu::always_inline]] inline void andnot_neon(uint64_t* __restrict__ dst, const uint64_t* __restrict__ src,
+                                                size_t word_count) noexcept {
+    size_t i = 0;
+    for (; i + 2 <= word_count; i += 2) {
+        uint64x2_t a = vld1q_u64(dst + i);
+        uint64x2_t b = vld1q_u64(src + i);
+        // a & ~b = vbicq(a, b)
+        vst1q_u64(dst + i, vbicq_u64(a, b));
+    }
+    for (; i < word_count; ++i) {
+        dst[i] &= ~src[i];
+    }
+}
+
+[[gnu::always_inline]] inline size_t popcount_neon(const uint64_t* data, size_t word_count) noexcept {
+    size_t i = 0;
+    uint64x2_t acc = vdupq_n_u64(0);
+
+    // Process 2 words at a time
+    for (; i + 2 <= word_count; i += 2) {
+        uint8x16_t v = vld1q_u8(reinterpret_cast<const uint8_t*>(data + i));
+        // Count bits in each byte
+        uint8x16_t cnt = vcntq_u8(v);
+        // Sum pairs of bytes -> 8 x 16-bit
+        uint16x8_t sum16 = vpaddlq_u8(cnt);
+        // Sum pairs of 16-bit -> 4 x 32-bit
+        uint32x4_t sum32 = vpaddlq_u16(sum16);
+        // Sum pairs of 32-bit -> 2 x 64-bit
+        uint64x2_t sum64 = vpaddlq_u32(sum32);
+        acc = vaddq_u64(acc, sum64);
+    }
+
+    // Horizontal sum
+    size_t total = vgetq_lane_u64(acc, 0) + vgetq_lane_u64(acc, 1);
+
+    // Scalar tail
+    for (; i < word_count; ++i) {
+        total += __builtin_popcountll(data[i]);
+    }
+
+    return total;
+}
+
+#endif  // BITMAP_HAS_NEON
+
+// =============================================================================
+// ARM SVE implementations
+// =============================================================================
+
+#if defined(BITMAP_HAS_SVE)
+
+[[gnu::always_inline]] inline void and_sve(uint64_t* __restrict__ dst, const uint64_t* __restrict__ src,
+                                            size_t word_count) noexcept {
+    size_t i = 0;
+    size_t vec_len = svcntd();  // Number of 64-bit elements per vector
+
+    while (i + vec_len <= word_count) {
+        svbool_t pg = svptrue_b64();
+        svuint64_t a = svld1_u64(pg, dst + i);
+        svuint64_t b = svld1_u64(pg, src + i);
+        svst1_u64(pg, dst + i, svand_u64_x(pg, a, b));
+        i += vec_len;
+    }
+
+    // Tail with predicate
+    if (i < word_count) {
+        svbool_t pg = svwhilelt_b64(i, word_count);
+        svuint64_t a = svld1_u64(pg, dst + i);
+        svuint64_t b = svld1_u64(pg, src + i);
+        svst1_u64(pg, dst + i, svand_u64_x(pg, a, b));
+    }
+}
+
+[[gnu::always_inline]] inline void or_sve(uint64_t* __restrict__ dst, const uint64_t* __restrict__ src,
+                                           size_t word_count) noexcept {
+    size_t i = 0;
+    size_t vec_len = svcntd();
+
+    while (i + vec_len <= word_count) {
+        svbool_t pg = svptrue_b64();
+        svuint64_t a = svld1_u64(pg, dst + i);
+        svuint64_t b = svld1_u64(pg, src + i);
+        svst1_u64(pg, dst + i, svorr_u64_x(pg, a, b));
+        i += vec_len;
+    }
+
+    if (i < word_count) {
+        svbool_t pg = svwhilelt_b64(i, word_count);
+        svuint64_t a = svld1_u64(pg, dst + i);
+        svuint64_t b = svld1_u64(pg, src + i);
+        svst1_u64(pg, dst + i, svorr_u64_x(pg, a, b));
+    }
+}
+
+[[gnu::always_inline]] inline void xor_sve(uint64_t* __restrict__ dst, const uint64_t* __restrict__ src,
+                                            size_t word_count) noexcept {
+    size_t i = 0;
+    size_t vec_len = svcntd();
+
+    while (i + vec_len <= word_count) {
+        svbool_t pg = svptrue_b64();
+        svuint64_t a = svld1_u64(pg, dst + i);
+        svuint64_t b = svld1_u64(pg, src + i);
+        svst1_u64(pg, dst + i, sveor_u64_x(pg, a, b));
+        i += vec_len;
+    }
+
+    if (i < word_count) {
+        svbool_t pg = svwhilelt_b64(i, word_count);
+        svuint64_t a = svld1_u64(pg, dst + i);
+        svuint64_t b = svld1_u64(pg, src + i);
+        svst1_u64(pg, dst + i, sveor_u64_x(pg, a, b));
+    }
+}
+
+[[gnu::always_inline]] inline void andnot_sve(uint64_t* __restrict__ dst, const uint64_t* __restrict__ src,
+                                               size_t word_count) noexcept {
+    size_t i = 0;
+    size_t vec_len = svcntd();
+
+    while (i + vec_len <= word_count) {
+        svbool_t pg = svptrue_b64();
+        svuint64_t a = svld1_u64(pg, dst + i);
+        svuint64_t b = svld1_u64(pg, src + i);
+        // a & ~b = svbic(a, b)
+        svst1_u64(pg, dst + i, svbic_u64_x(pg, a, b));
+        i += vec_len;
+    }
+
+    if (i < word_count) {
+        svbool_t pg = svwhilelt_b64(i, word_count);
+        svuint64_t a = svld1_u64(pg, dst + i);
+        svuint64_t b = svld1_u64(pg, src + i);
+        svst1_u64(pg, dst + i, svbic_u64_x(pg, a, b));
+    }
+}
+
+[[gnu::always_inline]] inline size_t popcount_sve(const uint64_t* data, size_t word_count) noexcept {
+    size_t i = 0;
+    size_t vec_len = svcntd();
+    svuint64_t acc = svdup_u64(0);
+
+    while (i + vec_len <= word_count) {
+        svbool_t pg = svptrue_b64();
+        svuint64_t v = svld1_u64(pg, data + i);
+        acc = svadd_u64_x(pg, acc, svcnt_u64_x(pg, v));
+        i += vec_len;
+    }
+
+    // Horizontal sum
+    size_t total = svaddv_u64(svptrue_b64(), acc);
+
+    // Scalar tail
+    for (; i < word_count; ++i) {
+        total += __builtin_popcountll(data[i]);
+    }
+
+    return total;
+}
+
+#endif  // BITMAP_HAS_SVE
+
+// =============================================================================
+// Dispatch functions - select best implementation at compile time
+// =============================================================================
+
+[[gnu::always_inline]] inline void bitmap_and(uint64_t* __restrict__ dst, const uint64_t* __restrict__ src,
+                                               size_t word_count) noexcept {
+#if defined(BITMAP_HAS_AVX512)
+    and_avx512(dst, src, word_count);
+#elif defined(BITMAP_HAS_AVX2)
+    and_avx2(dst, src, word_count);
+#elif defined(BITMAP_HAS_SSE2)
+    and_sse2(dst, src, word_count);
+#elif defined(BITMAP_HAS_SVE)
+    and_sve(dst, src, word_count);
+#elif defined(BITMAP_HAS_NEON)
+    and_neon(dst, src, word_count);
+#else
+    and_scalar(dst, src, word_count);
+#endif
+}
+
+[[gnu::always_inline]] inline void bitmap_or(uint64_t* __restrict__ dst, const uint64_t* __restrict__ src,
+                                              size_t word_count) noexcept {
+#if defined(BITMAP_HAS_AVX512)
+    or_avx512(dst, src, word_count);
+#elif defined(BITMAP_HAS_AVX2)
+    or_avx2(dst, src, word_count);
+#elif defined(BITMAP_HAS_SSE2)
+    or_sse2(dst, src, word_count);
+#elif defined(BITMAP_HAS_SVE)
+    or_sve(dst, src, word_count);
+#elif defined(BITMAP_HAS_NEON)
+    or_neon(dst, src, word_count);
+#else
+    or_scalar(dst, src, word_count);
+#endif
+}
+
+[[gnu::always_inline]] inline void bitmap_xor(uint64_t* __restrict__ dst, const uint64_t* __restrict__ src,
+                                               size_t word_count) noexcept {
+#if defined(BITMAP_HAS_AVX512)
+    xor_avx512(dst, src, word_count);
+#elif defined(BITMAP_HAS_AVX2)
+    xor_avx2(dst, src, word_count);
+#elif defined(BITMAP_HAS_SSE2)
+    xor_sse2(dst, src, word_count);
+#elif defined(BITMAP_HAS_SVE)
+    xor_sve(dst, src, word_count);
+#elif defined(BITMAP_HAS_NEON)
+    xor_neon(dst, src, word_count);
+#else
+    xor_scalar(dst, src, word_count);
+#endif
+}
+
+[[gnu::always_inline]] inline void bitmap_andnot(uint64_t* __restrict__ dst, const uint64_t* __restrict__ src,
+                                                  size_t word_count) noexcept {
+#if defined(BITMAP_HAS_AVX512)
+    andnot_avx512(dst, src, word_count);
+#elif defined(BITMAP_HAS_AVX2)
+    andnot_avx2(dst, src, word_count);
+#elif defined(BITMAP_HAS_SSE2)
+    andnot_sse2(dst, src, word_count);
+#elif defined(BITMAP_HAS_SVE)
+    andnot_sve(dst, src, word_count);
+#elif defined(BITMAP_HAS_NEON)
+    andnot_neon(dst, src, word_count);
+#else
+    andnot_scalar(dst, src, word_count);
+#endif
+}
+
+[[gnu::always_inline]] inline size_t bitmap_popcount(const uint64_t* data, size_t word_count) noexcept {
+#if defined(BITMAP_HAS_AVX512_VPOPCNT)
+    return popcount_avx512(data, word_count);
+#elif defined(BITMAP_HAS_AVX2)
+    return popcount_avx2(data, word_count);
+#elif defined(BITMAP_HAS_SVE)
+    return popcount_sve(data, word_count);
+#elif defined(BITMAP_HAS_NEON)
+    return popcount_neon(data, word_count);
+#else
+    return popcount_scalar(data, word_count);
+#endif
+}
+
+}  // namespace bitmap_detail
+
+// =============================================================================
+// Dynamic bitmap class
+// =============================================================================
+
+class bitmap
+{
+public:
+    using word_type = uint64_t;
+    static constexpr size_t bits_per_word = bitmap_detail::kBitsPerWord;
+
+private:
+    word_type* _data = nullptr;
+    size_t _size = 0;       // Number of bits
+    size_t _capacity = 0;   // Number of words allocated
+
+public:
+    // -------------------------------------------------------------------------
+    // Constructors / Destructor
+    // -------------------------------------------------------------------------
+
+    bitmap() noexcept = default;
+
+    explicit bitmap(size_t num_bits) : _size(num_bits) {
+        if (num_bits > 0) {
+            _capacity = bitmap_detail::words_for_bits(num_bits);
+            _data = bitmap_detail::allocate_aligned(_capacity);
+            std::memset(_data, 0, _capacity * sizeof(word_type));
+        }
+    }
+
+    bitmap(const bitmap& other) : _size(other._size), _capacity(other._capacity) {
+        if (_capacity > 0) {
+            _data = bitmap_detail::allocate_aligned(_capacity);
+            std::memcpy(_data, other._data, _capacity * sizeof(word_type));
+        }
+    }
+
+    bitmap(bitmap&& other) noexcept : _data(other._data), _size(other._size), _capacity(other._capacity) {
+        other._data = nullptr;
+        other._size = 0;
+        other._capacity = 0;
+    }
+
+    ~bitmap() {
+        bitmap_detail::deallocate_aligned(_data);
+    }
+
+    bitmap& operator=(const bitmap& other) {
+        if (this != &other) {
+            if (_capacity < other._capacity) {
+                bitmap_detail::deallocate_aligned(_data);
+                _capacity = other._capacity;
+                _data = bitmap_detail::allocate_aligned(_capacity);
+            }
+            _size = other._size;
+            if (_capacity > 0) {
+                std::memcpy(_data, other._data, other._capacity * sizeof(word_type));
+            }
+        }
+        return *this;
+    }
+
+    bitmap& operator=(bitmap&& other) noexcept {
+        if (this != &other) {
+            bitmap_detail::deallocate_aligned(_data);
+            _data = other._data;
+            _size = other._size;
+            _capacity = other._capacity;
+            other._data = nullptr;
+            other._size = 0;
+            other._capacity = 0;
+        }
+        return *this;
+    }
+
+    // -------------------------------------------------------------------------
+    // Capacity
+    // -------------------------------------------------------------------------
+
+    [[nodiscard]] size_t size() const noexcept { return _size; }
+    [[nodiscard]] bool empty() const noexcept { return _size == 0; }
+    [[nodiscard]] size_t capacity_bits() const noexcept { return _capacity * bits_per_word; }
+    [[nodiscard]] size_t word_count() const noexcept { return bitmap_detail::words_for_bits(_size); }
+
+    void resize(size_t new_size) {
+        size_t new_words = bitmap_detail::words_for_bits(new_size);
+        if (new_words > _capacity) {
+            word_type* new_data = bitmap_detail::allocate_aligned(new_words);
+            if (_data) {
+                std::memcpy(new_data, _data, _capacity * sizeof(word_type));
+                std::memset(new_data + _capacity, 0, (new_words - _capacity) * sizeof(word_type));
+                bitmap_detail::deallocate_aligned(_data);
+            } else {
+                std::memset(new_data, 0, new_words * sizeof(word_type));
+            }
+            _data = new_data;
+            _capacity = new_words;
+        }
+        // Clear bits beyond new_size if shrinking
+        if (new_size < _size && new_size > 0) {
+            size_t last_word = (new_size - 1) / bits_per_word;
+            size_t bit_in_word = new_size % bits_per_word;
+            if (bit_in_word != 0) {
+                _data[last_word] &= (word_type{1} << bit_in_word) - 1;
+            }
+            // Zero out words beyond
+            for (size_t i = last_word + 1; i < bitmap_detail::words_for_bits(_size); ++i) {
+                _data[i] = 0;
+            }
+        }
+        _size = new_size;
+    }
+
+    void reserve(size_t num_bits) {
+        size_t new_words = bitmap_detail::words_for_bits(num_bits);
+        if (new_words > _capacity) {
+            word_type* new_data = bitmap_detail::allocate_aligned(new_words);
+            if (_data) {
+                std::memcpy(new_data, _data, _capacity * sizeof(word_type));
+                std::memset(new_data + _capacity, 0, (new_words - _capacity) * sizeof(word_type));
+                bitmap_detail::deallocate_aligned(_data);
+            } else {
+                std::memset(new_data, 0, new_words * sizeof(word_type));
+            }
+            _data = new_data;
+            _capacity = new_words;
+        }
+    }
+
+    void clear() noexcept {
+        if (_data) {
+            std::memset(_data, 0, _capacity * sizeof(word_type));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Single bit operations
+    // -------------------------------------------------------------------------
+
+    void set(uint32_t id) noexcept {
+        BITMAP_ASSERT(id < _size, "id out of range");
+        _data[id / bits_per_word] |= word_type{1} << (id % bits_per_word);
+    }
+
+    void clear_bit(uint32_t id) noexcept {
+        BITMAP_ASSERT(id < _size, "id out of range");
+        _data[id / bits_per_word] &= ~(word_type{1} << (id % bits_per_word));
+    }
+
+    void flip(uint32_t id) noexcept {
+        BITMAP_ASSERT(id < _size, "id out of range");
+        _data[id / bits_per_word] ^= word_type{1} << (id % bits_per_word);
+    }
+
+    [[nodiscard]] bool test(uint32_t id) const noexcept {
+        BITMAP_ASSERT(id < _size, "id out of range");
+        return (_data[id / bits_per_word] & (word_type{1} << (id % bits_per_word))) != 0;
+    }
+
+    // Alias for test
+    [[nodiscard]] bool operator[](uint32_t id) const noexcept { return test(id); }
+
+    // -------------------------------------------------------------------------
+    // Bulk IN operations
+    // -------------------------------------------------------------------------
+
+    // Returns count of matching ids, writes matching ids to result
+    [[nodiscard]] size_t in(const uint32_t* ids, size_t count, uint32_t* result) const noexcept {
+        size_t out = 0;
+        for (size_t i = 0; i < count; ++i) {
+            uint32_t id = ids[i];
+            if (id < _size && test(id)) {
+                result[out++] = id;
+            }
+        }
+        return out;
+    }
+
+    // Writes matching flags to result bitmap (must be pre-sized to count bits)
+    void in(const uint32_t* ids, size_t count, bitmap& result) const noexcept {
+        result.resize(count);
+        result.clear();
+        for (size_t i = 0; i < count; ++i) {
+            uint32_t id = ids[i];
+            if (id < _size && test(id)) {
+                result.set(static_cast<uint32_t>(i));
+            }
+        }
+    }
+
+    // Span-based versions
+    [[nodiscard]] size_t in(std::span<const uint32_t> ids, std::span<uint32_t> result) const noexcept {
+        return in(ids.data(), std::min(ids.size(), result.size()), result.data());
+    }
+
+    void in(std::span<const uint32_t> ids, bitmap& result) const noexcept {
+        in(ids.data(), ids.size(), result);
+    }
+
+    // -------------------------------------------------------------------------
+    // Bulk bitwise operations
+    // -------------------------------------------------------------------------
+
+    bitmap& and_(const bitmap& other) noexcept {
+        size_t min_words = std::min(word_count(), other.word_count());
+        bitmap_detail::bitmap_and(_data, other._data, min_words);
+        // Zero out words beyond other's size
+        for (size_t i = min_words; i < word_count(); ++i) {
+            _data[i] = 0;
+        }
+        return *this;
+    }
+
+    bitmap& or_(const bitmap& other) noexcept {
+        size_t min_words = std::min(word_count(), other.word_count());
+        bitmap_detail::bitmap_or(_data, other._data, min_words);
+        return *this;
+    }
+
+    bitmap& xor_(const bitmap& other) noexcept {
+        size_t min_words = std::min(word_count(), other.word_count());
+        bitmap_detail::bitmap_xor(_data, other._data, min_words);
+        return *this;
+    }
+
+    bitmap& andnot_(const bitmap& other) noexcept {
+        size_t min_words = std::min(word_count(), other.word_count());
+        bitmap_detail::bitmap_andnot(_data, other._data, min_words);
+        return *this;
+    }
+
+    // Operator versions
+    bitmap& operator&=(const bitmap& other) noexcept { return and_(other); }
+    bitmap& operator|=(const bitmap& other) noexcept { return or_(other); }
+    bitmap& operator^=(const bitmap& other) noexcept { return xor_(other); }
+
+    // -------------------------------------------------------------------------
+    // Population count and iteration
+    // -------------------------------------------------------------------------
+
+    [[nodiscard]] size_t popcount() const noexcept {
+        return bitmap_detail::bitmap_popcount(_data, word_count());
+    }
+
+    [[nodiscard]] int64_t find_first() const noexcept {
+        size_t words = word_count();
+        for (size_t i = 0; i < words; ++i) {
+            if (_data[i] != 0) {
+                int64_t bit = static_cast<int64_t>(i * bits_per_word + __builtin_ctzll(_data[i]));
+                return bit < static_cast<int64_t>(_size) ? bit : -1;
+            }
+        }
+        return -1;
+    }
+
+    [[nodiscard]] int64_t find_next(uint32_t pos) const noexcept {
+        if (pos + 1 >= _size) return -1;
+
+        uint32_t start = pos + 1;
+        size_t word_idx = start / bits_per_word;
+        size_t bit_idx = start % bits_per_word;
+
+        // Check current word (mask out bits before start)
+        word_type word = _data[word_idx] & (~word_type{0} << bit_idx);
+        if (word != 0) {
+            int64_t bit = static_cast<int64_t>(word_idx * bits_per_word + __builtin_ctzll(word));
+            return bit < static_cast<int64_t>(_size) ? bit : -1;
+        }
+
+        // Check subsequent words
+        size_t words = word_count();
+        for (size_t i = word_idx + 1; i < words; ++i) {
+            if (_data[i] != 0) {
+                int64_t bit = static_cast<int64_t>(i * bits_per_word + __builtin_ctzll(_data[i]));
+                return bit < static_cast<int64_t>(_size) ? bit : -1;
+            }
+        }
+
+        return -1;
+    }
+
+    // -------------------------------------------------------------------------
+    // Raw data access
+    // -------------------------------------------------------------------------
+
+    [[nodiscard]] word_type* data() noexcept { return _data; }
+    [[nodiscard]] const word_type* data() const noexcept { return _data; }
+
+    // -------------------------------------------------------------------------
+    // Iterator for set bits
+    // -------------------------------------------------------------------------
+
+    class set_bit_iterator
+    {
+    public:
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = uint32_t;
+        using difference_type = std::ptrdiff_t;
+        using pointer = const uint32_t*;
+        using reference = uint32_t;
+
+    private:
+        const bitmap* _bm = nullptr;
+        int64_t _pos = -1;
+
+    public:
+        set_bit_iterator() = default;
+        set_bit_iterator(const bitmap* bm, int64_t pos) : _bm(bm), _pos(pos) {}
+
+        reference operator*() const { return static_cast<uint32_t>(_pos); }
+
+        set_bit_iterator& operator++() {
+            _pos = _bm->find_next(static_cast<uint32_t>(_pos));
+            return *this;
+        }
+
+        set_bit_iterator operator++(int) {
+            auto tmp = *this;
+            ++(*this);
+            return tmp;
+        }
+
+        bool operator==(const set_bit_iterator& other) const { return _pos == other._pos; }
+        bool operator!=(const set_bit_iterator& other) const { return _pos != other._pos; }
+    };
+
+    [[nodiscard]] set_bit_iterator begin() const { return set_bit_iterator(this, find_first()); }
+    [[nodiscard]] set_bit_iterator end() const { return set_bit_iterator(this, -1); }
+};
+
+// =============================================================================
+// Static bitmap class (compile-time size)
+// =============================================================================
+
+template <size_t NumBits>
+class static_bitmap
+{
+public:
+    using word_type = uint64_t;
+    static constexpr size_t bits_per_word = bitmap_detail::kBitsPerWord;
+    static constexpr size_t num_words = bitmap_detail::words_for_bits(NumBits);
+
+private:
+    alignas(bitmap_detail::kCacheLineSize) word_type _data[num_words] = {};
+
+public:
+    // -------------------------------------------------------------------------
+    // Constructors
+    // -------------------------------------------------------------------------
+
+    static_bitmap() noexcept = default;
+
+    static_bitmap(const static_bitmap& other) noexcept {
+        std::memcpy(_data, other._data, sizeof(_data));
+    }
+
+    static_bitmap& operator=(const static_bitmap& other) noexcept {
+        if (this != &other) {
+            std::memcpy(_data, other._data, sizeof(_data));
+        }
+        return *this;
+    }
+
+    // -------------------------------------------------------------------------
+    // Capacity
+    // -------------------------------------------------------------------------
+
+    [[nodiscard]] static constexpr size_t size() noexcept { return NumBits; }
+    [[nodiscard]] static constexpr bool empty() noexcept { return NumBits == 0; }
+    [[nodiscard]] static constexpr size_t word_count() noexcept { return num_words; }
+
+    void clear() noexcept {
+        std::memset(_data, 0, sizeof(_data));
+    }
+
+    void fill() noexcept {
+        std::memset(_data, 0xFF, sizeof(_data));
+        // Clear excess bits in last word
+        if constexpr (NumBits % bits_per_word != 0) {
+            _data[num_words - 1] &= (word_type{1} << (NumBits % bits_per_word)) - 1;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Single bit operations
+    // -------------------------------------------------------------------------
+
+    void set(uint32_t id) noexcept {
+        BITMAP_ASSERT(id < NumBits, "id out of range");
+        _data[id / bits_per_word] |= word_type{1} << (id % bits_per_word);
+    }
+
+    void clear_bit(uint32_t id) noexcept {
+        BITMAP_ASSERT(id < NumBits, "id out of range");
+        _data[id / bits_per_word] &= ~(word_type{1} << (id % bits_per_word));
+    }
+
+    void flip(uint32_t id) noexcept {
+        BITMAP_ASSERT(id < NumBits, "id out of range");
+        _data[id / bits_per_word] ^= word_type{1} << (id % bits_per_word);
+    }
+
+    [[nodiscard]] bool test(uint32_t id) const noexcept {
+        BITMAP_ASSERT(id < NumBits, "id out of range");
+        return (_data[id / bits_per_word] & (word_type{1} << (id % bits_per_word))) != 0;
+    }
+
+    [[nodiscard]] bool operator[](uint32_t id) const noexcept { return test(id); }
+
+    // -------------------------------------------------------------------------
+    // Bulk IN operations
+    // -------------------------------------------------------------------------
+
+    [[nodiscard]] size_t in(const uint32_t* ids, size_t count, uint32_t* result) const noexcept {
+        size_t out = 0;
+        for (size_t i = 0; i < count; ++i) {
+            uint32_t id = ids[i];
+            if (id < NumBits && test(id)) {
+                result[out++] = id;
+            }
+        }
+        return out;
+    }
+
+    template <size_t ResultBits>
+    void in(const uint32_t* ids, size_t count, static_bitmap<ResultBits>& result) const noexcept {
+        result.clear();
+        for (size_t i = 0; i < count && i < ResultBits; ++i) {
+            uint32_t id = ids[i];
+            if (id < NumBits && test(id)) {
+                result.set(static_cast<uint32_t>(i));
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Bulk bitwise operations
+    // -------------------------------------------------------------------------
+
+    static_bitmap& and_(const static_bitmap& other) noexcept {
+        bitmap_detail::bitmap_and(_data, other._data, num_words);
+        return *this;
+    }
+
+    static_bitmap& or_(const static_bitmap& other) noexcept {
+        bitmap_detail::bitmap_or(_data, other._data, num_words);
+        return *this;
+    }
+
+    static_bitmap& xor_(const static_bitmap& other) noexcept {
+        bitmap_detail::bitmap_xor(_data, other._data, num_words);
+        return *this;
+    }
+
+    static_bitmap& andnot_(const static_bitmap& other) noexcept {
+        bitmap_detail::bitmap_andnot(_data, other._data, num_words);
+        return *this;
+    }
+
+    static_bitmap& operator&=(const static_bitmap& other) noexcept { return and_(other); }
+    static_bitmap& operator|=(const static_bitmap& other) noexcept { return or_(other); }
+    static_bitmap& operator^=(const static_bitmap& other) noexcept { return xor_(other); }
+
+    // -------------------------------------------------------------------------
+    // Population count and iteration
+    // -------------------------------------------------------------------------
+
+    [[nodiscard]] size_t popcount() const noexcept {
+        return bitmap_detail::bitmap_popcount(_data, num_words);
+    }
+
+    [[nodiscard]] int64_t find_first() const noexcept {
+        for (size_t i = 0; i < num_words; ++i) {
+            if (_data[i] != 0) {
+                int64_t bit = static_cast<int64_t>(i * bits_per_word + __builtin_ctzll(_data[i]));
+                return bit < static_cast<int64_t>(NumBits) ? bit : -1;
+            }
+        }
+        return -1;
+    }
+
+    [[nodiscard]] int64_t find_next(uint32_t pos) const noexcept {
+        if (pos + 1 >= NumBits) return -1;
+
+        uint32_t start = pos + 1;
+        size_t word_idx = start / bits_per_word;
+        size_t bit_idx = start % bits_per_word;
+
+        word_type word = _data[word_idx] & (~word_type{0} << bit_idx);
+        if (word != 0) {
+            int64_t bit = static_cast<int64_t>(word_idx * bits_per_word + __builtin_ctzll(word));
+            return bit < static_cast<int64_t>(NumBits) ? bit : -1;
+        }
+
+        for (size_t i = word_idx + 1; i < num_words; ++i) {
+            if (_data[i] != 0) {
+                int64_t bit = static_cast<int64_t>(i * bits_per_word + __builtin_ctzll(_data[i]));
+                return bit < static_cast<int64_t>(NumBits) ? bit : -1;
+            }
+        }
+
+        return -1;
+    }
+
+    // -------------------------------------------------------------------------
+    // Raw data access
+    // -------------------------------------------------------------------------
+
+    [[nodiscard]] word_type* data() noexcept { return _data; }
+    [[nodiscard]] const word_type* data() const noexcept { return _data; }
+
+    // -------------------------------------------------------------------------
+    // Iterator for set bits
+    // -------------------------------------------------------------------------
+
+    class set_bit_iterator
+    {
+    public:
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = uint32_t;
+        using difference_type = std::ptrdiff_t;
+        using pointer = const uint32_t*;
+        using reference = uint32_t;
+
+    private:
+        const static_bitmap* _bm = nullptr;
+        int64_t _pos = -1;
+
+    public:
+        set_bit_iterator() = default;
+        set_bit_iterator(const static_bitmap* bm, int64_t pos) : _bm(bm), _pos(pos) {}
+
+        reference operator*() const { return static_cast<uint32_t>(_pos); }
+
+        set_bit_iterator& operator++() {
+            _pos = _bm->find_next(static_cast<uint32_t>(_pos));
+            return *this;
+        }
+
+        set_bit_iterator operator++(int) {
+            auto tmp = *this;
+            ++(*this);
+            return tmp;
+        }
+
+        bool operator==(const set_bit_iterator& other) const { return _pos == other._pos; }
+        bool operator!=(const set_bit_iterator& other) const { return _pos != other._pos; }
+    };
+
+    [[nodiscard]] set_bit_iterator begin() const { return set_bit_iterator(this, find_first()); }
+    [[nodiscard]] set_bit_iterator end() const { return set_bit_iterator(this, -1); }
+};
+
+}  // namespace stdb::container

--- a/tests/bitmap_test.cc
+++ b/tests/bitmap_test.cc
@@ -1,0 +1,579 @@
+/*
+ * Copyright 2025 ClapDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "container/bitmap.hpp"
+
+#include <algorithm>
+#include <random>
+#include <vector>
+
+#include "doctest/doctest/doctest.h"
+
+using namespace stdb::container;
+
+// =============================================================================
+// Dynamic bitmap tests
+// =============================================================================
+
+TEST_SUITE("bitmap") {
+    TEST_CASE("construction") {
+        SUBCASE("default constructor") {
+            bitmap b;
+            CHECK(b.size() == 0);
+            CHECK(b.empty());
+        }
+
+        SUBCASE("size constructor") {
+            bitmap b(100);
+            CHECK(b.size() == 100);
+            CHECK_FALSE(b.empty());
+            CHECK(b.popcount() == 0);
+        }
+
+        SUBCASE("copy constructor") {
+            bitmap b1(100);
+            b1.set(10);
+            b1.set(50);
+
+            bitmap b2(b1);
+            CHECK(b2.size() == 100);
+            CHECK(b2.test(10));
+            CHECK(b2.test(50));
+            CHECK(b2.popcount() == 2);
+        }
+
+        SUBCASE("move constructor") {
+            bitmap b1(100);
+            b1.set(10);
+
+            bitmap b2(std::move(b1));
+            CHECK(b2.size() == 100);
+            CHECK(b2.test(10));
+            CHECK(b1.size() == 0);  // NOLINT(bugprone-use-after-move)
+        }
+    }
+
+    TEST_CASE("single bit operations") {
+        bitmap b(200);
+
+        SUBCASE("set and test") {
+            CHECK_FALSE(b.test(0));
+            b.set(0);
+            CHECK(b.test(0));
+
+            CHECK_FALSE(b.test(63));
+            b.set(63);
+            CHECK(b.test(63));
+
+            CHECK_FALSE(b.test(64));
+            b.set(64);
+            CHECK(b.test(64));
+
+            CHECK_FALSE(b.test(127));
+            b.set(127);
+            CHECK(b.test(127));
+
+            CHECK_FALSE(b.test(199));
+            b.set(199);
+            CHECK(b.test(199));
+        }
+
+        SUBCASE("clear_bit") {
+            b.set(50);
+            CHECK(b.test(50));
+            b.clear_bit(50);
+            CHECK_FALSE(b.test(50));
+        }
+
+        SUBCASE("flip") {
+            CHECK_FALSE(b.test(75));
+            b.flip(75);
+            CHECK(b.test(75));
+            b.flip(75);
+            CHECK_FALSE(b.test(75));
+        }
+
+        SUBCASE("operator[]") {
+            b.set(42);
+            CHECK(b[42]);
+            CHECK_FALSE(b[41]);
+        }
+    }
+
+    TEST_CASE("popcount") {
+        SUBCASE("empty bitmap") {
+            bitmap b(1000);
+            CHECK(b.popcount() == 0);
+        }
+
+        SUBCASE("single bit") {
+            bitmap b(1000);
+            b.set(500);
+            CHECK(b.popcount() == 1);
+        }
+
+        SUBCASE("multiple bits") {
+            bitmap b(1000);
+            for (uint32_t i = 0; i < 100; ++i) {
+                b.set(i * 10);
+            }
+            CHECK(b.popcount() == 100);
+        }
+
+        SUBCASE("all bits set") {
+            bitmap b(128);
+            for (uint32_t i = 0; i < 128; ++i) {
+                b.set(i);
+            }
+            CHECK(b.popcount() == 128);
+        }
+
+        SUBCASE("large bitmap") {
+            bitmap b(100000);
+            for (uint32_t i = 0; i < 100000; i += 2) {
+                b.set(i);
+            }
+            CHECK(b.popcount() == 50000);
+        }
+    }
+
+    TEST_CASE("find_first and find_next") {
+        SUBCASE("empty bitmap") {
+            bitmap b(100);
+            CHECK(b.find_first() == -1);
+        }
+
+        SUBCASE("single bit at start") {
+            bitmap b(100);
+            b.set(0);
+            CHECK(b.find_first() == 0);
+            CHECK(b.find_next(0) == -1);
+        }
+
+        SUBCASE("single bit in middle") {
+            bitmap b(100);
+            b.set(50);
+            CHECK(b.find_first() == 50);
+            CHECK(b.find_next(50) == -1);
+        }
+
+        SUBCASE("multiple bits") {
+            bitmap b(200);
+            b.set(10);
+            b.set(64);
+            b.set(100);
+            b.set(150);
+
+            CHECK(b.find_first() == 10);
+            CHECK(b.find_next(10) == 64);
+            CHECK(b.find_next(64) == 100);
+            CHECK(b.find_next(100) == 150);
+            CHECK(b.find_next(150) == -1);
+        }
+
+        SUBCASE("word boundary") {
+            bitmap b(200);
+            b.set(63);
+            b.set(64);
+            CHECK(b.find_first() == 63);
+            CHECK(b.find_next(63) == 64);
+        }
+    }
+
+    TEST_CASE("iterator") {
+        bitmap b(200);
+        b.set(5);
+        b.set(64);
+        b.set(127);
+        b.set(128);
+
+        std::vector<uint32_t> bits;
+        for (uint32_t bit : b) {
+            bits.push_back(bit);
+        }
+
+        CHECK(bits.size() == 4);
+        CHECK(bits[0] == 5);
+        CHECK(bits[1] == 64);
+        CHECK(bits[2] == 127);
+        CHECK(bits[3] == 128);
+    }
+
+    TEST_CASE("bitwise operations") {
+        bitmap a(128);
+        bitmap b(128);
+
+        // a = {0, 1, 2, 64, 65}
+        a.set(0);
+        a.set(1);
+        a.set(2);
+        a.set(64);
+        a.set(65);
+
+        // b = {1, 2, 3, 65, 66}
+        b.set(1);
+        b.set(2);
+        b.set(3);
+        b.set(65);
+        b.set(66);
+
+        SUBCASE("and_") {
+            bitmap c = a;
+            c.and_(b);
+            // Expected: {1, 2, 65}
+            CHECK(c.popcount() == 3);
+            CHECK(c.test(1));
+            CHECK(c.test(2));
+            CHECK(c.test(65));
+            CHECK_FALSE(c.test(0));
+            CHECK_FALSE(c.test(3));
+        }
+
+        SUBCASE("or_") {
+            bitmap c = a;
+            c.or_(b);
+            // Expected: {0, 1, 2, 3, 64, 65, 66}
+            CHECK(c.popcount() == 7);
+            CHECK(c.test(0));
+            CHECK(c.test(1));
+            CHECK(c.test(2));
+            CHECK(c.test(3));
+            CHECK(c.test(64));
+            CHECK(c.test(65));
+            CHECK(c.test(66));
+        }
+
+        SUBCASE("xor_") {
+            bitmap c = a;
+            c.xor_(b);
+            // Expected: {0, 3, 64, 66}
+            CHECK(c.popcount() == 4);
+            CHECK(c.test(0));
+            CHECK(c.test(3));
+            CHECK(c.test(64));
+            CHECK(c.test(66));
+        }
+
+        SUBCASE("andnot_") {
+            bitmap c = a;
+            c.andnot_(b);
+            // Expected: {0, 64} (a - b)
+            CHECK(c.popcount() == 2);
+            CHECK(c.test(0));
+            CHECK(c.test(64));
+        }
+
+        SUBCASE("operators") {
+            bitmap c = a;
+            c &= b;
+            CHECK(c.popcount() == 3);
+
+            c = a;
+            c |= b;
+            CHECK(c.popcount() == 7);
+
+            c = a;
+            c ^= b;
+            CHECK(c.popcount() == 4);
+        }
+    }
+
+    TEST_CASE("large bitwise operations") {
+        constexpr size_t size = 100000;
+        bitmap a(size);
+        bitmap b(size);
+
+        std::mt19937 rng(42);
+        for (size_t i = 0; i < 10000; ++i) {
+            a.set(rng() % size);
+            b.set(rng() % size);
+        }
+
+        size_t a_pop = a.popcount();
+        size_t b_pop = b.popcount();
+
+        SUBCASE("and_ consistency") {
+            bitmap c = a;
+            c.and_(b);
+            // Verify result is subset of both
+            for (uint32_t bit : c) {
+                CHECK(a.test(bit));
+                CHECK(b.test(bit));
+            }
+        }
+
+        SUBCASE("or_ consistency") {
+            bitmap c = a;
+            c.or_(b);
+            // Verify all original bits are present
+            for (uint32_t bit : a) {
+                CHECK(c.test(bit));
+            }
+            for (uint32_t bit : b) {
+                CHECK(c.test(bit));
+            }
+        }
+    }
+
+    TEST_CASE("bulk IN operations") {
+        bitmap b(1000);
+        b.set(10);
+        b.set(50);
+        b.set(100);
+        b.set(500);
+        b.set(999);
+
+        SUBCASE("in with array") {
+            uint32_t ids[] = {5, 10, 20, 50, 100, 200, 500, 998, 999};
+            uint32_t result[9];
+            size_t count = b.in(ids, 9, result);
+
+            CHECK(count == 5);
+            CHECK(result[0] == 10);
+            CHECK(result[1] == 50);
+            CHECK(result[2] == 100);
+            CHECK(result[3] == 500);
+            CHECK(result[4] == 999);
+        }
+
+        SUBCASE("in with out of range ids") {
+            uint32_t ids[] = {10, 1000, 2000};  // 1000 and 2000 are out of range
+            uint32_t result[3];
+            size_t count = b.in(ids, 3, result);
+
+            CHECK(count == 1);
+            CHECK(result[0] == 10);
+        }
+
+        SUBCASE("in with bitmap result") {
+            uint32_t ids[] = {5, 10, 20, 50, 100};
+            bitmap result;
+            b.in(ids, 5, result);
+
+            CHECK(result.size() == 5);
+            CHECK_FALSE(result.test(0));  // id=5 not in b
+            CHECK(result.test(1));         // id=10 in b
+            CHECK_FALSE(result.test(2));  // id=20 not in b
+            CHECK(result.test(3));         // id=50 in b
+            CHECK(result.test(4));         // id=100 in b
+        }
+    }
+
+    TEST_CASE("resize") {
+        SUBCASE("grow") {
+            bitmap b(100);
+            b.set(50);
+            b.resize(200);
+
+            CHECK(b.size() == 200);
+            CHECK(b.test(50));
+            CHECK_FALSE(b.test(150));
+
+            b.set(150);
+            CHECK(b.test(150));
+        }
+
+        SUBCASE("shrink") {
+            bitmap b(200);
+            b.set(50);
+            b.set(150);
+            b.resize(100);
+
+            CHECK(b.size() == 100);
+            CHECK(b.test(50));
+            // bit 150 should be gone (out of range)
+        }
+    }
+
+    TEST_CASE("clear") {
+        bitmap b(1000);
+        for (uint32_t i = 0; i < 1000; ++i) {
+            b.set(i);
+        }
+        CHECK(b.popcount() == 1000);
+
+        b.clear();
+        CHECK(b.popcount() == 0);
+        CHECK(b.size() == 1000);
+    }
+}
+
+// =============================================================================
+// Static bitmap tests
+// =============================================================================
+
+TEST_SUITE("static_bitmap") {
+    TEST_CASE("construction") {
+        static_bitmap<100> b;
+        CHECK(b.size() == 100);
+        CHECK(b.popcount() == 0);
+    }
+
+    TEST_CASE("single bit operations") {
+        static_bitmap<200> b;
+
+        b.set(0);
+        CHECK(b.test(0));
+
+        b.set(63);
+        CHECK(b.test(63));
+
+        b.set(64);
+        CHECK(b.test(64));
+
+        b.set(199);
+        CHECK(b.test(199));
+
+        b.clear_bit(64);
+        CHECK_FALSE(b.test(64));
+
+        b.flip(100);
+        CHECK(b.test(100));
+        b.flip(100);
+        CHECK_FALSE(b.test(100));
+    }
+
+    TEST_CASE("popcount") {
+        static_bitmap<1000> b;
+        for (uint32_t i = 0; i < 100; ++i) {
+            b.set(i * 10);
+        }
+        CHECK(b.popcount() == 100);
+    }
+
+    TEST_CASE("find_first and find_next") {
+        static_bitmap<200> b;
+        b.set(10);
+        b.set(64);
+        b.set(100);
+
+        CHECK(b.find_first() == 10);
+        CHECK(b.find_next(10) == 64);
+        CHECK(b.find_next(64) == 100);
+        CHECK(b.find_next(100) == -1);
+    }
+
+    TEST_CASE("iterator") {
+        static_bitmap<200> b;
+        b.set(5);
+        b.set(64);
+        b.set(127);
+
+        std::vector<uint32_t> bits;
+        for (uint32_t bit : b) {
+            bits.push_back(bit);
+        }
+
+        CHECK(bits.size() == 3);
+        CHECK(bits[0] == 5);
+        CHECK(bits[1] == 64);
+        CHECK(bits[2] == 127);
+    }
+
+    TEST_CASE("bitwise operations") {
+        static_bitmap<128> a;
+        static_bitmap<128> b;
+
+        a.set(0);
+        a.set(1);
+        a.set(64);
+
+        b.set(1);
+        b.set(2);
+        b.set(64);
+
+        SUBCASE("and_") {
+            static_bitmap<128> c = a;
+            c.and_(b);
+            CHECK(c.popcount() == 2);  // {1, 64}
+            CHECK(c.test(1));
+            CHECK(c.test(64));
+        }
+
+        SUBCASE("or_") {
+            static_bitmap<128> c = a;
+            c.or_(b);
+            CHECK(c.popcount() == 4);  // {0, 1, 2, 64}
+        }
+
+        SUBCASE("xor_") {
+            static_bitmap<128> c = a;
+            c.xor_(b);
+            CHECK(c.popcount() == 2);  // {0, 2}
+        }
+    }
+
+    TEST_CASE("fill and clear") {
+        static_bitmap<100> b;
+
+        b.fill();
+        CHECK(b.popcount() == 100);
+        CHECK(b.test(0));
+        CHECK(b.test(99));
+
+        b.clear();
+        CHECK(b.popcount() == 0);
+    }
+
+    TEST_CASE("bulk IN operations") {
+        static_bitmap<1000> b;
+        b.set(10);
+        b.set(50);
+        b.set(100);
+
+        uint32_t ids[] = {5, 10, 50, 100, 200};
+        uint32_t result[5];
+        size_t count = b.in(ids, 5, result);
+
+        CHECK(count == 3);
+        CHECK(result[0] == 10);
+        CHECK(result[1] == 50);
+        CHECK(result[2] == 100);
+    }
+}
+
+// =============================================================================
+// Edge case tests
+// =============================================================================
+
+TEST_SUITE("bitmap edge cases") {
+    TEST_CASE("very small bitmap") {
+        bitmap b(1);
+        CHECK(b.size() == 1);
+        b.set(0);
+        CHECK(b.test(0));
+        CHECK(b.popcount() == 1);
+    }
+
+    TEST_CASE("word-aligned sizes") {
+        for (size_t size : {64, 128, 192, 256, 512}) {
+            bitmap b(size);
+            b.set(0);
+            b.set(static_cast<uint32_t>(size - 1));
+            CHECK(b.popcount() == 2);
+        }
+    }
+
+    TEST_CASE("non-word-aligned sizes") {
+        for (size_t size : {65, 127, 129, 255, 257}) {
+            bitmap b(size);
+            b.set(0);
+            b.set(static_cast<uint32_t>(size - 1));
+            CHECK(b.popcount() == 2);
+            CHECK(b.test(static_cast<uint32_t>(size - 1)));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `bitmap` class: dynamic-size bitmap with SIMD-accelerated operations
- Add `static_bitmap<N>` class: compile-time fixed-size bitmap
- SIMD support: AVX-512/AVX2/SSE2 (x86) and NEON/SVE (ARM)
- Core operations: `set`, `clear`, `flip`, `test`, `and_`, `or_`, `xor_`, `andnot_`, `popcount`
- Bulk `in()` query for batch membership testing
- Iterator for efficient traversal of set bits

## Performance (1M bits, clang -O3 -march=native)

### vs std::bitset
| Operation | bitmap | std::bitset | Speedup |
|-----------|--------|-------------|---------|
| set 1000x | 2.1μs | 2.6μs | 1.2x |
| test 1000x | 582ns | 697ns | 1.2x |
| AND/OR/XOR | ~6.5μs | ~6.9μs | ~equal |

### vs vector\<bool\>
| Operation | bitmap | vector\<bool\> | Speedup |
|-----------|--------|---------------|---------|
| popcount | 4.1μs | 1,169μs | **288x** |
| iterate | 75μs | 505μs | **6.7x** |

## Test plan

- [x] Unit tests pass: `./tests/containa_test -ts=bitmap -ts=static_bitmap`
- [x] Benchmarks run successfully: `./bench/bitmap_bench`

🤖 Generated with [Claude Code](https://claude.com/claude-code)