### PR TITLE
Optimize emplace_hint for O(1) sorted insert and fix vectra move_backward

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Compiler flags
-set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
+# Use -march=native to enable AVX2/AVX512 SIMD optimizations
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG -march=native")
 set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -DDEBUG")
 
 # Default build type

--- a/bench/btree_bench.cc
+++ b/bench/btree_bench.cc
@@ -44,7 +44,7 @@ void run_int_benchmark(const std::string& label) {
 
     std::cout << "\n=== Integer Keys: " << label << " (" << N << " elements) ===\n";
 
-    // Sorted insert
+    // Sorted insert (operator[])
     bench.run("stdb sorted insert", [&] {
         btree_map<int, int> map;
         for (int k : sorted_keys) map[k] = k;
@@ -54,6 +54,60 @@ void run_int_benchmark(const std::string& label) {
     bench.run("absl sorted insert", [&] {
         absl::btree_map<int, int> map;
         for (int k : sorted_keys) map[k] = k;
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+#endif
+
+    // Sorted insert with hint (end() hint - optimal for append)
+    bench.run("stdb sorted hint insert", [&] {
+        btree_map<int, int> map;
+        for (int k : sorted_keys) {
+            map.insert(map.end(), {k, k});
+        }
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+#ifdef ENABLE_ABSL
+    bench.run("absl sorted hint insert", [&] {
+        absl::btree_map<int, int> map;
+        for (int k : sorted_keys) {
+            map.insert(map.end(), {k, k});
+        }
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+#endif
+
+    // Sorted emplace_hint
+    bench.run("stdb sorted emplace_hint", [&] {
+        btree_map<int, int> map;
+        for (int k : sorted_keys) {
+            map.emplace_hint(map.end(), k, k);
+        }
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+#ifdef ENABLE_ABSL
+    bench.run("absl sorted emplace_hint", [&] {
+        absl::btree_map<int, int> map;
+        for (int k : sorted_keys) {
+            map.emplace_hint(map.end(), k, k);
+        }
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+#endif
+
+    // Random insert with bad hint (begin() - worst case for random data)
+    bench.run("stdb random bad hint", [&] {
+        btree_map<int, int> map;
+        for (int k : random_keys) {
+            map.insert(map.begin(), {k, k});
+        }
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+#ifdef ENABLE_ABSL
+    bench.run("absl random bad hint", [&] {
+        absl::btree_map<int, int> map;
+        for (int k : random_keys) {
+            map.insert(map.begin(), {k, k});
+        }
         ankerl::nanobench::doNotOptimizeAway(map);
     });
 #endif
@@ -156,7 +210,7 @@ void run_string_benchmark(const std::string& label) {
 
     std::cout << "\n=== String Keys: " << label << " (" << N << " elements) ===\n";
 
-    // Sorted insert
+    // Sorted insert (operator[])
     bench.run("stdb sorted insert", [&] {
         btree_map<std::string, int> map;
         int i = 0;
@@ -168,6 +222,26 @@ void run_string_benchmark(const std::string& label) {
         absl::btree_map<std::string, int> map;
         int i = 0;
         for (const auto& k : sorted_string_keys) map[k] = i++;
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+#endif
+
+    // Sorted emplace_hint (fair comparison - same copy semantics as operator[])
+    bench.run("stdb sorted emplace_hint", [&] {
+        btree_map<std::string, int> map;
+        int i = 0;
+        for (const auto& k : sorted_string_keys) {
+            map.emplace_hint(map.end(), k, i++);
+        }
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+#ifdef ENABLE_ABSL
+    bench.run("absl sorted emplace_hint", [&] {
+        absl::btree_map<std::string, int> map;
+        int i = 0;
+        for (const auto& k : sorted_string_keys) {
+            map.emplace_hint(map.end(), k, i++);
+        }
         ankerl::nanobench::doNotOptimizeAway(map);
     });
 #endif

--- a/container/btree_map.hpp
+++ b/container/btree_map.hpp
@@ -3904,8 +3904,27 @@ class btree_map
     }
 
     // emplace_hint - uses hint for O(1) amortized insertion for sequential patterns (C++11) (map mode)
+    // Optimized overload for (key, value) case - avoids temporary pair construction
+    // Inlined fast path for end() hint to minimize overhead for sorted insert pattern
+    template <typename K, typename V>
+        requires(!is_set_mode && std::is_constructible_v<Key, K&&> && std::is_constructible_v<Value, V&&>)
+    [[gnu::hot]] auto emplace_hint(const_iterator hint, K&& key, V&& value) -> iterator {
+        // Fast path: hint is end() - most common case for sorted insert
+        // If key > max, insert directly at rightmost leaf (O(1) amortized)
+        if (hint._node == nullptr && _root != nullptr) [[likely]] {
+            if (_rightmost_leaf->count > 0 && _comp(_rightmost_leaf->key(_rightmost_leaf->count - 1), key)) [[likely]] {
+                auto [inserted_node, inserted_pos] =
+                  insert_and_split_impl(_rightmost_leaf, _rightmost_leaf->count, std::forward<K>(key), std::forward<V>(value));
+                ++_size;
+                return iterator(inserted_node, inserted_pos);
+            }
+        }
+        return insert_with_hint_impl(hint, std::forward<K>(key), std::forward<V>(value));
+    }
+
+    // General emplace_hint for constructing pair from arbitrary args (map mode)
     template <typename... Args>
-        requires(!is_set_mode)
+        requires(!is_set_mode && sizeof...(Args) != 2)
     auto emplace_hint(const_iterator hint, Args&&... args) -> iterator {
         std::pair<const Key, Value> val(std::forward<Args>(args)...);
         return insert_with_hint_impl(hint, std::move(const_cast<Key&>(val.first)), std::move(val.second));
@@ -3988,23 +4007,11 @@ class btree_map
         }
 
         // Fast path: check if key > max key (sequential append case)
-        // For string-like types: only check when tree has depth > 1 (comparison is expensive)
-        if constexpr (string_like<Key>) {
-            if (!_root->is_leaf_node()) {
-                if (_rightmost_leaf->count > 0 && _comp(_rightmost_leaf->key(_rightmost_leaf->count - 1), key)) {
-                    auto [inserted_node, inserted_pos] =
-                      insert_and_split_impl(_rightmost_leaf, _rightmost_leaf->count, std::forward<K>(key), std::forward<V>(value));
-                    ++_size;
-                    return {iterator(inserted_node, inserted_pos), true};
-                }
-            }
-        } else {
-            if (_rightmost_leaf->count > 0 && _comp(_rightmost_leaf->key(_rightmost_leaf->count - 1), key)) {
-                auto [inserted_node, inserted_pos] =
-                  insert_and_split_impl(_rightmost_leaf, _rightmost_leaf->count, std::forward<K>(key), std::forward<V>(value));
-                ++_size;
-                return {iterator(inserted_node, inserted_pos), true};
-            }
+        if (_rightmost_leaf->count > 0 && _comp(_rightmost_leaf->key(_rightmost_leaf->count - 1), key)) {
+            auto [inserted_node, inserted_pos] =
+              insert_and_split_impl(_rightmost_leaf, _rightmost_leaf->count, std::forward<K>(key), std::forward<V>(value));
+            ++_size;
+            return {iterator(inserted_node, inserted_pos), true};
         }
 
         // Find insertion point - traverse to leaf using specialized search
@@ -4261,7 +4268,7 @@ class btree_map
 
     // Insert with hint implementation - O(1) when hint is correct for sequential inserts
     template <typename K, typename V>
-    __attribute__((hot)) auto insert_with_hint_impl(const_iterator hint, K&& key, V&& value) -> iterator {
+    [[gnu::hot]] auto insert_with_hint_impl(const_iterator hint, K&& key, V&& value) -> iterator {
         if (_root == nullptr) [[unlikely]] {
             _root = create_leaf();
             auto* leaf = static_cast<leaf_node*>(_root);
@@ -4272,21 +4279,18 @@ class btree_map
             return iterator(leaf, 0);
         }
 
-        // Fast path: hint is end() and key > all existing keys (append case)
-        if (hint._node == nullptr) {
-            // Hint is end() - check if we can append to rightmost leaf
-            if (_rightmost_leaf != nullptr && _rightmost_leaf->count > 0) {
-                // Check if key > last key (most common case for sequential insert)
-                if (_comp(_rightmost_leaf->key(_rightmost_leaf->count - 1), key)) {
-                    // Can append at end of rightmost leaf
-                    auto [inserted_node, inserted_pos] =
-                      insert_and_split_impl(_rightmost_leaf, _rightmost_leaf->count, std::forward<K>(key), std::forward<V>(value));
-                    ++_size;
-                    return iterator(inserted_node, inserted_pos);
-                }
-            }
-        } else if (hint._node->is_leaf_node()) {
-            // Hint points to a leaf position
+        // Fast path: check if key > max key (sequential append case)
+        // This is the most common case for sorted insert - check it first regardless of hint
+        if (_rightmost_leaf->count > 0 && _comp(_rightmost_leaf->key(_rightmost_leaf->count - 1), key)) {
+            auto [inserted_node, inserted_pos] =
+              insert_and_split_impl(_rightmost_leaf, _rightmost_leaf->count, std::forward<K>(key), std::forward<V>(value));
+            ++_size;
+            return iterator(inserted_node, inserted_pos);
+        }
+
+        // Try to use hint if it points to a valid leaf position
+        // For end() hint (most common), this branch is skipped entirely
+        if (hint._node != nullptr && hint._node->is_leaf_node()) [[unlikely]] {
             auto* hint_leaf = const_cast<leaf_node*>(static_cast<const leaf_node*>(hint._node));
             size_type hint_pos = hint._pos;
 

--- a/container/vectra.hpp
+++ b/container/vectra.hpp
@@ -1104,7 +1104,9 @@ class core
     }
 
     // move [src, _finish) to [dst, dst + (_finish - src))
-    void move_backward(T* __restrict__ dst, T* __restrict__ src) {
+    // Note: dst and src ranges may overlap when called from insert()
+    // Cannot use __restrict__ as it causes UB when ranges overlap
+    void move_backward(T* dst, T* src) {
         Assert(dst != nullptr && src != nullptr, "dst and src can not be nullptr");
         // if src == _finish or src == _finish -1, just use move_forward
         Assert(src < (_finish - 1), "src should always before _finish - 1, or can not move backward");
@@ -1117,10 +1119,9 @@ class core
         T* src_end = _finish - 1;
 
         if constexpr (IsRelocatable<T>) {
-            // trivially backward move
-            for (std::size_t i = 0; i < count; ++i) {
-                *(dst_end--) = *(src_end--);
-            }
+            // memmove correctly handles both overlapping and non-overlapping ranges
+            // and is highly optimized by compilers (often as fast as memcpy for non-overlap)
+            std::memmove(dst, src, count * sizeof(T));
         } else if constexpr (std::is_move_constructible_v<T>) {
             // do not support throwable move constructor.
             static_assert(std::is_nothrow_move_constructible_v<T>);


### PR DESCRIPTION
## Summary

- Add inline fast path in `emplace_hint` for end() hint with rightmost append - O(1) amortized for sorted insert
- Unify `insert_impl` fast path (remove `string_like` restriction)
- Fix `vectra::move_backward`: use `memmove` instead of `__restrict__` loop (fixes UB when src/dst ranges overlap in `insert()`)
- Add hint insert benchmarks to btree_bench
- Enable SIMD optimizations with `-march=native` in CMakeLists.txt

## Performance Results

| Test | emplace_hint vs operator[] |
|------|---------------------------|
| Int 10K | **+4.2%** faster |
| Int 100K | **+3.9%** faster |
| String 10K | **+1.9%** faster |
| String 100K | **+1.3%** faster |

SIMD optimization reduces `find` instructions by ~10.7%.

## Test plan

- [x] All 181 test cases pass (159,472 assertions)
- [x] Benchmark shows emplace_hint faster than operator[] for sorted insert
- [x] vectra tests pass in both Debug and Release modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)