### PR TITLE
feat: add dense_map with hybrid storage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,15 +6,31 @@ project(Containa
     LANGUAGES CXX
 )
 
-# Set C++ standard
-set(CMAKE_CXX_STANDARD 20)
+# Set C++ standard (C++23 for std::flat_map)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Default to Clang compiler
+if(NOT DEFINED CMAKE_C_COMPILER AND NOT DEFINED CMAKE_CXX_COMPILER)
+    find_program(CLANG_C_COMPILER clang)
+    find_program(CLANG_CXX_COMPILER clang++)
+    if(CLANG_C_COMPILER AND CLANG_CXX_COMPILER)
+        set(CMAKE_C_COMPILER ${CLANG_C_COMPILER} CACHE STRING "C compiler" FORCE)
+        set(CMAKE_CXX_COMPILER ${CLANG_CXX_COMPILER} CACHE STRING "C++ compiler" FORCE)
+    endif()
+endif()
 
 # Compiler flags
 # Use -march=native to enable AVX2/AVX512 SIMD optimizations
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG -march=native")
 set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -DDEBUG")
+
+# Use libc++ with Clang for std::flat_map support
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_options(-stdlib=libc++)
+    add_link_options(-stdlib=libc++)
+endif()
 
 # Default build type
 if(NOT CMAKE_BUILD_TYPE)

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -24,6 +24,20 @@ add_bench_target(boolean_vector_bench boolean_vector_bench.cc)
 # Container benchmarks (small_vectra, devectra, ring_buffer)
 add_bench_target(container_bench container_bench.cc)
 
+# Dense map benchmarks
+add_executable(dense_map_bench dense_map_bench.cc)
+target_compile_definitions(dense_map_bench PRIVATE NDEBUG)
+target_link_libraries(dense_map_bench nanobench)
+if(ENABLE_ABSL_BENCH)
+    target_compile_definitions(dense_map_bench PRIVATE ENABLE_ABSL)
+    target_link_libraries(dense_map_bench absl::flat_hash_map absl::hash)
+endif()
+
+# Comprehensive dense_map benchmark (vs ankerl vs tsl)
+add_executable(dense_map_comprehensive_bench dense_map_comprehensive_bench.cc)
+target_compile_definitions(dense_map_comprehensive_bench PRIVATE NDEBUG)
+target_link_libraries(dense_map_comprehensive_bench nanobench)
+
 # Concurrent benchmark (skiplist vs btree)
 add_executable(skiplist_concurrent_bench skiplist_concurrent_bench.cc)
 target_compile_definitions(skiplist_concurrent_bench PRIVATE NDEBUG)

--- a/bench/dense_map_bench.cc
+++ b/bench/dense_map_bench.cc
@@ -76,11 +76,11 @@ void run_int_benchmark(const std::string& label) {
     std::cout << "\n=== Integer Keys: " << label << " (" << N << " elements) ===\n";
 
     // Type aliases for different policies
-    using dense_map_default = dense_map<int64_t, int64_t>;
-    using dense_map_find_opt = dense_map<int64_t, int64_t, dense_hash<int64_t>,
-                                          std::equal_to<int64_t>,
-                                          std::allocator<std::pair<int64_t, int64_t>>,
-                                          find_optimized_policy>;
+    using dense_map_default = dense_map<int64_t, int64_t>;  // flat storage (like ankerl)
+    using dense_map_inline = dense_map<int64_t, int64_t, dense_hash<int64_t>,
+                                        std::equal_to<int64_t>,
+                                        std::allocator<std::pair<int64_t, int64_t>>,
+                                        inline_storage_policy>;  // inline storage (like tsl)
 
     // ========== INSERT BENCHMARK ==========
     bench.run("dense_map insert", [&] {
@@ -90,8 +90,8 @@ void run_int_benchmark(const std::string& label) {
         ankerl::nanobench::doNotOptimizeAway(map);
     });
 
-    bench.run("dense_map (find_opt) insert", [&] {
-        dense_map_find_opt map;
+    bench.run("dense_map (inline) insert", [&] {
+        dense_map_inline map;
         map.reserve(N);
         for (auto k : keys) map[k] = k;
         ankerl::nanobench::doNotOptimizeAway(map);
@@ -197,9 +197,9 @@ void run_int_benchmark(const std::string& label) {
     dense.reserve(N);
     for (auto k : keys) dense[k] = k;
 
-    dense_map_find_opt dense_find_opt;
-    dense_find_opt.reserve(N);
-    for (auto k : keys) dense_find_opt[k] = k;
+    dense_map_inline dense_inline;
+    dense_inline.reserve(N);
+    for (auto k : keys) dense_inline[k] = k;
 
     flat_map<int64_t, int64_t> flat;
     flat.reserve(N);
@@ -233,11 +233,11 @@ void run_int_benchmark(const std::string& label) {
         ankerl::nanobench::doNotOptimizeAway(sum);
     });
 
-    bench.run("dense_map (find_opt) find (50% hit)", [&] {
+    bench.run("dense_map (inline) find (50% hit)", [&] {
         int64_t sum = 0;
         for (auto k : lookup_keys) {
-            auto it = dense_find_opt.find(k);
-            if (it != dense_find_opt.end()) sum += it->second;
+            auto it = dense_inline.find(k);
+            if (it != dense_inline.end()) sum += it->second;
         }
         ankerl::nanobench::doNotOptimizeAway(sum);
     });
@@ -270,10 +270,10 @@ void run_int_benchmark(const std::string& label) {
         ankerl::nanobench::doNotOptimizeAway(sum);
     });
 
-    bench.run("dense_map (find_opt) find (100% hit)", [&] {
+    bench.run("dense_map (inline) find (100% hit)", [&] {
         int64_t sum = 0;
         for (auto k : keys) {
-            auto it = dense_find_opt.find(k);
+            auto it = dense_inline.find(k);
             sum += it->second;
         }
         ankerl::nanobench::doNotOptimizeAway(sum);
@@ -344,9 +344,9 @@ void run_int_benchmark(const std::string& label) {
         ankerl::nanobench::doNotOptimizeAway(sum);
     });
 
-    bench.run("dense_map (find_opt) iterate", [&] {
+    bench.run("dense_map (inline) iterate", [&] {
         int64_t sum = 0;
-        for (const auto& [k, v] : dense_find_opt) {
+        for (const auto& [k, v] : dense_inline) {
             sum += v;
         }
         ankerl::nanobench::doNotOptimizeAway(sum);

--- a/bench/dense_map_bench.cc
+++ b/bench/dense_map_bench.cc
@@ -75,9 +75,23 @@ void run_int_benchmark(const std::string& label) {
 
     std::cout << "\n=== Integer Keys: " << label << " (" << N << " elements) ===\n";
 
+    // Type aliases for different policies
+    using dense_map_default = dense_map<int64_t, int64_t>;
+    using dense_map_find_opt = dense_map<int64_t, int64_t, dense_hash<int64_t>,
+                                          std::equal_to<int64_t>,
+                                          std::allocator<std::pair<int64_t, int64_t>>,
+                                          find_optimized_policy>;
+
     // ========== INSERT BENCHMARK ==========
     bench.run("dense_map insert", [&] {
-        dense_map<int64_t, int64_t> map;
+        dense_map_default map;
+        map.reserve(N);
+        for (auto k : keys) map[k] = k;
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+    bench.run("dense_map (find_opt) insert", [&] {
+        dense_map_find_opt map;
         map.reserve(N);
         for (auto k : keys) map[k] = k;
         ankerl::nanobench::doNotOptimizeAway(map);
@@ -179,9 +193,13 @@ void run_int_benchmark(const std::string& label) {
     });
 
     // ========== PREPARE MAPS FOR LOOKUP ==========
-    dense_map<int64_t, int64_t> dense;
+    dense_map_default dense;
     dense.reserve(N);
     for (auto k : keys) dense[k] = k;
+
+    dense_map_find_opt dense_find_opt;
+    dense_find_opt.reserve(N);
+    for (auto k : keys) dense_find_opt[k] = k;
 
     flat_map<int64_t, int64_t> flat;
     flat.reserve(N);
@@ -215,6 +233,15 @@ void run_int_benchmark(const std::string& label) {
         ankerl::nanobench::doNotOptimizeAway(sum);
     });
 
+    bench.run("dense_map (find_opt) find (50% hit)", [&] {
+        int64_t sum = 0;
+        for (auto k : lookup_keys) {
+            auto it = dense_find_opt.find(k);
+            if (it != dense_find_opt.end()) sum += it->second;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
     bench.run("ankerl find (50% hit)", [&] {
         int64_t sum = 0;
         for (auto k : lookup_keys) {
@@ -238,6 +265,15 @@ void run_int_benchmark(const std::string& label) {
         int64_t sum = 0;
         for (auto k : keys) {  // Use keys that all exist
             auto it = dense.find(k);
+            sum += it->second;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+    bench.run("dense_map (find_opt) find (100% hit)", [&] {
+        int64_t sum = 0;
+        for (auto k : keys) {
+            auto it = dense_find_opt.find(k);
             sum += it->second;
         }
         ankerl::nanobench::doNotOptimizeAway(sum);
@@ -303,6 +339,14 @@ void run_int_benchmark(const std::string& label) {
     bench.run("dense_map iterate", [&] {
         int64_t sum = 0;
         for (const auto& [k, v] : dense) {
+            sum += v;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+    bench.run("dense_map (find_opt) iterate", [&] {
+        int64_t sum = 0;
+        for (const auto& [k, v] : dense_find_opt) {
             sum += v;
         }
         ankerl::nanobench::doNotOptimizeAway(sum);

--- a/bench/dense_map_bench.cc
+++ b/bench/dense_map_bench.cc
@@ -1,0 +1,683 @@
+/*
+ * Copyright 2025 ClapDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define ANKERL_NANOBENCH_IMPLEMENT
+#include "../nanobench/src/include/nanobench.h"
+
+#include <iostream>
+#include <random>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "container/dense_map.hpp"
+#include "container/flat_map.hpp"
+
+// Competitors
+#include "../third_party/unordered_dense.h"  // ankerl::unordered_dense
+#include "../third_party/robin_map.h"         // tsl::robin_map
+
+#ifdef ENABLE_ABSL
+#include <absl/container/flat_hash_map.h>
+#endif
+
+using namespace stdb::container;
+
+// Generate random strings for string key benchmarks
+std::vector<std::string> generate_random_strings(size_t count, size_t min_len, size_t max_len) {
+    std::vector<std::string> result;
+    result.reserve(count);
+    std::mt19937 rng(42);
+    std::uniform_int_distribution<size_t> len_dist(min_len, max_len);
+    std::uniform_int_distribution<int> char_dist('a', 'z');
+
+    for (size_t i = 0; i < count; ++i) {
+        size_t len = len_dist(rng);
+        std::string s;
+        s.reserve(len);
+        for (size_t j = 0; j < len; ++j) {
+            s.push_back(static_cast<char>(char_dist(rng)));
+        }
+        result.push_back(std::move(s));
+    }
+    return result;
+}
+
+template <size_t N>
+void run_int_benchmark(const std::string& label) {
+    std::vector<int64_t> keys(N);
+    for (size_t i = 0; i < N; ++i) keys[i] = static_cast<int64_t>(i);
+    std::mt19937_64 rng(42);
+    std::shuffle(keys.begin(), keys.end(), rng);
+
+    // Generate lookup keys (mix of existing and non-existing)
+    std::vector<int64_t> lookup_keys(N);
+    for (size_t i = 0; i < N; ++i) {
+        lookup_keys[i] = static_cast<int64_t>(i * 2);  // 50% hit rate
+    }
+    std::shuffle(lookup_keys.begin(), lookup_keys.end(), rng);
+
+    ankerl::nanobench::Bench bench;
+    bench.warmup(3).epochs(5).relative(true);
+
+    std::cout << "\n=== Integer Keys: " << label << " (" << N << " elements) ===\n";
+
+    // ========== INSERT BENCHMARK ==========
+    bench.run("dense_map insert", [&] {
+        dense_map<int64_t, int64_t> map;
+        map.reserve(N);
+        for (auto k : keys) map[k] = k;
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+    bench.run("flat_map insert", [&] {
+        flat_map<int64_t, int64_t> map;
+        map.reserve(N);
+        for (auto k : keys) map[k] = k;
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+    bench.run("ankerl::unordered_dense insert", [&] {
+        ankerl::unordered_dense::map<int64_t, int64_t> map;
+        map.reserve(N);
+        for (auto k : keys) map[k] = k;
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+    bench.run("tsl::robin_map insert", [&] {
+        tsl::robin_map<int64_t, int64_t> map;
+        map.reserve(N);
+        for (auto k : keys) map[k] = k;
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+#ifdef ENABLE_ABSL
+    bench.run("absl::flat_hash_map insert", [&] {
+        absl::flat_hash_map<int64_t, int64_t> map;
+        map.reserve(N);
+        for (auto k : keys) map[k] = k;
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+#endif
+
+    bench.run("std::unordered_map insert", [&] {
+        std::unordered_map<int64_t, int64_t> map;
+        map.reserve(N);
+        for (auto k : keys) map[k] = k;
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+    // ========== TRY_EMPLACE BENCHMARK ==========
+    bench.run("dense_map try_emplace", [&] {
+        dense_map<int64_t, int64_t> map;
+        map.reserve(N);
+        for (auto k : keys) map.try_emplace(k, k);
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+    bench.run("ankerl::unordered_dense try_emplace", [&] {
+        ankerl::unordered_dense::map<int64_t, int64_t> map;
+        map.reserve(N);
+        for (auto k : keys) map.try_emplace(k, k);
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+    bench.run("tsl::robin_map try_emplace", [&] {
+        tsl::robin_map<int64_t, int64_t> map;
+        map.reserve(N);
+        for (auto k : keys) map.try_emplace(k, k);
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+    bench.run("std::unordered_map try_emplace", [&] {
+        std::unordered_map<int64_t, int64_t> map;
+        map.reserve(N);
+        for (auto k : keys) map.try_emplace(k, k);
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+    // ========== EMPLACE BENCHMARK ==========
+    bench.run("dense_map emplace", [&] {
+        dense_map<int64_t, int64_t> map;
+        map.reserve(N);
+        for (auto k : keys) map.emplace(k, k);
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+    bench.run("ankerl::unordered_dense emplace", [&] {
+        ankerl::unordered_dense::map<int64_t, int64_t> map;
+        map.reserve(N);
+        for (auto k : keys) map.emplace(k, k);
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+    bench.run("tsl::robin_map emplace", [&] {
+        tsl::robin_map<int64_t, int64_t> map;
+        map.reserve(N);
+        for (auto k : keys) map.emplace(k, k);
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+    bench.run("std::unordered_map emplace", [&] {
+        std::unordered_map<int64_t, int64_t> map;
+        map.reserve(N);
+        for (auto k : keys) map.emplace(k, k);
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+    // ========== PREPARE MAPS FOR LOOKUP ==========
+    dense_map<int64_t, int64_t> dense;
+    dense.reserve(N);
+    for (auto k : keys) dense[k] = k;
+
+    flat_map<int64_t, int64_t> flat;
+    flat.reserve(N);
+    for (auto k : keys) flat[k] = k;
+
+    ankerl::unordered_dense::map<int64_t, int64_t> ankerl_map;
+    ankerl_map.reserve(N);
+    for (auto k : keys) ankerl_map[k] = k;
+
+    tsl::robin_map<int64_t, int64_t> robin;
+    robin.reserve(N);
+    for (auto k : keys) robin[k] = k;
+
+#ifdef ENABLE_ABSL
+    absl::flat_hash_map<int64_t, int64_t> absl_map;
+    absl_map.reserve(N);
+    for (auto k : keys) absl_map[k] = k;
+#endif
+
+    std::unordered_map<int64_t, int64_t> std_map;
+    std_map.reserve(N);
+    for (auto k : keys) std_map[k] = k;
+
+    // ========== FIND BENCHMARK (50% hit rate) ==========
+    bench.run("dense_map find (50% hit)", [&] {
+        int64_t sum = 0;
+        for (auto k : lookup_keys) {
+            auto it = dense.find(k);
+            if (it != dense.end()) sum += it->second;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+    bench.run("ankerl find (50% hit)", [&] {
+        int64_t sum = 0;
+        for (auto k : lookup_keys) {
+            auto it = ankerl_map.find(k);
+            if (it != ankerl_map.end()) sum += it->second;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+    bench.run("tsl::robin find (50% hit)", [&] {
+        int64_t sum = 0;
+        for (auto k : lookup_keys) {
+            auto it = robin.find(k);
+            if (it != robin.end()) sum += it->second;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+    // ========== FIND BENCHMARK (100% hit rate) ==========
+    bench.run("dense_map find (100% hit)", [&] {
+        int64_t sum = 0;
+        for (auto k : keys) {  // Use keys that all exist
+            auto it = dense.find(k);
+            sum += it->second;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+    bench.run("ankerl find (100% hit)", [&] {
+        int64_t sum = 0;
+        for (auto k : keys) {
+            auto it = ankerl_map.find(k);
+            sum += it->second;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+    bench.run("tsl::robin find (100% hit)", [&] {
+        int64_t sum = 0;
+        for (auto k : keys) {
+            auto it = robin.find(k);
+            sum += it->second;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+    bench.run("flat_map find", [&] {
+        int64_t sum = 0;
+        for (auto k : lookup_keys) {
+            auto it = flat.find(k);
+            if (it != flat.end()) sum += it->second;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+    bench.run("tsl::robin_map find", [&] {
+        int64_t sum = 0;
+        for (auto k : lookup_keys) {
+            auto it = robin.find(k);
+            if (it != robin.end()) sum += it->second;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+#ifdef ENABLE_ABSL
+    bench.run("absl::flat_hash_map find", [&] {
+        int64_t sum = 0;
+        for (auto k : lookup_keys) {
+            auto it = absl_map.find(k);
+            if (it != absl_map.end()) sum += it->second;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+#endif
+
+    bench.run("std::unordered_map find", [&] {
+        int64_t sum = 0;
+        for (auto k : lookup_keys) {
+            auto it = std_map.find(k);
+            if (it != std_map.end()) sum += it->second;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+    // ========== ITERATION BENCHMARK ==========
+    bench.run("dense_map iterate", [&] {
+        int64_t sum = 0;
+        for (const auto& [k, v] : dense) {
+            sum += v;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+    bench.run("flat_map iterate", [&] {
+        int64_t sum = 0;
+        for (const auto& [k, v] : flat) {
+            sum += v;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+    bench.run("ankerl::unordered_dense iterate", [&] {
+        int64_t sum = 0;
+        for (const auto& [k, v] : ankerl_map) {
+            sum += v;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+    bench.run("tsl::robin_map iterate", [&] {
+        int64_t sum = 0;
+        for (const auto& [k, v] : robin) {
+            sum += v;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+#ifdef ENABLE_ABSL
+    bench.run("absl::flat_hash_map iterate", [&] {
+        int64_t sum = 0;
+        for (const auto& [k, v] : absl_map) {
+            sum += v;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+#endif
+
+    bench.run("std::unordered_map iterate", [&] {
+        int64_t sum = 0;
+        for (const auto& [k, v] : std_map) {
+            sum += v;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+
+    // ========== ERASE BENCHMARK ==========
+    bench.run("dense_map erase", [&] {
+        dense_map<int64_t, int64_t> map;
+        map.reserve(N);
+        for (auto k : keys) map[k] = k;
+        for (size_t i = 0; i < N / 2; ++i) {
+            map.erase(keys[i]);
+        }
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+    bench.run("flat_map erase", [&] {
+        flat_map<int64_t, int64_t> map;
+        map.reserve(N);
+        for (auto k : keys) map[k] = k;
+        for (size_t i = 0; i < N / 2; ++i) {
+            map.erase(keys[i]);
+        }
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+    bench.run("ankerl::unordered_dense erase", [&] {
+        ankerl::unordered_dense::map<int64_t, int64_t> map;
+        map.reserve(N);
+        for (auto k : keys) map[k] = k;
+        for (size_t i = 0; i < N / 2; ++i) {
+            map.erase(keys[i]);
+        }
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+    bench.run("tsl::robin_map erase", [&] {
+        tsl::robin_map<int64_t, int64_t> map;
+        map.reserve(N);
+        for (auto k : keys) map[k] = k;
+        for (size_t i = 0; i < N / 2; ++i) {
+            map.erase(keys[i]);
+        }
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+#ifdef ENABLE_ABSL
+    bench.run("absl::flat_hash_map erase", [&] {
+        absl::flat_hash_map<int64_t, int64_t> map;
+        map.reserve(N);
+        for (auto k : keys) map[k] = k;
+        for (size_t i = 0; i < N / 2; ++i) {
+            map.erase(keys[i]);
+        }
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+#endif
+
+    bench.run("std::unordered_map erase", [&] {
+        std::unordered_map<int64_t, int64_t> map;
+        map.reserve(N);
+        for (auto k : keys) map[k] = k;
+        for (size_t i = 0; i < N / 2; ++i) {
+            map.erase(keys[i]);
+        }
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+}
+
+template <size_t N>
+void run_string_benchmark(const std::string& label, size_t key_len) {
+    auto keys = generate_random_strings(N, key_len, key_len);
+
+    ankerl::nanobench::Bench bench;
+    bench.warmup(3).epochs(5).relative(true);
+
+    std::cout << "\n=== String Keys (" << key_len << " chars): " << label
+              << " (" << N << " elements) ===\n";
+
+    // ========== INSERT ==========
+    bench.run("dense_map insert", [&] {
+        dense_map<std::string, int64_t> map;
+        map.reserve(N);
+        int64_t v = 0;
+        for (const auto& k : keys) map[k] = v++;
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+    bench.run("flat_map insert", [&] {
+        flat_map<std::string, int64_t> map;
+        map.reserve(N);
+        int64_t v = 0;
+        for (const auto& k : keys) map[k] = v++;
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+    bench.run("ankerl::unordered_dense insert", [&] {
+        ankerl::unordered_dense::map<std::string, int64_t> map;
+        map.reserve(N);
+        int64_t v = 0;
+        for (const auto& k : keys) map[k] = v++;
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+    bench.run("tsl::robin_map insert", [&] {
+        tsl::robin_map<std::string, int64_t> map;
+        map.reserve(N);
+        int64_t v = 0;
+        for (const auto& k : keys) map[k] = v++;
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+#ifdef ENABLE_ABSL
+    bench.run("absl::flat_hash_map insert", [&] {
+        absl::flat_hash_map<std::string, int64_t> map;
+        map.reserve(N);
+        int64_t v = 0;
+        for (const auto& k : keys) map[k] = v++;
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+#endif
+
+    bench.run("std::unordered_map insert", [&] {
+        std::unordered_map<std::string, int64_t> map;
+        map.reserve(N);
+        int64_t v = 0;
+        for (const auto& k : keys) map[k] = v++;
+        ankerl::nanobench::doNotOptimizeAway(map);
+    });
+
+
+    // Prepare maps
+    dense_map<std::string, int64_t> dense;
+    dense.reserve(N);
+    int64_t v = 0;
+    for (const auto& k : keys) dense[k] = v++;
+
+    flat_map<std::string, int64_t> flat;
+    flat.reserve(N);
+    v = 0;
+    for (const auto& k : keys) flat[k] = v++;
+
+    ankerl::unordered_dense::map<std::string, int64_t> ankerl_map;
+    ankerl_map.reserve(N);
+    v = 0;
+    for (const auto& k : keys) ankerl_map[k] = v++;
+
+    tsl::robin_map<std::string, int64_t> robin;
+    robin.reserve(N);
+    v = 0;
+    for (const auto& k : keys) robin[k] = v++;
+
+#ifdef ENABLE_ABSL
+    absl::flat_hash_map<std::string, int64_t> absl_map;
+    absl_map.reserve(N);
+    v = 0;
+    for (const auto& k : keys) absl_map[k] = v++;
+#endif
+
+    std::unordered_map<std::string, int64_t> std_map;
+    std_map.reserve(N);
+    v = 0;
+    for (const auto& k : keys) std_map[k] = v++;
+
+
+    // ========== FIND ==========
+    bench.run("dense_map find", [&] {
+        int64_t sum = 0;
+        for (const auto& k : keys) {
+            auto it = dense.find(k);
+            if (it != dense.end()) sum += it->second;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+    bench.run("flat_map find", [&] {
+        int64_t sum = 0;
+        for (const auto& k : keys) {
+            auto it = flat.find(k);
+            if (it != flat.end()) sum += it->second;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+    bench.run("ankerl::unordered_dense find", [&] {
+        int64_t sum = 0;
+        for (const auto& k : keys) {
+            auto it = ankerl_map.find(k);
+            if (it != ankerl_map.end()) sum += it->second;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+    bench.run("tsl::robin_map find", [&] {
+        int64_t sum = 0;
+        for (const auto& k : keys) {
+            auto it = robin.find(k);
+            if (it != robin.end()) sum += it->second;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+#ifdef ENABLE_ABSL
+    bench.run("absl::flat_hash_map find", [&] {
+        int64_t sum = 0;
+        for (const auto& k : keys) {
+            auto it = absl_map.find(k);
+            if (it != absl_map.end()) sum += it->second;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+#endif
+
+    bench.run("std::unordered_map find", [&] {
+        int64_t sum = 0;
+        for (const auto& k : keys) {
+            auto it = std_map.find(k);
+            if (it != std_map.end()) sum += it->second;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+
+    // ========== ITERATION ==========
+    bench.run("dense_map iterate", [&] {
+        int64_t sum = 0;
+        for (const auto& [k, v] : dense) {
+            sum += v;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+    bench.run("flat_map iterate", [&] {
+        int64_t sum = 0;
+        for (const auto& [k, v] : flat) {
+            sum += v;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+    bench.run("ankerl::unordered_dense iterate", [&] {
+        int64_t sum = 0;
+        for (const auto& [k, v] : ankerl_map) {
+            sum += v;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+    bench.run("tsl::robin_map iterate", [&] {
+        int64_t sum = 0;
+        for (const auto& [k, v] : robin) {
+            sum += v;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+#ifdef ENABLE_ABSL
+    bench.run("absl::flat_hash_map iterate", [&] {
+        int64_t sum = 0;
+        for (const auto& [k, v] : absl_map) {
+            sum += v;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+#endif
+
+    bench.run("std::unordered_map iterate", [&] {
+        int64_t sum = 0;
+        for (const auto& [k, v] : std_map) {
+            sum += v;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+}
+
+void run_memory_benchmark() {
+    std::cout << "\n=== Memory Usage Comparison (100K int64 -> int64) ===\n";
+
+    constexpr size_t N = 100000;
+    std::vector<int64_t> keys(N);
+    for (size_t i = 0; i < N; ++i) keys[i] = static_cast<int64_t>(i);
+
+    dense_map<int64_t, int64_t> dense;
+    for (auto k : keys) dense[k] = k;
+
+    ankerl::unordered_dense::map<int64_t, int64_t> ankerl_map;
+    for (auto k : keys) ankerl_map[k] = k;
+
+    tsl::robin_map<int64_t, int64_t> robin;
+    for (auto k : keys) robin[k] = k;
+
+    std::unordered_map<int64_t, int64_t> std_map;
+    for (auto k : keys) std_map[k] = k;
+
+    // Estimate memory
+    size_t dense_mem = dense.capacity() * (sizeof(std::pair<int64_t, int64_t>) + 1);
+    size_t ankerl_mem = ankerl_map.size() * sizeof(std::pair<int64_t, int64_t>) +
+                        ankerl_map.bucket_count() * sizeof(uint32_t);
+    size_t robin_mem = robin.bucket_count() * (sizeof(std::pair<int64_t, int64_t>) + 1);
+    size_t std_mem = std_map.bucket_count() * sizeof(void*) +
+                     std_map.size() * (sizeof(std::pair<int64_t, int64_t>) + sizeof(void*) * 2);
+
+    std::cout << "dense_map:             " << dense_mem / 1024 << " KB (capacity=" << dense.capacity()
+              << ", load=" << dense.load_factor() << ")\n";
+    std::cout << "ankerl::unordered_dense: " << ankerl_mem / 1024 << " KB (size=" << ankerl_map.size()
+              << ", buckets=" << ankerl_map.bucket_count() << ")\n";
+    std::cout << "tsl::robin_map:        " << robin_mem / 1024 << " KB (buckets=" << robin.bucket_count()
+              << ", load=" << robin.load_factor() << ")\n";
+    std::cout << "std::unordered_map:    " << std_mem / 1024 << " KB (buckets=" << std_map.bucket_count()
+              << ", load=" << std_map.load_factor() << ")\n";
+}
+
+int main() {
+    std::cout << "=== Dense Map Benchmark vs Top Hash Maps ===\n";
+    std::cout << "Competitors: ankerl::unordered_dense, tsl::robin_map";
+#ifdef ENABLE_ABSL
+    std::cout << ", absl::flat_hash_map";
+#endif
+    std::cout << ", std::unordered_map\n";
+
+    // Integer key benchmarks
+    run_int_benchmark<10000>("10K");
+    run_int_benchmark<100000>("100K");
+    run_int_benchmark<1000000>("1M");
+
+    // String key benchmarks
+    run_string_benchmark<100000>("100K", 16);
+
+    // Memory comparison
+    run_memory_benchmark();
+
+    return 0;
+}

--- a/bench/dense_map_comprehensive_bench.cc
+++ b/bench/dense_map_comprehensive_bench.cc
@@ -1,0 +1,1036 @@
+/*
+ * Comprehensive Benchmark: dense_map vs ankerl::unordered_dense vs tsl::robin_map
+ *
+ * Tests across:
+ * - Key types: int32, int64, string (short/medium/long)
+ * - Value types: int64, string, large struct
+ * - Data distributions: sequential, random, clustered, skewed
+ * - Operations: insert, find (100%/50%/0% hit), iterate
+ */
+
+#define ANKERL_NANOBENCH_IMPLEMENT
+#include "../nanobench/src/include/nanobench.h"
+
+#include <algorithm>
+#include <array>
+#include <iomanip>
+#include <iostream>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "container/dense_map.hpp"
+#include "../third_party/unordered_dense.h"
+#include "../third_party/robin_map.h"
+
+using namespace stdb::container;
+
+// ============================================================================
+// Large Value Type (128 bytes)
+// ============================================================================
+struct LargeValue {
+    std::array<uint64_t, 16> data;
+    LargeValue() : data{} {}
+    LargeValue(uint64_t v) { for (auto& d : data) d = v; }
+    bool operator==(const LargeValue& o) const { return data == o.data; }
+};
+
+// ============================================================================
+// Data Generators
+// ============================================================================
+template<typename T>
+std::vector<T> gen_sequential(size_t n) {
+    std::vector<T> keys(n);
+    for (size_t i = 0; i < n; ++i) keys[i] = static_cast<T>(i);
+    return keys;
+}
+
+template<typename T>
+std::vector<T> gen_random(size_t n, uint64_t seed = 42) {
+    auto keys = gen_sequential<T>(n);
+    std::mt19937_64 rng(seed);
+    std::shuffle(keys.begin(), keys.end(), rng);
+    return keys;
+}
+
+template<typename T>
+std::vector<T> gen_clustered(size_t n, uint64_t seed = 42) {
+    std::vector<T> keys;
+    keys.reserve(n);
+    std::mt19937_64 rng(seed);
+    T base = 0;
+    while (keys.size() < n) {
+        for (size_t i = 0; i < 100 && keys.size() < n; ++i) {
+            keys.push_back(base + static_cast<T>(i));
+        }
+        base += static_cast<T>(100 + rng() % 10000);
+    }
+    std::shuffle(keys.begin(), keys.end(), rng);
+    return keys;
+}
+
+std::vector<std::string> gen_strings(size_t n, size_t len, uint64_t seed = 42) {
+    std::vector<std::string> keys;
+    keys.reserve(n);
+    std::mt19937_64 rng(seed);
+    std::uniform_int_distribution<int> dist('a', 'z');
+    for (size_t i = 0; i < n; ++i) {
+        std::string s(len, ' ');
+        for (auto& c : s) c = static_cast<char>(dist(rng));
+        keys.push_back(std::move(s));
+    }
+    return keys;
+}
+
+// ============================================================================
+// Result Storage
+// ============================================================================
+struct Result {
+    std::string name;
+    double dense_ns, ankerl_ns, tsl_ns;
+};
+std::vector<Result> g_results;
+
+void record(const std::string& name, double d, double a, double t) {
+    g_results.push_back({name, d, a, t});
+}
+
+// ============================================================================
+// Benchmark Helpers
+// ============================================================================
+#define BENCH_INSERT(Name, KeyType, ValType, keys, gen_val) do { \
+    const size_t N = keys.size(); \
+    double d_time = 0, a_time = 0, t_time = 0; \
+    bench.run("dense " Name, [&] { \
+        dense_map<KeyType, ValType> m; m.reserve(N); \
+        for (size_t i = 0; i < N; ++i) m[keys[i]] = gen_val(i); \
+        ankerl::nanobench::doNotOptimizeAway(m); \
+    }); d_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9; \
+    bench.run("ankerl " Name, [&] { \
+        ankerl::unordered_dense::map<KeyType, ValType> m; m.reserve(N); \
+        for (size_t i = 0; i < N; ++i) m[keys[i]] = gen_val(i); \
+        ankerl::nanobench::doNotOptimizeAway(m); \
+    }); a_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9; \
+    bench.run("tsl " Name, [&] { \
+        tsl::robin_map<KeyType, ValType> m; m.reserve(N); \
+        for (size_t i = 0; i < N; ++i) m[keys[i]] = gen_val(i); \
+        ankerl::nanobench::doNotOptimizeAway(m); \
+    }); t_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9; \
+    record(std::string(Name) + " insert", d_time, a_time, t_time); \
+} while(0)
+
+#define BENCH_FIND(Name, dense, ankerl_m, tsl_m, lookup) do { \
+    double d_time = 0, a_time = 0, t_time = 0; \
+    bench.run("dense find " Name, [&] { \
+        int64_t sum = 0; \
+        for (const auto& k : lookup) { auto it = dense.find(k); if (it != dense.end()) sum++; } \
+        ankerl::nanobench::doNotOptimizeAway(sum); \
+    }); d_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9; \
+    bench.run("ankerl find " Name, [&] { \
+        int64_t sum = 0; \
+        for (const auto& k : lookup) { auto it = ankerl_m.find(k); if (it != ankerl_m.end()) sum++; } \
+        ankerl::nanobench::doNotOptimizeAway(sum); \
+    }); a_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9; \
+    bench.run("tsl find " Name, [&] { \
+        int64_t sum = 0; \
+        for (const auto& k : lookup) { auto it = tsl_m.find(k); if (it != tsl_m.end()) sum++; } \
+        ankerl::nanobench::doNotOptimizeAway(sum); \
+    }); t_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9; \
+    record(std::string(Name) + " find", d_time, a_time, t_time); \
+} while(0)
+
+#define BENCH_ITER(Name, dense, ankerl_m, tsl_m) do { \
+    double d_time = 0, a_time = 0, t_time = 0; \
+    bench.run("dense iter " Name, [&] { \
+        int64_t sum = 0; for (const auto& [k,v] : dense) sum++; \
+        ankerl::nanobench::doNotOptimizeAway(sum); \
+    }); d_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9; \
+    bench.run("ankerl iter " Name, [&] { \
+        int64_t sum = 0; for (const auto& [k,v] : ankerl_m) sum++; \
+        ankerl::nanobench::doNotOptimizeAway(sum); \
+    }); a_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9; \
+    bench.run("tsl iter " Name, [&] { \
+        int64_t sum = 0; for (const auto& [k,v] : tsl_m) sum++; \
+        ankerl::nanobench::doNotOptimizeAway(sum); \
+    }); t_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9; \
+    record(std::string(Name) + " iterate", d_time, a_time, t_time); \
+} while(0)
+
+#define BENCH_ERASE(Name, KeyType, ValType, keys, gen_val) do { \
+    const size_t N = keys.size(); \
+    double d_time = 0, a_time = 0, t_time = 0; \
+    bench.run("dense erase " Name, [&] { \
+        dense_map<KeyType, ValType> m; m.reserve(N); \
+        for (size_t i = 0; i < N; ++i) m[keys[i]] = gen_val(i); \
+        for (size_t i = 0; i < N; ++i) m.erase(keys[i]); \
+        ankerl::nanobench::doNotOptimizeAway(m.size()); \
+    }); d_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9; \
+    bench.run("ankerl erase " Name, [&] { \
+        ankerl::unordered_dense::map<KeyType, ValType> m; m.reserve(N); \
+        for (size_t i = 0; i < N; ++i) m[keys[i]] = gen_val(i); \
+        for (size_t i = 0; i < N; ++i) m.erase(keys[i]); \
+        ankerl::nanobench::doNotOptimizeAway(m.size()); \
+    }); a_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9; \
+    bench.run("tsl erase " Name, [&] { \
+        tsl::robin_map<KeyType, ValType> m; m.reserve(N); \
+        for (size_t i = 0; i < N; ++i) m[keys[i]] = gen_val(i); \
+        for (size_t i = 0; i < N; ++i) m.erase(keys[i]); \
+        ankerl::nanobench::doNotOptimizeAway(m.size()); \
+    }); t_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9; \
+    record(std::string(Name) + " erase", d_time, a_time, t_time); \
+} while(0)
+
+// ============================================================================
+// Test Functions
+// ============================================================================
+
+void test_int_keys() {
+    std::cout << "\n=== INT KEY TESTS (N=100K) ===\n";
+    constexpr size_t N = 100000;
+    ankerl::nanobench::Bench bench;
+    bench.warmup(3).epochs(5).relative(true);
+    auto gen_val = [](size_t i) { return static_cast<int64_t>(i); };
+
+    // int32 -> int64
+    {
+        auto keys = gen_random<int32_t>(N);
+        BENCH_INSERT("int32->i64", int32_t, int64_t, keys, gen_val);
+
+        dense_map<int32_t, int64_t> dm; dm.reserve(N);
+        ankerl::unordered_dense::map<int32_t, int64_t> am; am.reserve(N);
+        tsl::robin_map<int32_t, int64_t> tm; tm.reserve(N);
+        for (size_t i = 0; i < N; ++i) { dm[keys[i]] = gen_val(i); am[keys[i]] = gen_val(i); tm[keys[i]] = gen_val(i); }
+
+        BENCH_FIND("int32->i64", dm, am, tm, keys);
+        BENCH_ITER("int32->i64", dm, am, tm);
+    }
+
+    // int64 -> int64
+    {
+        auto keys = gen_random<int64_t>(N);
+        BENCH_INSERT("int64->i64", int64_t, int64_t, keys, gen_val);
+
+        dense_map<int64_t, int64_t> dm; dm.reserve(N);
+        ankerl::unordered_dense::map<int64_t, int64_t> am; am.reserve(N);
+        tsl::robin_map<int64_t, int64_t> tm; tm.reserve(N);
+        for (size_t i = 0; i < N; ++i) { dm[keys[i]] = gen_val(i); am[keys[i]] = gen_val(i); tm[keys[i]] = gen_val(i); }
+
+        BENCH_FIND("int64->i64", dm, am, tm, keys);
+        BENCH_ITER("int64->i64", dm, am, tm);
+    }
+}
+
+void test_string_keys() {
+    std::cout << "\n=== STRING KEY TESTS (N=100K) ===\n";
+    constexpr size_t N = 100000;
+    ankerl::nanobench::Bench bench;
+    bench.warmup(3).epochs(5).relative(true);
+    auto gen_val = [](size_t i) { return static_cast<int64_t>(i); };
+
+    // Short strings (8 chars - SSO)
+    {
+        auto keys = gen_strings(N, 8);
+        BENCH_INSERT("str8->i64", std::string, int64_t, keys, gen_val);
+
+        dense_map<std::string, int64_t> dm; dm.reserve(N);
+        ankerl::unordered_dense::map<std::string, int64_t> am; am.reserve(N);
+        tsl::robin_map<std::string, int64_t> tm; tm.reserve(N);
+        for (size_t i = 0; i < N; ++i) { dm[keys[i]] = gen_val(i); am[keys[i]] = gen_val(i); tm[keys[i]] = gen_val(i); }
+
+        BENCH_FIND("str8->i64", dm, am, tm, keys);
+        BENCH_ITER("str8->i64", dm, am, tm);
+    }
+
+    // Medium strings (32 chars)
+    {
+        auto keys = gen_strings(N, 32);
+        BENCH_INSERT("str32->i64", std::string, int64_t, keys, gen_val);
+
+        dense_map<std::string, int64_t> dm; dm.reserve(N);
+        ankerl::unordered_dense::map<std::string, int64_t> am; am.reserve(N);
+        tsl::robin_map<std::string, int64_t> tm; tm.reserve(N);
+        for (size_t i = 0; i < N; ++i) { dm[keys[i]] = gen_val(i); am[keys[i]] = gen_val(i); tm[keys[i]] = gen_val(i); }
+
+        BENCH_FIND("str32->i64", dm, am, tm, keys);
+        BENCH_ITER("str32->i64", dm, am, tm);
+    }
+
+    // Long strings (128 chars)
+    {
+        auto keys = gen_strings(N, 128);
+        BENCH_INSERT("str128->i64", std::string, int64_t, keys, gen_val);
+
+        dense_map<std::string, int64_t> dm; dm.reserve(N);
+        ankerl::unordered_dense::map<std::string, int64_t> am; am.reserve(N);
+        tsl::robin_map<std::string, int64_t> tm; tm.reserve(N);
+        for (size_t i = 0; i < N; ++i) { dm[keys[i]] = gen_val(i); am[keys[i]] = gen_val(i); tm[keys[i]] = gen_val(i); }
+
+        BENCH_FIND("str128->i64", dm, am, tm, keys);
+        BENCH_ITER("str128->i64", dm, am, tm);
+    }
+}
+
+void test_value_types() {
+    std::cout << "\n=== VALUE TYPE TESTS (Key=int64, N=100K) ===\n";
+    constexpr size_t N = 100000;
+    ankerl::nanobench::Bench bench;
+    bench.warmup(3).epochs(5).relative(true);
+    auto keys = gen_random<int64_t>(N);
+
+    // int64 -> string
+    {
+        auto gen_val = [](size_t i) { return "value_" + std::to_string(i); };
+        BENCH_INSERT("i64->string", int64_t, std::string, keys, gen_val);
+
+        dense_map<int64_t, std::string> dm; dm.reserve(N);
+        ankerl::unordered_dense::map<int64_t, std::string> am; am.reserve(N);
+        tsl::robin_map<int64_t, std::string> tm; tm.reserve(N);
+        for (size_t i = 0; i < N; ++i) { dm[keys[i]] = gen_val(i); am[keys[i]] = gen_val(i); tm[keys[i]] = gen_val(i); }
+
+        BENCH_FIND("i64->string", dm, am, tm, keys);
+        BENCH_ITER("i64->string", dm, am, tm);
+    }
+
+    // int64 -> LargeValue (128 bytes)
+    {
+        auto gen_val = [](size_t i) { return LargeValue(static_cast<uint64_t>(i)); };
+        BENCH_INSERT("i64->Large128B", int64_t, LargeValue, keys, gen_val);
+
+        dense_map<int64_t, LargeValue> dm; dm.reserve(N);
+        ankerl::unordered_dense::map<int64_t, LargeValue> am; am.reserve(N);
+        tsl::robin_map<int64_t, LargeValue> tm; tm.reserve(N);
+        for (size_t i = 0; i < N; ++i) { dm[keys[i]] = gen_val(i); am[keys[i]] = gen_val(i); tm[keys[i]] = gen_val(i); }
+
+        BENCH_FIND("i64->Large128B", dm, am, tm, keys);
+        BENCH_ITER("i64->Large128B", dm, am, tm);
+    }
+}
+
+void test_distributions() {
+    std::cout << "\n=== DATA DISTRIBUTION TESTS (int64->int64, N=100K) ===\n";
+    constexpr size_t N = 100000;
+    ankerl::nanobench::Bench bench;
+    bench.warmup(3).epochs(5).relative(true);
+    auto gen_val = [](size_t i) { return static_cast<int64_t>(i); };
+
+    // Sequential
+    {
+        auto keys = gen_sequential<int64_t>(N);
+        BENCH_INSERT("Sequential", int64_t, int64_t, keys, gen_val);
+
+        dense_map<int64_t, int64_t> dm; dm.reserve(N);
+        ankerl::unordered_dense::map<int64_t, int64_t> am; am.reserve(N);
+        tsl::robin_map<int64_t, int64_t> tm; tm.reserve(N);
+        for (size_t i = 0; i < N; ++i) { dm[keys[i]] = gen_val(i); am[keys[i]] = gen_val(i); tm[keys[i]] = gen_val(i); }
+
+        BENCH_FIND("Sequential", dm, am, tm, keys);
+    }
+
+    // Random
+    {
+        auto keys = gen_random<int64_t>(N);
+        BENCH_INSERT("Random", int64_t, int64_t, keys, gen_val);
+
+        dense_map<int64_t, int64_t> dm; dm.reserve(N);
+        ankerl::unordered_dense::map<int64_t, int64_t> am; am.reserve(N);
+        tsl::robin_map<int64_t, int64_t> tm; tm.reserve(N);
+        for (size_t i = 0; i < N; ++i) { dm[keys[i]] = gen_val(i); am[keys[i]] = gen_val(i); tm[keys[i]] = gen_val(i); }
+
+        BENCH_FIND("Random", dm, am, tm, keys);
+    }
+
+    // Clustered
+    {
+        auto keys = gen_clustered<int64_t>(N);
+        BENCH_INSERT("Clustered", int64_t, int64_t, keys, gen_val);
+
+        dense_map<int64_t, int64_t> dm; dm.reserve(N);
+        ankerl::unordered_dense::map<int64_t, int64_t> am; am.reserve(N);
+        tsl::robin_map<int64_t, int64_t> tm; tm.reserve(N);
+        for (size_t i = 0; i < N; ++i) { dm[keys[i]] = gen_val(i); am[keys[i]] = gen_val(i); tm[keys[i]] = gen_val(i); }
+
+        BENCH_FIND("Clustered", dm, am, tm, keys);
+    }
+}
+
+void test_hit_rates() {
+    std::cout << "\n=== FIND HIT RATE TESTS (int64->int64, N=100K) ===\n";
+    constexpr size_t N = 100000;
+    ankerl::nanobench::Bench bench;
+    bench.warmup(3).epochs(5).relative(true);
+
+    auto keys = gen_random<int64_t>(N);
+
+    dense_map<int64_t, int64_t> dm; dm.reserve(N);
+    ankerl::unordered_dense::map<int64_t, int64_t> am; am.reserve(N);
+    tsl::robin_map<int64_t, int64_t> tm; tm.reserve(N);
+    for (size_t i = 0; i < N; ++i) {
+        dm[keys[i]] = static_cast<int64_t>(i);
+        am[keys[i]] = static_cast<int64_t>(i);
+        tm[keys[i]] = static_cast<int64_t>(i);
+    }
+
+    // 100% hit
+    BENCH_FIND("100%hit", dm, am, tm, keys);
+
+    // 50% hit
+    std::vector<int64_t> keys_50;
+    keys_50.reserve(N);
+    std::mt19937_64 rng(123);
+    for (size_t i = 0; i < N; ++i) {
+        keys_50.push_back(i % 2 == 0 ? keys[i] : static_cast<int64_t>(N + rng()));
+    }
+    BENCH_FIND("50%hit", dm, am, tm, keys_50);
+
+    // 0% hit
+    std::vector<int64_t> keys_0;
+    keys_0.reserve(N);
+    for (size_t i = 0; i < N; ++i) keys_0.push_back(static_cast<int64_t>(N * 2 + i));
+    BENCH_FIND("0%hit", dm, am, tm, keys_0);
+}
+
+void test_scale() {
+    std::cout << "\n=== SCALE TESTS (int64->int64, Random) ===\n";
+    auto gen_val = [](size_t i) { return static_cast<int64_t>(i); };
+
+    // 10K
+    {
+        constexpr size_t N = 10000;
+        ankerl::nanobench::Bench bench;
+        bench.warmup(2).epochs(3).relative(true);
+        auto keys = gen_random<int64_t>(N);
+        BENCH_INSERT("10K", int64_t, int64_t, keys, gen_val);
+
+        dense_map<int64_t, int64_t> dm; dm.reserve(N);
+        ankerl::unordered_dense::map<int64_t, int64_t> am; am.reserve(N);
+        tsl::robin_map<int64_t, int64_t> tm; tm.reserve(N);
+        for (size_t i = 0; i < N; ++i) { dm[keys[i]] = gen_val(i); am[keys[i]] = gen_val(i); tm[keys[i]] = gen_val(i); }
+        BENCH_FIND("10K", dm, am, tm, keys);
+        BENCH_ITER("10K", dm, am, tm);
+    }
+
+    // 100K
+    {
+        constexpr size_t N = 100000;
+        ankerl::nanobench::Bench bench;
+        bench.warmup(2).epochs(3).relative(true);
+        auto keys = gen_random<int64_t>(N);
+        BENCH_INSERT("100K", int64_t, int64_t, keys, gen_val);
+
+        dense_map<int64_t, int64_t> dm; dm.reserve(N);
+        ankerl::unordered_dense::map<int64_t, int64_t> am; am.reserve(N);
+        tsl::robin_map<int64_t, int64_t> tm; tm.reserve(N);
+        for (size_t i = 0; i < N; ++i) { dm[keys[i]] = gen_val(i); am[keys[i]] = gen_val(i); tm[keys[i]] = gen_val(i); }
+        BENCH_FIND("100K", dm, am, tm, keys);
+        BENCH_ITER("100K", dm, am, tm);
+    }
+
+    // 1M
+    {
+        constexpr size_t N = 1000000;
+        ankerl::nanobench::Bench bench;
+        bench.warmup(2).epochs(3).relative(true);
+        auto keys = gen_random<int64_t>(N);
+        BENCH_INSERT("1M", int64_t, int64_t, keys, gen_val);
+
+        dense_map<int64_t, int64_t> dm; dm.reserve(N);
+        ankerl::unordered_dense::map<int64_t, int64_t> am; am.reserve(N);
+        tsl::robin_map<int64_t, int64_t> tm; tm.reserve(N);
+        for (size_t i = 0; i < N; ++i) { dm[keys[i]] = gen_val(i); am[keys[i]] = gen_val(i); tm[keys[i]] = gen_val(i); }
+        BENCH_FIND("1M", dm, am, tm, keys);
+        BENCH_ITER("1M", dm, am, tm);
+    }
+}
+
+void test_string_scale() {
+    std::cout << "\n=== STRING SCALE TESTS (str16->int64) ===\n";
+    auto gen_val = [](size_t i) { return static_cast<int64_t>(i); };
+
+    // 10K strings
+    {
+        constexpr size_t N = 10000;
+        ankerl::nanobench::Bench bench;
+        bench.warmup(2).epochs(3).relative(true);
+        auto keys = gen_strings(N, 16);
+        BENCH_INSERT("str16_10K", std::string, int64_t, keys, gen_val);
+
+        dense_map<std::string, int64_t> dm; dm.reserve(N);
+        ankerl::unordered_dense::map<std::string, int64_t> am; am.reserve(N);
+        tsl::robin_map<std::string, int64_t> tm; tm.reserve(N);
+        for (size_t i = 0; i < N; ++i) { dm[keys[i]] = gen_val(i); am[keys[i]] = gen_val(i); tm[keys[i]] = gen_val(i); }
+        BENCH_FIND("str16_10K", dm, am, tm, keys);
+        BENCH_ITER("str16_10K", dm, am, tm);
+    }
+
+    // 100K strings
+    {
+        constexpr size_t N = 100000;
+        ankerl::nanobench::Bench bench;
+        bench.warmup(2).epochs(3).relative(true);
+        auto keys = gen_strings(N, 16);
+        BENCH_INSERT("str16_100K", std::string, int64_t, keys, gen_val);
+
+        dense_map<std::string, int64_t> dm; dm.reserve(N);
+        ankerl::unordered_dense::map<std::string, int64_t> am; am.reserve(N);
+        tsl::robin_map<std::string, int64_t> tm; tm.reserve(N);
+        for (size_t i = 0; i < N; ++i) { dm[keys[i]] = gen_val(i); am[keys[i]] = gen_val(i); tm[keys[i]] = gen_val(i); }
+        BENCH_FIND("str16_100K", dm, am, tm, keys);
+        BENCH_ITER("str16_100K", dm, am, tm);
+    }
+
+    // 500K strings
+    {
+        constexpr size_t N = 500000;
+        ankerl::nanobench::Bench bench;
+        bench.warmup(2).epochs(3).relative(true);
+        auto keys = gen_strings(N, 16);
+        BENCH_INSERT("str16_500K", std::string, int64_t, keys, gen_val);
+
+        dense_map<std::string, int64_t> dm; dm.reserve(N);
+        ankerl::unordered_dense::map<std::string, int64_t> am; am.reserve(N);
+        tsl::robin_map<std::string, int64_t> tm; tm.reserve(N);
+        for (size_t i = 0; i < N; ++i) { dm[keys[i]] = gen_val(i); am[keys[i]] = gen_val(i); tm[keys[i]] = gen_val(i); }
+        BENCH_FIND("str16_500K", dm, am, tm, keys);
+        BENCH_ITER("str16_500K", dm, am, tm);
+    }
+}
+
+// ============================================================================
+// NEW: Erase Performance Tests
+// ============================================================================
+void test_erase() {
+    std::cout << "\n=== ERASE TESTS (N=100K) ===\n";
+    constexpr size_t N = 100000;
+    ankerl::nanobench::Bench bench;
+    bench.warmup(2).epochs(3).relative(true);
+    auto gen_val = [](size_t i) { return static_cast<int64_t>(i); };
+
+    // int64 keys
+    {
+        auto keys = gen_random<int64_t>(N);
+        BENCH_ERASE("int64", int64_t, int64_t, keys, gen_val);
+    }
+
+    // string keys
+    {
+        auto keys = gen_strings(N, 16);
+        BENCH_ERASE("str16", std::string, int64_t, keys, gen_val);
+    }
+}
+
+// ============================================================================
+// NEW: Mixed Operations (realistic workload)
+// ============================================================================
+void test_mixed_ops() {
+    std::cout << "\n=== MIXED OPERATIONS (80% find, 10% insert, 10% erase) ===\n";
+    constexpr size_t N = 50000;       // Initial size
+    constexpr size_t OPS = 100000;    // Total operations
+    ankerl::nanobench::Bench bench;
+    bench.warmup(2).epochs(5).relative(true);
+
+    auto keys = gen_random<int64_t>(N * 2);  // Pool of keys
+    std::mt19937_64 rng(42);
+
+    double d_time = 0, a_time = 0, t_time = 0;
+
+    bench.run("dense mixed", [&] {
+        dense_map<int64_t, int64_t> m;
+        m.reserve(N);
+        // Pre-populate
+        for (size_t i = 0; i < N; ++i) m[keys[i]] = static_cast<int64_t>(i);
+
+        std::mt19937_64 local_rng(123);
+        int64_t sum = 0;
+        for (size_t op = 0; op < OPS; ++op) {
+            size_t r = local_rng() % 100;
+            size_t idx = local_rng() % (N * 2);
+            if (r < 80) {           // 80% find
+                auto it = m.find(keys[idx]);
+                if (it != m.end()) sum += it->second;
+            } else if (r < 90) {    // 10% insert
+                m[keys[idx]] = static_cast<int64_t>(op);
+            } else {                // 10% erase
+                m.erase(keys[idx]);
+            }
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+    d_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9;
+
+    bench.run("ankerl mixed", [&] {
+        ankerl::unordered_dense::map<int64_t, int64_t> m;
+        m.reserve(N);
+        for (size_t i = 0; i < N; ++i) m[keys[i]] = static_cast<int64_t>(i);
+
+        std::mt19937_64 local_rng(123);
+        int64_t sum = 0;
+        for (size_t op = 0; op < OPS; ++op) {
+            size_t r = local_rng() % 100;
+            size_t idx = local_rng() % (N * 2);
+            if (r < 80) {
+                auto it = m.find(keys[idx]);
+                if (it != m.end()) sum += it->second;
+            } else if (r < 90) {
+                m[keys[idx]] = static_cast<int64_t>(op);
+            } else {
+                m.erase(keys[idx]);
+            }
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+    a_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9;
+
+    bench.run("tsl mixed", [&] {
+        tsl::robin_map<int64_t, int64_t> m;
+        m.reserve(N);
+        for (size_t i = 0; i < N; ++i) m[keys[i]] = static_cast<int64_t>(i);
+
+        std::mt19937_64 local_rng(123);
+        int64_t sum = 0;
+        for (size_t op = 0; op < OPS; ++op) {
+            size_t r = local_rng() % 100;
+            size_t idx = local_rng() % (N * 2);
+            if (r < 80) {
+                auto it = m.find(keys[idx]);
+                if (it != m.end()) sum += it->second;
+            } else if (r < 90) {
+                m[keys[idx]] = static_cast<int64_t>(op);
+            } else {
+                m.erase(keys[idx]);
+            }
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+    t_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9;
+
+    record("mixed 80/10/10", d_time, a_time, t_time);
+}
+
+// ============================================================================
+// NEW: Reserve vs Grow (with and without pre-allocation)
+// ============================================================================
+void test_reserve_vs_grow() {
+    std::cout << "\n=== RESERVE VS GROW TESTS ===\n";
+    constexpr size_t N = 100000;
+    ankerl::nanobench::Bench bench;
+    bench.warmup(2).epochs(5).relative(true);
+    auto gen_val = [](size_t i) { return static_cast<int64_t>(i); };
+    auto keys = gen_random<int64_t>(N);
+
+    double d_time = 0, a_time = 0, t_time = 0;
+
+    // With reserve
+    bench.run("dense reserved", [&] {
+        dense_map<int64_t, int64_t> m;
+        m.reserve(N);
+        for (size_t i = 0; i < N; ++i) m[keys[i]] = gen_val(i);
+        ankerl::nanobench::doNotOptimizeAway(m);
+    });
+    d_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9;
+
+    bench.run("ankerl reserved", [&] {
+        ankerl::unordered_dense::map<int64_t, int64_t> m;
+        m.reserve(N);
+        for (size_t i = 0; i < N; ++i) m[keys[i]] = gen_val(i);
+        ankerl::nanobench::doNotOptimizeAway(m);
+    });
+    a_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9;
+
+    bench.run("tsl reserved", [&] {
+        tsl::robin_map<int64_t, int64_t> m;
+        m.reserve(N);
+        for (size_t i = 0; i < N; ++i) m[keys[i]] = gen_val(i);
+        ankerl::nanobench::doNotOptimizeAway(m);
+    });
+    t_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9;
+
+    record("reserved insert", d_time, a_time, t_time);
+
+    // Without reserve (grow dynamically)
+    bench.run("dense grow", [&] {
+        dense_map<int64_t, int64_t> m;
+        for (size_t i = 0; i < N; ++i) m[keys[i]] = gen_val(i);
+        ankerl::nanobench::doNotOptimizeAway(m);
+    });
+    d_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9;
+
+    bench.run("ankerl grow", [&] {
+        ankerl::unordered_dense::map<int64_t, int64_t> m;
+        for (size_t i = 0; i < N; ++i) m[keys[i]] = gen_val(i);
+        ankerl::nanobench::doNotOptimizeAway(m);
+    });
+    a_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9;
+
+    bench.run("tsl grow", [&] {
+        tsl::robin_map<int64_t, int64_t> m;
+        for (size_t i = 0; i < N; ++i) m[keys[i]] = gen_val(i);
+        ankerl::nanobench::doNotOptimizeAway(m);
+    });
+    t_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9;
+
+    record("grow insert", d_time, a_time, t_time);
+}
+
+// ============================================================================
+// NEW: Hot Key Access (Zipf distribution - some keys accessed way more)
+// ============================================================================
+void test_zipf_access() {
+    std::cout << "\n=== ZIPF (HOT KEY) ACCESS PATTERN ===\n";
+    constexpr size_t N = 100000;
+    constexpr size_t LOOKUPS = 500000;
+    ankerl::nanobench::Bench bench;
+    bench.warmup(2).epochs(5).relative(true);
+
+    auto keys = gen_random<int64_t>(N);
+
+    // Generate Zipf-like access pattern (top 20% keys get 80% of accesses)
+    std::vector<int64_t> lookup_keys;
+    lookup_keys.reserve(LOOKUPS);
+    std::mt19937_64 rng(99);
+    for (size_t i = 0; i < LOOKUPS; ++i) {
+        double r = static_cast<double>(rng()) / std::mt19937_64::max();
+        size_t idx;
+        if (r < 0.8) {
+            // 80% of accesses go to top 20% of keys
+            idx = rng() % (N / 5);
+        } else {
+            // 20% of accesses to remaining 80% of keys
+            idx = N / 5 + rng() % (N - N / 5);
+        }
+        lookup_keys.push_back(keys[idx]);
+    }
+
+    dense_map<int64_t, int64_t> dm; dm.reserve(N);
+    ankerl::unordered_dense::map<int64_t, int64_t> am; am.reserve(N);
+    tsl::robin_map<int64_t, int64_t> tm; tm.reserve(N);
+    for (size_t i = 0; i < N; ++i) {
+        dm[keys[i]] = static_cast<int64_t>(i);
+        am[keys[i]] = static_cast<int64_t>(i);
+        tm[keys[i]] = static_cast<int64_t>(i);
+    }
+
+    double d_time = 0, a_time = 0, t_time = 0;
+
+    bench.run("dense zipf", [&] {
+        int64_t sum = 0;
+        for (const auto& k : lookup_keys) {
+            auto it = dm.find(k);
+            if (it != dm.end()) sum += it->second;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+    d_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9;
+
+    bench.run("ankerl zipf", [&] {
+        int64_t sum = 0;
+        for (const auto& k : lookup_keys) {
+            auto it = am.find(k);
+            if (it != am.end()) sum += it->second;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+    a_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9;
+
+    bench.run("tsl zipf", [&] {
+        int64_t sum = 0;
+        for (const auto& k : lookup_keys) {
+            auto it = tm.find(k);
+            if (it != tm.end()) sum += it->second;
+        }
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+    t_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9;
+
+    record("zipf find", d_time, a_time, t_time);
+}
+
+// ============================================================================
+// NEW: Small Map Performance (N < 100)
+// ============================================================================
+void test_small_maps() {
+    std::cout << "\n=== SMALL MAP TESTS ===\n";
+    ankerl::nanobench::Bench bench;
+    bench.warmup(5).epochs(10).relative(true);
+    auto gen_val = [](size_t i) { return static_cast<int64_t>(i); };
+
+    // N = 8 (single cache line territory)
+    {
+        constexpr size_t N = 8;
+        auto keys = gen_random<int64_t>(N);
+
+        double d_time = 0, a_time = 0, t_time = 0;
+
+        bench.run("dense N=8 insert", [&] {
+            dense_map<int64_t, int64_t> m;
+            for (size_t i = 0; i < N; ++i) m[keys[i]] = gen_val(i);
+            ankerl::nanobench::doNotOptimizeAway(m);
+        });
+        d_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9;
+
+        bench.run("ankerl N=8 insert", [&] {
+            ankerl::unordered_dense::map<int64_t, int64_t> m;
+            for (size_t i = 0; i < N; ++i) m[keys[i]] = gen_val(i);
+            ankerl::nanobench::doNotOptimizeAway(m);
+        });
+        a_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9;
+
+        bench.run("tsl N=8 insert", [&] {
+            tsl::robin_map<int64_t, int64_t> m;
+            for (size_t i = 0; i < N; ++i) m[keys[i]] = gen_val(i);
+            ankerl::nanobench::doNotOptimizeAway(m);
+        });
+        t_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9;
+
+        record("N=8 insert", d_time, a_time, t_time);
+
+        dense_map<int64_t, int64_t> dm;
+        ankerl::unordered_dense::map<int64_t, int64_t> am;
+        tsl::robin_map<int64_t, int64_t> tm;
+        for (size_t i = 0; i < N; ++i) { dm[keys[i]] = gen_val(i); am[keys[i]] = gen_val(i); tm[keys[i]] = gen_val(i); }
+
+        bench.run("dense N=8 find", [&] {
+            int64_t sum = 0;
+            for (size_t rep = 0; rep < 1000; ++rep)
+                for (const auto& k : keys) { auto it = dm.find(k); if (it != dm.end()) sum++; }
+            ankerl::nanobench::doNotOptimizeAway(sum);
+        });
+        d_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9;
+
+        bench.run("ankerl N=8 find", [&] {
+            int64_t sum = 0;
+            for (size_t rep = 0; rep < 1000; ++rep)
+                for (const auto& k : keys) { auto it = am.find(k); if (it != am.end()) sum++; }
+            ankerl::nanobench::doNotOptimizeAway(sum);
+        });
+        a_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9;
+
+        bench.run("tsl N=8 find", [&] {
+            int64_t sum = 0;
+            for (size_t rep = 0; rep < 1000; ++rep)
+                for (const auto& k : keys) { auto it = tm.find(k); if (it != tm.end()) sum++; }
+            ankerl::nanobench::doNotOptimizeAway(sum);
+        });
+        t_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9;
+
+        record("N=8 find", d_time, a_time, t_time);
+    }
+
+    // N = 32
+    {
+        constexpr size_t N = 32;
+        auto keys = gen_random<int64_t>(N);
+
+        double d_time = 0, a_time = 0, t_time = 0;
+
+        bench.run("dense N=32 insert", [&] {
+            dense_map<int64_t, int64_t> m;
+            for (size_t i = 0; i < N; ++i) m[keys[i]] = gen_val(i);
+            ankerl::nanobench::doNotOptimizeAway(m);
+        });
+        d_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9;
+
+        bench.run("ankerl N=32 insert", [&] {
+            ankerl::unordered_dense::map<int64_t, int64_t> m;
+            for (size_t i = 0; i < N; ++i) m[keys[i]] = gen_val(i);
+            ankerl::nanobench::doNotOptimizeAway(m);
+        });
+        a_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9;
+
+        bench.run("tsl N=32 insert", [&] {
+            tsl::robin_map<int64_t, int64_t> m;
+            for (size_t i = 0; i < N; ++i) m[keys[i]] = gen_val(i);
+            ankerl::nanobench::doNotOptimizeAway(m);
+        });
+        t_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9;
+
+        record("N=32 insert", d_time, a_time, t_time);
+
+        dense_map<int64_t, int64_t> dm;
+        ankerl::unordered_dense::map<int64_t, int64_t> am;
+        tsl::robin_map<int64_t, int64_t> tm;
+        for (size_t i = 0; i < N; ++i) { dm[keys[i]] = gen_val(i); am[keys[i]] = gen_val(i); tm[keys[i]] = gen_val(i); }
+
+        bench.run("dense N=32 find", [&] {
+            int64_t sum = 0;
+            for (size_t rep = 0; rep < 500; ++rep)
+                for (const auto& k : keys) { auto it = dm.find(k); if (it != dm.end()) sum++; }
+            ankerl::nanobench::doNotOptimizeAway(sum);
+        });
+        d_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9;
+
+        bench.run("ankerl N=32 find", [&] {
+            int64_t sum = 0;
+            for (size_t rep = 0; rep < 500; ++rep)
+                for (const auto& k : keys) { auto it = am.find(k); if (it != am.end()) sum++; }
+            ankerl::nanobench::doNotOptimizeAway(sum);
+        });
+        a_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9;
+
+        bench.run("tsl N=32 find", [&] {
+            int64_t sum = 0;
+            for (size_t rep = 0; rep < 500; ++rep)
+                for (const auto& k : keys) { auto it = tm.find(k); if (it != tm.end()) sum++; }
+            ankerl::nanobench::doNotOptimizeAway(sum);
+        });
+        t_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9;
+
+        record("N=32 find", d_time, a_time, t_time);
+    }
+
+    // N = 64
+    {
+        constexpr size_t N = 64;
+        auto keys = gen_random<int64_t>(N);
+
+        double d_time = 0, a_time = 0, t_time = 0;
+
+        bench.run("dense N=64 insert", [&] {
+            dense_map<int64_t, int64_t> m;
+            for (size_t i = 0; i < N; ++i) m[keys[i]] = gen_val(i);
+            ankerl::nanobench::doNotOptimizeAway(m);
+        });
+        d_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9;
+
+        bench.run("ankerl N=64 insert", [&] {
+            ankerl::unordered_dense::map<int64_t, int64_t> m;
+            for (size_t i = 0; i < N; ++i) m[keys[i]] = gen_val(i);
+            ankerl::nanobench::doNotOptimizeAway(m);
+        });
+        a_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9;
+
+        bench.run("tsl N=64 insert", [&] {
+            tsl::robin_map<int64_t, int64_t> m;
+            for (size_t i = 0; i < N; ++i) m[keys[i]] = gen_val(i);
+            ankerl::nanobench::doNotOptimizeAway(m);
+        });
+        t_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9;
+
+        record("N=64 insert", d_time, a_time, t_time);
+
+        dense_map<int64_t, int64_t> dm;
+        ankerl::unordered_dense::map<int64_t, int64_t> am;
+        tsl::robin_map<int64_t, int64_t> tm;
+        for (size_t i = 0; i < N; ++i) { dm[keys[i]] = gen_val(i); am[keys[i]] = gen_val(i); tm[keys[i]] = gen_val(i); }
+
+        bench.run("dense N=64 find", [&] {
+            int64_t sum = 0;
+            for (size_t rep = 0; rep < 250; ++rep)
+                for (const auto& k : keys) { auto it = dm.find(k); if (it != dm.end()) sum++; }
+            ankerl::nanobench::doNotOptimizeAway(sum);
+        });
+        d_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9;
+
+        bench.run("ankerl N=64 find", [&] {
+            int64_t sum = 0;
+            for (size_t rep = 0; rep < 250; ++rep)
+                for (const auto& k : keys) { auto it = am.find(k); if (it != am.end()) sum++; }
+            ankerl::nanobench::doNotOptimizeAway(sum);
+        });
+        a_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9;
+
+        bench.run("tsl N=64 find", [&] {
+            int64_t sum = 0;
+            for (size_t rep = 0; rep < 250; ++rep)
+                for (const auto& k : keys) { auto it = tm.find(k); if (it != tm.end()) sum++; }
+            ankerl::nanobench::doNotOptimizeAway(sum);
+        });
+        t_time = bench.results().back().median(ankerl::nanobench::Result::Measure::elapsed) * 1e9;
+
+        record("N=64 find", d_time, a_time, t_time);
+    }
+}
+
+// ============================================================================
+// Summary
+// ============================================================================
+void print_summary() {
+    std::cout << "\n" << std::string(120, '=') << "\n";
+    std::cout << "                    SUMMARY: dense_map vs ankerl vs tsl (ratio < 1.0 = dense faster)\n";
+    std::cout << std::string(120, '=') << "\n\n";
+
+    std::cout << std::left << std::setw(35) << "Test"
+              << std::right << std::setw(14) << "dense(ns)"
+              << std::setw(14) << "ankerl(ns)"
+              << std::setw(14) << "tsl(ns)"
+              << std::setw(12) << "d/ankerl"
+              << std::setw(12) << "d/tsl"
+              << std::setw(14) << "Best" << "\n";
+    std::cout << std::string(120, '-') << "\n";
+
+    int d_vs_a_wins = 0, d_vs_t_wins = 0, a_wins = 0, t_wins = 0;
+
+    for (const auto& r : g_results) {
+        double ra = r.dense_ns / r.ankerl_ns;
+        double rt = r.dense_ns / r.tsl_ns;
+
+        std::string best;
+        if (r.dense_ns <= r.ankerl_ns && r.dense_ns <= r.tsl_ns) {
+            best = "DENSE";
+            d_vs_a_wins++; d_vs_t_wins++;
+        } else if (r.ankerl_ns <= r.tsl_ns) {
+            best = "ankerl";
+            a_wins++;
+        } else {
+            best = "tsl";
+            t_wins++;
+        }
+
+        std::cout << std::left << std::setw(35) << r.name
+                  << std::right << std::fixed << std::setprecision(0)
+                  << std::setw(14) << r.dense_ns
+                  << std::setw(14) << r.ankerl_ns
+                  << std::setw(14) << r.tsl_ns
+                  << std::setprecision(2)
+                  << std::setw(12) << ra
+                  << std::setw(12) << rt
+                  << std::setw(14) << best << "\n";
+    }
+
+    std::cout << std::string(120, '-') << "\n";
+    std::cout << "\nWin counts: dense=" << d_vs_a_wins << ", ankerl=" << a_wins << ", tsl=" << t_wins << "\n";
+
+    // Calculate averages
+    double insert_ra = 0, find_ra = 0, iter_ra = 0, erase_ra = 0;
+    double insert_rt = 0, find_rt = 0, iter_rt = 0, erase_rt = 0;
+    int ins_c = 0, find_c = 0, iter_c = 0, erase_c = 0;
+
+    for (const auto& r : g_results) {
+        double ra = r.dense_ns / r.ankerl_ns;
+        double rt = r.dense_ns / r.tsl_ns;
+        if (r.name.find("insert") != std::string::npos) { insert_ra += ra; insert_rt += rt; ins_c++; }
+        else if (r.name.find("find") != std::string::npos) { find_ra += ra; find_rt += rt; find_c++; }
+        else if (r.name.find("iterate") != std::string::npos) { iter_ra += ra; iter_rt += rt; iter_c++; }
+        else if (r.name.find("erase") != std::string::npos) { erase_ra += ra; erase_rt += rt; erase_c++; }
+    }
+
+    std::cout << "\nAverage ratios (dense/competitor, <1.0 = dense faster):\n";
+    std::cout << "           vs ankerl    vs tsl\n";
+    if (ins_c > 0) std::cout << "  Insert:  " << std::fixed << std::setprecision(2) << (insert_ra/ins_c) << "          " << (insert_rt/ins_c) << "\n";
+    if (find_c > 0) std::cout << "  Find:    " << (find_ra/find_c) << "          " << (find_rt/find_c) << "\n";
+    if (iter_c > 0) std::cout << "  Iterate: " << (iter_ra/iter_c) << "          " << (iter_rt/iter_c) << "\n";
+    if (erase_c > 0) std::cout << "  Erase:   " << (erase_ra/erase_c) << "          " << (erase_rt/erase_c) << "\n";
+}
+
+int main() {
+    std::cout << "========================================================\n";
+    std::cout << "  COMPREHENSIVE BENCHMARK: dense_map vs ankerl vs tsl\n";
+    std::cout << "========================================================\n";
+
+    test_int_keys();
+    test_string_keys();
+    test_value_types();
+    test_distributions();
+    test_hit_rates();
+    test_scale();
+    test_string_scale();
+
+    // New tests
+    test_erase();
+    test_mixed_ops();
+    test_reserve_vs_grow();
+    test_zipf_access();
+    test_small_maps();
+
+    print_summary();
+    return 0;
+}

--- a/container/dense_map.hpp
+++ b/container/dense_map.hpp
@@ -503,27 +503,34 @@ struct force_flat_policy {
     using storage_tag = flat_storage_tag;
 };
 
-// Alias: Swiss Table storage (SIMD-accelerated)
+// ============================================================================
+// User-friendly storage policy aliases
+// ============================================================================
+
+// Inline storage: key-value pairs stored directly in hash table slots
+// Similar to: tsl::robin_map, absl::flat_hash_map
 // Best for:
 // - Large maps (1M+ elements) with high miss rates
 // - Workloads where most finds() return end() (key not found)
 // Trade-offs:
 // - Slower iteration (must skip empty slots)
-// - Slower for 100% hit workloads (Robin Hood is faster)
 // - No pointer/iterator stability across rehash
-using swiss_table_policy = force_inline_policy;
+// - More memory movement on insert (shift entire KV pairs)
+using inline_storage_policy = force_inline_policy;
 
-// Alias: Robin Hood flat storage (optimized for most use cases)
+// Flat storage: buckets store index, values in separate contiguous array
+// Similar to: ankerl::unordered_dense
 // Best for:
-// - Fast iteration over all elements
+// - Fast iteration over all elements (contiguous memory)
 // - Balanced insert/find/iterate performance
 // - High hit rate workloads
-// - Pointer stability for values (not invalidated by insert)
-using robin_hood_policy = force_flat_policy;
+// - Pointer stability for values (not invalidated by non-rehashing insert)
+// - Large value types (only 8-byte buckets are shifted)
+using flat_storage_policy = force_flat_policy;
 
-// Legacy aliases for compatibility
-using find_optimized_policy = swiss_table_policy;
-using iteration_optimized_policy = robin_hood_policy;
+// Legacy/convenience aliases
+using swiss_table_policy = inline_storage_policy;
+using robin_hood_policy = flat_storage_policy;  // Note: different from tsl::robin_map!
 
 // ============================================================================
 // Bucket for flat storage (ankerl-style Robin Hood)

--- a/container/dense_map.hpp
+++ b/container/dense_map.hpp
@@ -483,19 +483,47 @@ struct default_memory_policy {
 };
 
 // Force inline storage (Swiss Table style)
+// Best for: find-heavy workloads, small value types
+// Trade-off: Fast find (1 cache line), but slow iteration (skip empty slots)
 struct force_inline_policy {
     using storage_tag = inline_storage_tag;
 };
 
 // Force indirect storage (Swiss Table + indirect values)
+// Best for: string keys, large value types
+// Trade-off: SIMD matching + pointer stability, but 2 cache lines for find
 struct force_indirect_policy {
     using storage_tag = indirect_storage_tag;
 };
 
 // Force flat storage (ankerl/Robin Hood style - best for small keys)
+// Best for: balanced workloads with iteration
+// Trade-off: Fast iteration + insert, find needs 2 memory accesses
 struct force_flat_policy {
     using storage_tag = flat_storage_tag;
 };
+
+// Alias: Swiss Table storage (SIMD-accelerated)
+// Best for:
+// - Large maps (1M+ elements) with high miss rates
+// - Workloads where most finds() return end() (key not found)
+// Trade-offs:
+// - Slower iteration (must skip empty slots)
+// - Slower for 100% hit workloads (Robin Hood is faster)
+// - No pointer/iterator stability across rehash
+using swiss_table_policy = force_inline_policy;
+
+// Alias: Robin Hood flat storage (optimized for most use cases)
+// Best for:
+// - Fast iteration over all elements
+// - Balanced insert/find/iterate performance
+// - High hit rate workloads
+// - Pointer stability for values (not invalidated by insert)
+using robin_hood_policy = force_flat_policy;
+
+// Legacy aliases for compatibility
+using find_optimized_policy = swiss_table_policy;
+using iteration_optimized_policy = robin_hood_policy;
 
 // ============================================================================
 // Bucket for flat storage (ankerl-style Robin Hood)

--- a/container/dense_map.hpp
+++ b/container/dense_map.hpp
@@ -1,0 +1,1970 @@
+/*
+ * Copyright 2025 ClapDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <bit>
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <initializer_list>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <new>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+
+// SIMD support detection
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
+#include <immintrin.h>
+#if defined(__SSE2__) || defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 2)
+#define DENSE_MAP_SSE2 1
+#endif
+#if defined(__AVX2__)
+#define DENSE_MAP_AVX2 1
+#endif
+#elif defined(__aarch64__) || defined(_M_ARM64)
+#include <arm_neon.h>
+#define DENSE_MAP_NEON 1
+#endif
+
+// Compiler hints
+#if defined(__GNUC__) || defined(__clang__)
+#define DENSE_MAP_LIKELY(x) __builtin_expect(!!(x), 1)
+#define DENSE_MAP_UNLIKELY(x) __builtin_expect(!!(x), 0)
+#define DENSE_MAP_ALWAYS_INLINE [[gnu::always_inline]] inline
+#define DENSE_MAP_NOINLINE [[gnu::noinline]]
+#define DENSE_MAP_PREFETCH(addr) __builtin_prefetch(addr)
+#elif defined(_MSC_VER)
+#include <intrin.h>
+#define DENSE_MAP_LIKELY(x) (x)
+#define DENSE_MAP_UNLIKELY(x) (x)
+#define DENSE_MAP_ALWAYS_INLINE __forceinline
+#define DENSE_MAP_NOINLINE __declspec(noinline)
+#define DENSE_MAP_PREFETCH(addr) _mm_prefetch(reinterpret_cast<const char*>(addr), _MM_HINT_T0)
+#else
+#define DENSE_MAP_LIKELY(x) (x)
+#define DENSE_MAP_UNLIKELY(x) (x)
+#define DENSE_MAP_ALWAYS_INLINE inline
+#define DENSE_MAP_NOINLINE
+#define DENSE_MAP_PREFETCH(addr) ((void)0)
+#endif
+
+namespace stdb::container {
+
+// ============================================================================
+// wyhash - Fast, high-quality hash function
+// Based on wyhash by Wang Yi: https://github.com/wangyi-fudan/wyhash
+// ============================================================================
+namespace detail {
+
+DENSE_MAP_ALWAYS_INLINE constexpr uint64_t wymum(uint64_t a, uint64_t b) {
+#if defined(__SIZEOF_INT128__)
+    __uint128_t r = static_cast<__uint128_t>(a) * b;
+    return static_cast<uint64_t>(r ^ (r >> 64));
+#else
+    // Fallback for platforms without 128-bit integers
+    uint64_t ha = a >> 32, hb = b >> 32;
+    uint64_t la = static_cast<uint32_t>(a), lb = static_cast<uint32_t>(b);
+    uint64_t hi = ha * hb;
+    uint64_t lo = la * lb;
+    uint64_t rh = ha * lb;
+    uint64_t rl = la * hb;
+    uint64_t t = rl + (lo >> 32);
+    uint64_t c = t < rl;
+    lo = (t << 32) | static_cast<uint32_t>(lo);
+    hi += rh + (t >> 32) + c;
+    return hi ^ lo;
+#endif
+}
+
+DENSE_MAP_ALWAYS_INLINE uint64_t wyr8(const uint8_t* p) {
+    uint64_t v;
+    std::memcpy(&v, p, 8);
+    return v;
+}
+
+DENSE_MAP_ALWAYS_INLINE uint64_t wyr4(const uint8_t* p) {
+    uint32_t v;
+    std::memcpy(&v, p, 4);
+    return v;
+}
+
+DENSE_MAP_ALWAYS_INLINE constexpr uint64_t wyr3(const uint8_t* p, size_t k) {
+    return (static_cast<uint64_t>(p[0]) << 16) |
+           (static_cast<uint64_t>(p[k >> 1]) << 8) | p[k - 1];
+}
+
+// wyhash constants
+inline constexpr uint64_t wyp0 = 0xa0761d6478bd642full;
+inline constexpr uint64_t wyp1 = 0xe7037ed1a0b428dbull;
+inline constexpr uint64_t wyp2 = 0x8ebc6af09c88c6e3ull;
+inline constexpr uint64_t wyp3 = 0x589965cc75374cc3ull;
+
+DENSE_MAP_ALWAYS_INLINE uint64_t wyhash(const void* key, size_t len, uint64_t seed = 0) {
+    const auto* p = static_cast<const uint8_t*>(key);
+    seed ^= wyp0;
+    uint64_t a, b;
+
+    if (DENSE_MAP_LIKELY(len <= 16)) {
+        if (DENSE_MAP_LIKELY(len >= 4)) {
+            a = (wyr4(p) << 32) | wyr4(p + ((len >> 3) << 2));
+            b = (wyr4(p + len - 4) << 32) | wyr4(p + len - 4 - ((len >> 3) << 2));
+        } else if (DENSE_MAP_LIKELY(len > 0)) {
+            a = wyr3(p, len);
+            b = 0;
+        } else {
+            a = b = 0;
+        }
+    } else {
+        size_t i = len;
+        if (DENSE_MAP_UNLIKELY(i > 48)) {
+            uint64_t see1 = seed, see2 = seed;
+            do {
+                seed = wymum(wyr8(p) ^ wyp1, wyr8(p + 8) ^ seed);
+                see1 = wymum(wyr8(p + 16) ^ wyp2, wyr8(p + 24) ^ see1);
+                see2 = wymum(wyr8(p + 32) ^ wyp3, wyr8(p + 40) ^ see2);
+                p += 48;
+                i -= 48;
+            } while (DENSE_MAP_LIKELY(i > 48));
+            seed ^= see1 ^ see2;
+        }
+        while (DENSE_MAP_UNLIKELY(i > 16)) {
+            seed = wymum(wyr8(p) ^ wyp1, wyr8(p + 8) ^ seed);
+            i -= 16;
+            p += 16;
+        }
+        a = wyr8(p + i - 16);
+        b = wyr8(p + i - 8);
+    }
+    return wymum(wyp1 ^ len, wymum(a ^ wyp1, b ^ seed));
+}
+
+// wyhash mix - 128-bit multiply with XOR fold (same as ankerl)
+DENSE_MAP_ALWAYS_INLINE uint64_t wyhash_mix(uint64_t a, uint64_t b) {
+#if defined(__SIZEOF_INT128__)
+    __uint128_t r = static_cast<__uint128_t>(a) * b;
+    return static_cast<uint64_t>(r) ^ static_cast<uint64_t>(r >> 64);
+#else
+    uint64_t ha = a >> 32, hb = b >> 32;
+    uint64_t la = static_cast<uint32_t>(a), lb = static_cast<uint32_t>(b);
+    uint64_t rh = ha * hb, rm0 = ha * lb, rm1 = hb * la, rl = la * lb;
+    uint64_t t = rl + (rm0 << 32), c = t < rl;
+    uint64_t lo = t + (rm1 << 32); c += lo < t;
+    uint64_t hi = rh + (rm0 >> 32) + (rm1 >> 32) + c;
+    return lo ^ hi;
+#endif
+}
+
+// Hash for integral types - wyhash mix (same quality as ankerl)
+template <typename T>
+DENSE_MAP_ALWAYS_INLINE uint64_t hash_integral(T value) {
+    static_assert(std::is_integral_v<T> || std::is_enum_v<T>);
+    return wyhash_mix(static_cast<uint64_t>(value), 0x9e3779b97f4a7c15ull);
+}
+
+}  // namespace detail
+
+// ============================================================================
+// Default hash function - wyhash based
+// ============================================================================
+template <typename T, typename Enable = void>
+struct dense_hash {
+    size_t operator()(const T& value) const noexcept {
+        return static_cast<size_t>(detail::wyhash(&value, sizeof(T)));
+    }
+};
+
+// Specialization for integral types
+template <typename T>
+struct dense_hash<T, std::enable_if_t<std::is_integral_v<T> || std::is_enum_v<T>>> {
+    size_t operator()(T value) const noexcept {
+        return static_cast<size_t>(detail::hash_integral(value));
+    }
+};
+
+// Specialization for pointers
+template <typename T>
+struct dense_hash<T*> {
+    size_t operator()(T* ptr) const noexcept {
+        return static_cast<size_t>(
+            detail::hash_integral(reinterpret_cast<uintptr_t>(ptr)));
+    }
+};
+
+// Specialization for std::string and string_view
+template <>
+struct dense_hash<std::string> {
+    size_t operator()(const std::string& s) const noexcept {
+        return static_cast<size_t>(detail::wyhash(s.data(), s.size()));
+    }
+};
+
+template <>
+struct dense_hash<std::string_view> {
+    size_t operator()(std::string_view s) const noexcept {
+        return static_cast<size_t>(detail::wyhash(s.data(), s.size()));
+    }
+};
+
+// Transparent hash for string types
+struct string_hash {
+    using is_transparent = void;
+
+    size_t operator()(const char* s) const noexcept {
+        return static_cast<size_t>(detail::wyhash(s, std::strlen(s)));
+    }
+    size_t operator()(std::string_view s) const noexcept {
+        return static_cast<size_t>(detail::wyhash(s.data(), s.size()));
+    }
+    size_t operator()(const std::string& s) const noexcept {
+        return static_cast<size_t>(detail::wyhash(s.data(), s.size()));
+    }
+};
+
+// ============================================================================
+// SIMD utilities for Swiss Table probing
+// ============================================================================
+namespace detail {
+
+// Control byte values
+inline constexpr int8_t kEmpty = -128;     // 0b10000000
+inline constexpr int8_t kDeleted = -2;     // 0b11111110
+inline constexpr int8_t kSentinel = -1;    // 0b11111111
+
+// Check if control byte is empty
+DENSE_MAP_ALWAYS_INLINE constexpr bool is_empty(int8_t c) { return c == kEmpty; }
+
+// Check if control byte is deleted
+DENSE_MAP_ALWAYS_INLINE constexpr bool is_deleted(int8_t c) { return c == kDeleted; }
+
+// Check if control byte is empty or deleted
+DENSE_MAP_ALWAYS_INLINE constexpr bool is_empty_or_deleted(int8_t c) { return c < kSentinel; }
+
+// Check if control byte is full (has an element)
+DENSE_MAP_ALWAYS_INLINE constexpr bool is_full(int8_t c) { return c >= 0; }
+
+// Extract H2 hash (top 7 bits mapped to 0-127)
+DENSE_MAP_ALWAYS_INLINE constexpr int8_t h2(size_t hash) {
+    return static_cast<int8_t>(hash >> (sizeof(size_t) * 8 - 7));
+}
+
+// Extract H1 hash (all bits except top 7)
+DENSE_MAP_ALWAYS_INLINE constexpr size_t h1(size_t hash) { return hash; }
+
+// Group width for SIMD operations
+#if defined(DENSE_MAP_AVX2)
+inline constexpr size_t kGroupWidth = 32;
+#elif defined(DENSE_MAP_SSE2) || defined(DENSE_MAP_NEON)
+inline constexpr size_t kGroupWidth = 16;
+#else
+inline constexpr size_t kGroupWidth = 8;
+#endif
+
+// BitMask helper for iterating over set bits
+struct BitMask {
+    uint32_t mask;
+
+    explicit BitMask(uint32_t m) : mask(m) {}
+
+    explicit operator bool() const { return mask != 0; }
+
+    uint32_t lowest_set_bit() const {
+        return static_cast<uint32_t>(std::countr_zero(mask));
+    }
+
+    BitMask& remove_lowest_bit() {
+        mask &= mask - 1;
+        return *this;
+    }
+
+    uint32_t trailing_zeros() const {
+        return static_cast<uint32_t>(std::countr_zero(mask));
+    }
+};
+
+// Group operations - SIMD-accelerated probe operations
+struct Group {
+#if defined(DENSE_MAP_AVX2)
+    __m256i ctrl;
+
+    explicit Group(const int8_t* pos) {
+        ctrl = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(pos));
+    }
+
+    BitMask match(int8_t h) const {
+        auto match_vec = _mm256_set1_epi8(h);
+        return BitMask(static_cast<uint32_t>(
+            _mm256_movemask_epi8(_mm256_cmpeq_epi8(match_vec, ctrl))));
+    }
+
+    BitMask match_empty() const {
+        // Empty is 0b10000000, check for high bit set
+        return BitMask(static_cast<uint32_t>(
+            _mm256_movemask_epi8(ctrl)));
+    }
+
+    BitMask match_empty_or_deleted() const {
+        // Empty and Deleted both have high bit set and bit 0 clear
+        auto special = _mm256_set1_epi8(static_cast<int8_t>(kSentinel));
+        return BitMask(static_cast<uint32_t>(
+            _mm256_movemask_epi8(_mm256_cmpgt_epi8(special, ctrl))));
+    }
+
+#elif defined(DENSE_MAP_SSE2)
+    __m128i ctrl;
+
+    explicit Group(const int8_t* pos) {
+        ctrl = _mm_loadu_si128(reinterpret_cast<const __m128i*>(pos));
+    }
+
+    BitMask match(int8_t h) const {
+        auto match_vec = _mm_set1_epi8(h);
+        return BitMask(static_cast<uint32_t>(
+            _mm_movemask_epi8(_mm_cmpeq_epi8(match_vec, ctrl))));
+    }
+
+    BitMask match_empty() const {
+        return BitMask(static_cast<uint32_t>(_mm_movemask_epi8(ctrl)));
+    }
+
+    BitMask match_empty_or_deleted() const {
+        auto special = _mm_set1_epi8(static_cast<int8_t>(kSentinel));
+        return BitMask(static_cast<uint32_t>(
+            _mm_movemask_epi8(_mm_cmpgt_epi8(special, ctrl))));
+    }
+
+#elif defined(DENSE_MAP_NEON)
+    uint8x16_t ctrl;
+
+    explicit Group(const int8_t* pos) {
+        ctrl = vld1q_u8(reinterpret_cast<const uint8_t*>(pos));
+    }
+
+    BitMask match(int8_t h) const {
+        auto match_vec = vdupq_n_u8(static_cast<uint8_t>(h));
+        auto cmp = vceqq_u8(match_vec, ctrl);
+        // Convert to bitmask
+        static const uint8_t shifts[] = {1, 2, 4, 8, 16, 32, 64, 128,
+                                         1, 2, 4, 8, 16, 32, 64, 128};
+        auto bits = vld1q_u8(shifts);
+        auto masked = vandq_u8(cmp, bits);
+        auto paired = vpaddq_u8(masked, masked);
+        paired = vpaddq_u8(paired, paired);
+        paired = vpaddq_u8(paired, paired);
+        return BitMask(vgetq_lane_u16(vreinterpretq_u16_u8(paired), 0));
+    }
+
+    BitMask match_empty() const {
+        // Check for 0x80 (empty) - high bit set
+        auto msb = vreinterpretq_u8_s8(vshrq_n_s8(vreinterpretq_s8_u8(ctrl), 7));
+        static const uint8_t shifts[] = {1, 2, 4, 8, 16, 32, 64, 128,
+                                         1, 2, 4, 8, 16, 32, 64, 128};
+        auto bits = vld1q_u8(shifts);
+        auto masked = vandq_u8(msb, bits);
+        auto paired = vpaddq_u8(masked, masked);
+        paired = vpaddq_u8(paired, paired);
+        paired = vpaddq_u8(paired, paired);
+        return BitMask(vgetq_lane_u16(vreinterpretq_u16_u8(paired), 0));
+    }
+
+    BitMask match_empty_or_deleted() const {
+        auto special = vdupq_n_s8(kSentinel);
+        auto cmp = vcgtq_s8(special, vreinterpretq_s8_u8(ctrl));
+        static const uint8_t shifts[] = {1, 2, 4, 8, 16, 32, 64, 128,
+                                         1, 2, 4, 8, 16, 32, 64, 128};
+        auto bits = vld1q_u8(shifts);
+        auto masked = vandq_u8(vreinterpretq_u8_s8(cmp), bits);
+        auto paired = vpaddq_u8(masked, masked);
+        paired = vpaddq_u8(paired, paired);
+        paired = vpaddq_u8(paired, paired);
+        return BitMask(vgetq_lane_u16(vreinterpretq_u16_u8(paired), 0));
+    }
+
+#else
+    // Portable fallback
+    int8_t ctrl[8];
+
+    explicit Group(const int8_t* pos) { std::memcpy(ctrl, pos, 8); }
+
+    BitMask match(int8_t h) const {
+        uint32_t mask = 0;
+        for (int i = 0; i < 8; ++i) {
+            if (ctrl[i] == h) mask |= (1u << i);
+        }
+        return BitMask(mask);
+    }
+
+    BitMask match_empty() const {
+        uint32_t mask = 0;
+        for (int i = 0; i < 8; ++i) {
+            if (ctrl[i] == kEmpty) mask |= (1u << i);
+        }
+        return BitMask(mask);
+    }
+
+    BitMask match_empty_or_deleted() const {
+        uint32_t mask = 0;
+        for (int i = 0; i < 8; ++i) {
+            if (ctrl[i] < kSentinel) mask |= (1u << i);
+        }
+        return BitMask(mask);
+    }
+#endif
+};
+
+// Probe sequence - linear probing for better cache locality
+class ProbeSeq {
+public:
+    ProbeSeq(size_t hash, size_t mask) : mask_(mask), offset_(hash & mask) {}
+
+    size_t offset() const { return offset_; }
+    size_t offset(size_t i) const { return (offset_ + i) & mask_; }
+
+    void next() {
+        offset_ = (offset_ + kGroupWidth) & mask_;
+    }
+
+private:
+    size_t mask_;
+    size_t offset_;
+};
+
+}  // namespace detail
+
+// ============================================================================
+// Memory Policy - Selects storage layout based on type characteristics
+// ============================================================================
+
+// Storage layout tags
+struct inline_storage_tag {};    // Swiss Table: ctrl bytes + inline slots
+struct indirect_storage_tag {};  // Swiss Table + indirect values (for string keys)
+struct flat_storage_tag {};      // ankerl-style: Robin Hood buckets + contiguous values
+
+// Default memory policy: select storage based on type characteristics
+template <typename Key, typename Value>
+struct default_memory_policy {
+    using value_type = std::pair<Key, Value>;
+
+    // For small trivially copyable keys (int, pointers, etc.), use flat storage (ankerl-style)
+    // This gives better cache efficiency: fingerprint + index in same bucket
+    static constexpr bool use_flat =
+        sizeof(Key) <= 8 &&
+        std::is_trivially_copyable_v<Key>;
+
+    // Use Swiss Table indirect for larger/non-trivial keys (like strings)
+    // SIMD h2 matching saves expensive key comparisons
+    static constexpr bool use_indirect = !use_flat;
+
+    using storage_tag = std::conditional_t<use_flat,
+                                           flat_storage_tag,
+                                           indirect_storage_tag>;
+};
+
+// Force inline storage (Swiss Table style)
+struct force_inline_policy {
+    using storage_tag = inline_storage_tag;
+};
+
+// Force indirect storage (Swiss Table + indirect values)
+struct force_indirect_policy {
+    using storage_tag = indirect_storage_tag;
+};
+
+// Force flat storage (ankerl/Robin Hood style - best for small keys)
+struct force_flat_policy {
+    using storage_tag = flat_storage_tag;
+};
+
+// ============================================================================
+// Bucket for flat storage (ankerl-style Robin Hood)
+// ============================================================================
+namespace detail {
+
+// Bucket stores fingerprint+distance and index into values array
+// Layout matches ankerl::unordered_dense for optimal comparison:
+// - dist_and_fingerprint: upper 24 bits = distance, lower 8 bits = fingerprint
+// - This allows single integer comparison for Robin Hood probing
+struct Bucket {
+    static constexpr uint32_t kDistInc = 1U << 8U;           // Increment for distance (skip fingerprint byte)
+    static constexpr uint32_t kFingerprintMask = kDistInc - 1;  // Mask for 8-bit fingerprint
+
+    uint32_t dist_and_fingerprint;  // [distance:24][fingerprint:8] - 0 means empty
+    uint32_t value_idx;             // Index into values array
+
+    Bucket() : dist_and_fingerprint(0), value_idx(0) {}
+    Bucket(uint32_t daf, uint32_t idx) : dist_and_fingerprint(daf), value_idx(idx) {}
+
+    // Empty bucket has dist_and_fingerprint == 0
+    bool is_empty() const { return dist_and_fingerprint == 0; }
+
+    // Create dist_and_fingerprint from hash (starting distance = 1)
+    static uint32_t make_dist_and_fingerprint(uint64_t hash) {
+        return kDistInc | (static_cast<uint32_t>(hash) & kFingerprintMask);
+    }
+
+    // Increment distance portion only
+    static uint32_t inc_dist(uint32_t daf) {
+        return daf + kDistInc;
+    }
+
+    void set_empty() { dist_and_fingerprint = 0; value_idx = 0; }
+};
+
+}  // namespace detail
+
+// ============================================================================
+// dense_map - High-performance hash map with type-specialized storage
+// ============================================================================
+template <typename Key, typename Value, typename Hash = dense_hash<Key>,
+          typename KeyEqual = std::equal_to<Key>,
+          typename Allocator = std::allocator<std::pair<Key, Value>>,
+          typename MemoryPolicy = default_memory_policy<Key, Value>>
+class dense_map {
+public:
+    using key_type = Key;
+    using mapped_type = Value;
+    using value_type = std::pair<Key, Value>;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using hasher = Hash;
+    using key_equal = KeyEqual;
+    using allocator_type = Allocator;
+    using reference = value_type&;
+    using const_reference = const value_type&;
+    using pointer = typename std::allocator_traits<Allocator>::pointer;
+    using const_pointer = typename std::allocator_traits<Allocator>::const_pointer;
+
+private:
+    using AllocTraits = std::allocator_traits<Allocator>;
+    using CtrlAlloc =
+        typename AllocTraits::template rebind_alloc<int8_t>;
+    using SlotAlloc =
+        typename AllocTraits::template rebind_alloc<value_type>;
+    using IndexAlloc =
+        typename AllocTraits::template rebind_alloc<uint32_t>;
+    using BucketAlloc =
+        typename AllocTraits::template rebind_alloc<detail::Bucket>;
+
+    // Storage policy selection
+    using storage_tag = typename MemoryPolicy::storage_tag;
+    static constexpr bool kUseInline = std::is_same_v<storage_tag, inline_storage_tag>;
+    static constexpr bool kUseFlat = std::is_same_v<storage_tag, flat_storage_tag>;
+    static constexpr bool kUseIndirect = std::is_same_v<storage_tag, indirect_storage_tag>;
+
+    static constexpr size_t kGroupWidth = detail::kGroupWidth;
+    static constexpr float kMaxLoadFactor = 0.875f;
+    static constexpr size_t kMinCapacity = kUseInline ? kGroupWidth : 8;
+
+    // ========== Inline storage (Swiss Table) ==========
+    // Used when kUseInline == true
+    value_type* slots_ = nullptr;      // Inline key-value pairs
+
+    // ========== Flat storage (ankerl/Robin Hood style) ==========
+    // Used when kUseFlat == true
+    // Robin Hood linear probing with fingerprint in bucket
+    detail::Bucket* buckets_ = nullptr;  // [value_idx | dist_and_h2]
+
+    // ========== Indirect storage (Swiss Table + Contiguous Values) ==========
+    // Used when kUseIndirect == true
+    // Still uses ctrl_ for SIMD probing, but stores value indices instead of inline values
+    uint32_t* value_indices_ = nullptr;  // Maps slot -> value index in values array
+
+    // ========== Shared for Flat and Indirect: Contiguous values array ==========
+    value_type* values_ = nullptr;       // Contiguous values array
+    size_t values_capacity_ = 0;         // Capacity of values array
+
+    // ========== Shared for Inline and Indirect: Control bytes for Swiss Table ==========
+    int8_t* ctrl_ = nullptr;           // Control bytes (h2 fingerprint)
+
+    // ========== Common ==========
+    size_t size_ = 0;
+    size_t capacity_ = 0;       // Bucket/slot capacity
+    size_t growth_left_ = 0;
+    uint8_t shift_ = 64;        // For flat storage: bucket_idx = hash >> shift_ (uses high bits)
+
+    [[no_unique_address]] Hash hash_;
+    [[no_unique_address]] KeyEqual key_equal_;
+    [[no_unique_address]] Allocator alloc_;
+
+public:
+    // ========== Iterator for inline storage (Swiss Table) ==========
+    class inline_iterator {
+    public:
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = dense_map::value_type;
+        using difference_type = std::ptrdiff_t;
+        using pointer = value_type*;
+        using reference = value_type&;
+
+        inline_iterator() = default;
+        inline_iterator(const int8_t* ctrl, value_type* slot, const int8_t* ctrl_end)
+            : ctrl_(ctrl), slot_(slot), ctrl_end_(ctrl_end) {}
+
+        reference operator*() const { return *slot_; }
+        pointer operator->() const { return slot_; }
+
+        inline_iterator& operator++() {
+            ++ctrl_; ++slot_;
+            skip_empty_or_deleted();
+            return *this;
+        }
+        inline_iterator operator++(int) { auto tmp = *this; ++*this; return tmp; }
+
+        friend bool operator==(const inline_iterator& a, const inline_iterator& b) { return a.ctrl_ == b.ctrl_; }
+        friend bool operator!=(const inline_iterator& a, const inline_iterator& b) { return a.ctrl_ != b.ctrl_; }
+
+        void skip_empty_or_deleted() {
+            while (ctrl_ != ctrl_end_ && detail::is_empty_or_deleted(*ctrl_)) { ++ctrl_; ++slot_; }
+            if (ctrl_ == ctrl_end_) { ctrl_ = nullptr; slot_ = nullptr; ctrl_end_ = nullptr; }
+        }
+
+        const int8_t* ctrl_ = nullptr;
+        value_type* slot_ = nullptr;
+        const int8_t* ctrl_end_ = nullptr;
+    };
+
+    class const_inline_iterator {
+    public:
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = const dense_map::value_type;
+        using difference_type = std::ptrdiff_t;
+        using pointer = const value_type*;
+        using reference = const value_type&;
+
+        const_inline_iterator() = default;
+        const_inline_iterator(const inline_iterator& it) : ctrl_(it.ctrl_), slot_(it.slot_), ctrl_end_(it.ctrl_end_) {}
+        const_inline_iterator(const int8_t* ctrl, const value_type* slot, const int8_t* ctrl_end)
+            : ctrl_(ctrl), slot_(slot), ctrl_end_(ctrl_end) {}
+
+        reference operator*() const { return *slot_; }
+        pointer operator->() const { return slot_; }
+
+        const_inline_iterator& operator++() {
+            ++ctrl_; ++slot_;
+            skip_empty_or_deleted();
+            return *this;
+        }
+        const_inline_iterator operator++(int) { auto tmp = *this; ++*this; return tmp; }
+
+        friend bool operator==(const const_inline_iterator& a, const const_inline_iterator& b) { return a.ctrl_ == b.ctrl_; }
+        friend bool operator!=(const const_inline_iterator& a, const const_inline_iterator& b) { return a.ctrl_ != b.ctrl_; }
+
+        void skip_empty_or_deleted() {
+            while (ctrl_ != ctrl_end_ && detail::is_empty_or_deleted(*ctrl_)) { ++ctrl_; ++slot_; }
+            if (ctrl_ == ctrl_end_) { ctrl_ = nullptr; slot_ = nullptr; ctrl_end_ = nullptr; }
+        }
+
+        const int8_t* ctrl_ = nullptr;
+        const value_type* slot_ = nullptr;
+        const int8_t* ctrl_end_ = nullptr;
+    };
+
+    // Select iterator type based on storage policy
+    using iterator = std::conditional_t<kUseInline, inline_iterator, value_type*>;
+    using const_iterator = std::conditional_t<kUseInline, const_inline_iterator, const value_type*>;
+
+    // Constructors
+    dense_map() = default;
+
+    explicit dense_map(size_type bucket_count, const Hash& hash = Hash(),
+                       const KeyEqual& equal = KeyEqual(),
+                       const Allocator& alloc = Allocator())
+        : hash_(hash), key_equal_(equal), alloc_(alloc) {
+        if (bucket_count > 0) {
+            initialize(bucket_count);
+        }
+    }
+
+    dense_map(const dense_map& other)
+        : hash_(other.hash_),
+          key_equal_(other.key_equal_),
+          alloc_(AllocTraits::select_on_container_copy_construction(other.alloc_)) {
+        if (other.size_ > 0) {
+            initialize(other.capacity_);
+            if constexpr (kUseInline) {
+                for (size_t i = 0; i < other.capacity_; ++i) {
+                    if (detail::is_full(other.ctrl_[i])) {
+                        ctrl_[i] = other.ctrl_[i];
+                        AllocTraits::construct(alloc_, slots_ + i, other.slots_[i]);
+                    }
+                }
+            } else if constexpr (kUseFlat) {
+                // Copy buckets
+                std::memcpy(buckets_, other.buckets_, other.capacity_ * sizeof(detail::Bucket));
+                // Copy values
+                for (size_t i = 0; i < other.size_; ++i) {
+                    AllocTraits::construct(alloc_, values_ + i, other.values_[i]);
+                }
+            } else {
+                // Copy ctrl and value_indices
+                std::memcpy(ctrl_, other.ctrl_, other.capacity_ + kGroupWidth + 1);
+                std::memcpy(value_indices_, other.value_indices_, other.capacity_ * sizeof(uint32_t));
+                // Copy values
+                for (size_t i = 0; i < other.size_; ++i) {
+                    AllocTraits::construct(alloc_, values_ + i, other.values_[i]);
+                }
+            }
+            size_ = other.size_;
+            growth_left_ = other.growth_left_;
+        }
+    }
+
+    dense_map(dense_map&& other) noexcept
+        : slots_(other.slots_),
+          buckets_(other.buckets_),
+          value_indices_(other.value_indices_),
+          values_(other.values_),
+          values_capacity_(other.values_capacity_),
+          ctrl_(other.ctrl_),
+          size_(other.size_),
+          capacity_(other.capacity_),
+          growth_left_(other.growth_left_),
+          shift_(other.shift_),
+          hash_(std::move(other.hash_)),
+          key_equal_(std::move(other.key_equal_)),
+          alloc_(std::move(other.alloc_)) {
+        other.slots_ = nullptr;
+        other.buckets_ = nullptr;
+        other.value_indices_ = nullptr;
+        other.values_ = nullptr;
+        other.values_capacity_ = 0;
+        other.ctrl_ = nullptr;
+        other.size_ = 0;
+        other.capacity_ = 0;
+        other.growth_left_ = 0;
+        other.shift_ = 64;
+    }
+
+    dense_map(std::initializer_list<value_type> init, size_type bucket_count = 0,
+              const Hash& hash = Hash(), const KeyEqual& equal = KeyEqual(),
+              const Allocator& alloc = Allocator())
+        : hash_(hash), key_equal_(equal), alloc_(alloc) {
+        size_t min_size = init.size() > 0 ? init.size() : 1;
+        size_t cap = bucket_count > 0 ? bucket_count : min_size;
+        reserve(cap);
+        for (const auto& item : init) {
+            insert(item);
+        }
+    }
+
+    ~dense_map() { destroy(); }
+
+    dense_map& operator=(const dense_map& other) {
+        if (this != &other) {
+            dense_map tmp(other);
+            swap(tmp);
+        }
+        return *this;
+    }
+
+    dense_map& operator=(dense_map&& other) noexcept {
+        if (this != &other) {
+            destroy();
+            slots_ = other.slots_;
+            buckets_ = other.buckets_;
+            value_indices_ = other.value_indices_;
+            values_ = other.values_;
+            values_capacity_ = other.values_capacity_;
+            ctrl_ = other.ctrl_;
+            size_ = other.size_;
+            capacity_ = other.capacity_;
+            growth_left_ = other.growth_left_;
+            shift_ = other.shift_;
+            hash_ = std::move(other.hash_);
+            key_equal_ = std::move(other.key_equal_);
+            if constexpr (AllocTraits::propagate_on_container_move_assignment::value) {
+                alloc_ = std::move(other.alloc_);
+            }
+            other.slots_ = nullptr;
+            other.buckets_ = nullptr;
+            other.value_indices_ = nullptr;
+            other.values_ = nullptr;
+            other.values_capacity_ = 0;
+            other.ctrl_ = nullptr;
+            other.size_ = 0;
+            other.capacity_ = 0;
+            other.growth_left_ = 0;
+            other.shift_ = 64;
+        }
+        return *this;
+    }
+
+    // Iterators
+    iterator begin() {
+        if (empty()) return end();
+        if constexpr (kUseInline) {
+            iterator it(ctrl_, slots_, ctrl_ + capacity_);
+            if (detail::is_empty_or_deleted(*it.ctrl_)) {
+                ++it;
+            }
+            return it;
+        } else {
+            return values_;
+        }
+    }
+
+    const_iterator begin() const {
+        if (empty()) return end();
+        if constexpr (kUseInline) {
+            const_iterator it(ctrl_, slots_, ctrl_ + capacity_);
+            if (detail::is_empty_or_deleted(*it.ctrl_)) {
+                ++it;
+            }
+            return it;
+        } else {
+            return values_;
+        }
+    }
+
+    const_iterator cbegin() const { return begin(); }
+
+    iterator end() {
+        if constexpr (kUseInline) {
+            return iterator(nullptr, nullptr, nullptr);
+        } else {
+            return values_ + size_;
+        }
+    }
+
+    const_iterator end() const {
+        if constexpr (kUseInline) {
+            return const_iterator(nullptr, nullptr, nullptr);
+        } else {
+            return values_ + size_;
+        }
+    }
+
+    const_iterator cend() const { return end(); }
+
+    // Capacity
+    [[nodiscard]] bool empty() const noexcept { return size_ == 0; }
+    size_type size() const noexcept { return size_; }
+    size_type max_size() const noexcept { return std::numeric_limits<size_type>::max() / 2; }
+    size_type capacity() const noexcept { return capacity_; }
+
+    // Modifiers
+    void clear() noexcept {
+        if (size_ == 0) return;
+        if constexpr (kUseInline) {
+            for (size_t i = 0; i < capacity_; ++i) {
+                if (detail::is_full(ctrl_[i])) {
+                    AllocTraits::destroy(alloc_, slots_ + i);
+                    ctrl_[i] = detail::kEmpty;
+                }
+            }
+        } else if constexpr (kUseFlat) {
+            // Flat storage: destroy values and reset buckets
+            for (size_t i = 0; i < size_; ++i) {
+                AllocTraits::destroy(alloc_, values_ + i);
+            }
+            for (size_t i = 0; i < capacity_; ++i) {
+                buckets_[i].set_empty();
+            }
+        } else {
+            // Indirect storage: destroy values and reset control bytes
+            for (size_t i = 0; i < size_; ++i) {
+                AllocTraits::destroy(alloc_, values_ + i);
+            }
+            std::memset(ctrl_, static_cast<int>(detail::kEmpty), capacity_ + kGroupWidth);
+        }
+        size_ = 0;
+        reset_growth();
+    }
+
+    std::pair<iterator, bool> insert(const value_type& value) {
+        return emplace(value.first, value.second);
+    }
+
+    std::pair<iterator, bool> insert(value_type&& value) {
+        return emplace(std::move(value.first), std::move(value.second));
+    }
+
+    template <typename P, typename = std::enable_if_t<
+                              std::is_constructible_v<value_type, P&&>>>
+    std::pair<iterator, bool> insert(P&& value) {
+        return emplace(std::forward<P>(value));
+    }
+
+    template <typename InputIt>
+    void insert(InputIt first, InputIt last) {
+        for (; first != last; ++first) {
+            insert(*first);
+        }
+    }
+
+    void insert(std::initializer_list<value_type> ilist) {
+        insert(ilist.begin(), ilist.end());
+    }
+
+    template <typename M>
+    std::pair<iterator, bool> insert_or_assign(const Key& key, M&& obj) {
+        auto result = try_emplace(key, std::forward<M>(obj));
+        if (!result.second) {
+            result.first->second = std::forward<M>(obj);
+        }
+        return result;
+    }
+
+    template <typename M>
+    std::pair<iterator, bool> insert_or_assign(Key&& key, M&& obj) {
+        auto result = try_emplace(std::move(key), std::forward<M>(obj));
+        if (!result.second) {
+            result.first->second = std::forward<M>(obj);
+        }
+        return result;
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> emplace(Args&&... args) {
+        // Construct the value to get the key
+        alignas(value_type) unsigned char storage[sizeof(value_type)];
+        value_type* value = reinterpret_cast<value_type*>(storage);
+        AllocTraits::construct(alloc_, value, std::forward<Args>(args)...);
+
+        auto result = emplace_impl(value->first, std::move(*value));
+        if (!result.second) {
+            AllocTraits::destroy(alloc_, value);
+        }
+        return result;
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> try_emplace(const Key& key, Args&&... args) {
+        return try_emplace_impl(key, std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> try_emplace(Key&& key, Args&&... args) {
+        return try_emplace_impl(std::move(key), std::forward<Args>(args)...);
+    }
+
+    iterator erase(const_iterator pos) {
+        if constexpr (kUseInline) {
+            assert(pos.ctrl_ != nullptr);
+            size_t index = static_cast<size_t>(pos.ctrl_ - ctrl_);
+            erase_at(index);
+
+            // Return iterator to next element
+            iterator next(ctrl_ + index, slots_ + index, ctrl_ + capacity_);
+            if (detail::is_empty_or_deleted(*next.ctrl_)) {
+                ++next;
+            }
+            return next;
+        } else {
+            // pos is a pointer into values array
+            size_t value_idx = static_cast<size_t>(pos - values_);
+            erase_value_at(value_idx);
+            // Return iterator to element now at this position (or end)
+            return values_ + std::min(value_idx, size_);
+        }
+    }
+
+    iterator erase(const_iterator first, const_iterator last) {
+        if constexpr (kUseInline) {
+            while (first != last) {
+                first = erase(first);
+            }
+            return iterator(const_cast<int8_t*>(first.ctrl_),
+                            const_cast<value_type*>(first.slot_),
+                            const_cast<int8_t*>(first.ctrl_end_));
+        } else {
+            // For indirect storage, erase from end to start to avoid index shifting issues
+            size_t count = static_cast<size_t>(last - first);
+            size_t start_idx = static_cast<size_t>(first - values_);
+            for (size_t i = 0; i < count; ++i) {
+                erase_value_at(start_idx);
+            }
+            return values_ + std::min(start_idx, size_);
+        }
+    }
+
+    size_type erase(const Key& key) {
+        auto it = find(key);
+        if (it == end()) return 0;
+        erase(it);
+        return 1;
+    }
+
+    void swap(dense_map& other) noexcept {
+        using std::swap;
+        swap(slots_, other.slots_);
+        swap(buckets_, other.buckets_);
+        swap(ctrl_, other.ctrl_);
+        swap(value_indices_, other.value_indices_);
+        swap(values_, other.values_);
+        swap(values_capacity_, other.values_capacity_);
+        swap(size_, other.size_);
+        swap(capacity_, other.capacity_);
+        swap(growth_left_, other.growth_left_);
+        swap(shift_, other.shift_);
+        swap(hash_, other.hash_);
+        swap(key_equal_, other.key_equal_);
+        if constexpr (AllocTraits::propagate_on_container_swap::value) {
+            swap(alloc_, other.alloc_);
+        }
+    }
+
+    // Lookup
+    mapped_type& at(const Key& key) {
+        auto it = find(key);
+        if (it == end()) {
+            throw std::out_of_range("dense_map::at: key not found");
+        }
+        return it->second;
+    }
+
+    const mapped_type& at(const Key& key) const {
+        auto it = find(key);
+        if (it == end()) {
+            throw std::out_of_range("dense_map::at: key not found");
+        }
+        return it->second;
+    }
+
+    mapped_type& operator[](const Key& key) {
+        auto result = try_emplace(key);
+        return result.first->second;
+    }
+
+    mapped_type& operator[](Key&& key) {
+        auto result = try_emplace(std::move(key));
+        return result.first->second;
+    }
+
+    size_type count(const Key& key) const { return contains(key) ? 1 : 0; }
+
+    template <typename K>
+    size_type count(const K& key) const
+        requires requires { hash_(key); key_equal_(key, std::declval<Key>()); }
+    {
+        return contains(key) ? 1 : 0;
+    }
+
+    iterator find(const Key& key) {
+        if (capacity_ == 0) return end();
+        return find_impl(key);
+    }
+
+    const_iterator find(const Key& key) const {
+        if (capacity_ == 0) return end();
+        return const_cast<dense_map*>(this)->find_impl(key);
+    }
+
+    template <typename K>
+    iterator find(const K& key)
+        requires requires { hash_(key); key_equal_(key, std::declval<Key>()); }
+    {
+        if (capacity_ == 0) return end();
+        return find_impl(key);
+    }
+
+    template <typename K>
+    const_iterator find(const K& key) const
+        requires requires { hash_(key); key_equal_(key, std::declval<Key>()); }
+    {
+        if (capacity_ == 0) return end();
+        return const_cast<dense_map*>(this)->find_impl(key);
+    }
+
+    bool contains(const Key& key) const { return find(key) != end(); }
+
+    template <typename K>
+    bool contains(const K& key) const
+        requires requires { hash_(key); key_equal_(key, std::declval<Key>()); }
+    {
+        return find(key) != end();
+    }
+
+    std::pair<iterator, iterator> equal_range(const Key& key) {
+        auto it = find(key);
+        if (it == end()) return {it, it};
+        auto next = it;
+        ++next;
+        return {it, next};
+    }
+
+    std::pair<const_iterator, const_iterator> equal_range(const Key& key) const {
+        auto it = find(key);
+        if (it == end()) return {it, it};
+        auto next = it;
+        ++next;
+        return {it, next};
+    }
+
+    // Bucket interface
+    size_type bucket_count() const noexcept { return capacity_; }
+    size_type max_bucket_count() const noexcept { return max_size(); }
+
+    // Hash policy
+    float load_factor() const noexcept {
+        return capacity_ == 0 ? 0.0f : static_cast<float>(size_) / capacity_;
+    }
+
+    float max_load_factor() const noexcept { return kMaxLoadFactor; }
+
+    void rehash(size_type count) {
+        size_t min_size = static_cast<size_t>(
+            std::ceil(static_cast<float>(size_) / kMaxLoadFactor));
+        count = std::max({count, min_size, kMinCapacity});
+        count = normalize_capacity(count);
+        if (count != capacity_) {
+            rehash_impl(count);
+        }
+    }
+
+    void reserve(size_type count) {
+        size_t required = static_cast<size_t>(
+            std::ceil(static_cast<float>(count) / kMaxLoadFactor));
+        if (required > capacity_) {
+            rehash(required);
+        }
+    }
+
+    // Observers
+    hasher hash_function() const { return hash_; }
+    key_equal key_eq() const { return key_equal_; }
+    allocator_type get_allocator() const noexcept { return alloc_; }
+
+private:
+    // Round up to power of 2, minimum kGroupWidth
+    static size_t normalize_capacity(size_t n) {
+        if (n < kMinCapacity) return kMinCapacity;
+        return size_t{1} << (64 - std::countl_zero(n - 1));
+    }
+
+    // Calculate how many elements we can insert before rehash
+    size_t capacity_to_growth(size_t cap) const {
+        return static_cast<size_t>(cap * kMaxLoadFactor);
+    }
+
+    void reset_growth() {
+        growth_left_ = capacity_to_growth(capacity_) - size_;
+    }
+
+    void initialize(size_t cap) {
+        cap = normalize_capacity(cap);
+        capacity_ = cap;
+        // For flat storage: shift_ = 64 - log2(capacity), so hash >> shift_ gives bucket index
+        shift_ = static_cast<uint8_t>(64 - std::countr_zero(cap));
+
+        if constexpr (kUseInline) {
+            // Inline storage: allocate control bytes + sentinel group + slots
+            CtrlAlloc ctrl_alloc(alloc_);
+            ctrl_ = std::allocator_traits<CtrlAlloc>::allocate(
+                ctrl_alloc, cap + kGroupWidth + 1);
+            std::memset(ctrl_, static_cast<int>(detail::kEmpty), cap + kGroupWidth);
+            ctrl_[cap + kGroupWidth] = detail::kSentinel;
+
+            SlotAlloc slot_alloc(alloc_);
+            slots_ = std::allocator_traits<SlotAlloc>::allocate(slot_alloc, cap);
+        } else if constexpr (kUseFlat) {
+            // Flat storage (ankerl/Robin Hood style):
+            // Allocate buckets array (fingerprint + value_idx per bucket)
+            BucketAlloc bucket_alloc(alloc_);
+            buckets_ = std::allocator_traits<BucketAlloc>::allocate(bucket_alloc, cap);
+            // Initialize all buckets as empty
+            for (size_t i = 0; i < cap; ++i) {
+                buckets_[i].set_empty();
+            }
+
+            // Allocate values array
+            values_capacity_ = cap;
+            SlotAlloc slot_alloc(alloc_);
+            values_ = std::allocator_traits<SlotAlloc>::allocate(slot_alloc, values_capacity_);
+        } else {
+            // Indirect storage (Swiss Table + Contiguous Values):
+            // Allocate control bytes + sentinel group
+            CtrlAlloc ctrl_alloc(alloc_);
+            ctrl_ = std::allocator_traits<CtrlAlloc>::allocate(
+                ctrl_alloc, cap + kGroupWidth + 1);
+            std::memset(ctrl_, static_cast<int>(detail::kEmpty), cap + kGroupWidth);
+            ctrl_[cap + kGroupWidth] = detail::kSentinel;
+
+            // Allocate value indices array (maps slot -> value index)
+            IndexAlloc index_alloc(alloc_);
+            value_indices_ = std::allocator_traits<IndexAlloc>::allocate(index_alloc, cap);
+
+            // Allocate initial values array
+            values_capacity_ = cap;
+            SlotAlloc slot_alloc(alloc_);
+            values_ = std::allocator_traits<SlotAlloc>::allocate(slot_alloc, values_capacity_);
+        }
+
+        reset_growth();
+    }
+
+    void destroy() {
+        if constexpr (kUseInline) {
+            if (ctrl_) {
+                for (size_t i = 0; i < capacity_; ++i) {
+                    if (detail::is_full(ctrl_[i])) {
+                        AllocTraits::destroy(alloc_, slots_ + i);
+                    }
+                }
+                CtrlAlloc ctrl_alloc(alloc_);
+                std::allocator_traits<CtrlAlloc>::deallocate(
+                    ctrl_alloc, ctrl_, capacity_ + kGroupWidth + 1);
+                SlotAlloc slot_alloc(alloc_);
+                std::allocator_traits<SlotAlloc>::deallocate(slot_alloc, slots_, capacity_);
+            }
+            ctrl_ = nullptr;
+            slots_ = nullptr;
+        } else if constexpr (kUseFlat) {
+            if (buckets_) {
+                // Destroy all values (stored contiguously)
+                for (size_t i = 0; i < size_; ++i) {
+                    AllocTraits::destroy(alloc_, values_ + i);
+                }
+                BucketAlloc bucket_alloc(alloc_);
+                std::allocator_traits<BucketAlloc>::deallocate(bucket_alloc, buckets_, capacity_);
+                SlotAlloc slot_alloc(alloc_);
+                std::allocator_traits<SlotAlloc>::deallocate(slot_alloc, values_, values_capacity_);
+            }
+            buckets_ = nullptr;
+            values_ = nullptr;
+            values_capacity_ = 0;
+        } else {
+            if (ctrl_) {
+                // Destroy all values
+                for (size_t i = 0; i < size_; ++i) {
+                    AllocTraits::destroy(alloc_, values_ + i);
+                }
+                CtrlAlloc ctrl_alloc(alloc_);
+                std::allocator_traits<CtrlAlloc>::deallocate(
+                    ctrl_alloc, ctrl_, capacity_ + kGroupWidth + 1);
+                IndexAlloc index_alloc(alloc_);
+                std::allocator_traits<IndexAlloc>::deallocate(index_alloc, value_indices_, capacity_);
+                SlotAlloc slot_alloc(alloc_);
+                std::allocator_traits<SlotAlloc>::deallocate(slot_alloc, values_, values_capacity_);
+            }
+            ctrl_ = nullptr;
+            value_indices_ = nullptr;
+            values_ = nullptr;
+            values_capacity_ = 0;
+        }
+        size_ = 0;
+        capacity_ = 0;
+        growth_left_ = 0;
+    }
+
+    // Robin Hood: place bucket at position and shift up displaced entries
+    DENSE_MAP_ALWAYS_INLINE void place_and_shift_up(size_t bucket_idx, uint32_t dist_and_fp, uint32_t value_idx) {
+        const size_t mask = capacity_ - 1;
+        detail::Bucket to_insert{dist_and_fp, value_idx};
+
+        while (buckets_[bucket_idx].dist_and_fingerprint != 0) {
+            if (to_insert.dist_and_fingerprint > buckets_[bucket_idx].dist_and_fingerprint) {
+                std::swap(to_insert, buckets_[bucket_idx]);
+            }
+            to_insert.dist_and_fingerprint = detail::Bucket::inc_dist(to_insert.dist_and_fingerprint);
+            bucket_idx = (bucket_idx + 1) & mask;
+        }
+        buckets_[bucket_idx] = to_insert;
+    }
+
+    template <typename K>
+    DENSE_MAP_ALWAYS_INLINE iterator find_impl(const K& key) {
+        if constexpr (kUseInline) {
+            // Swiss Table: SIMD probing
+            const size_t hash = hash_(key);
+            const int8_t h2_val = detail::h2(hash);
+            const size_t mask = capacity_ - 1;
+
+            detail::ProbeSeq seq(hash, mask);
+            for (;;) {
+                const detail::Group g(ctrl_ + seq.offset());
+                for (auto match_mask = g.match(h2_val); match_mask; match_mask.remove_lowest_bit()) {
+                    const size_t idx = seq.offset(match_mask.lowest_set_bit());
+                    if (DENSE_MAP_LIKELY(key_equal_(key, slots_[idx].first))) {
+                        return iterator(ctrl_ + idx, slots_ + idx, ctrl_ + capacity_);
+                    }
+                }
+                if (DENSE_MAP_LIKELY(g.match_empty())) {
+                    return end();
+                }
+                seq.next();
+            }
+        } else if constexpr (kUseFlat) {
+            // Flat storage: Robin Hood linear probing (ankerl-style optimized)
+            // Use HIGH bits for bucket index, LOW 8 bits for fingerprint (independent bits!)
+            const size_t hash = hash_(key);
+            const size_t mask = capacity_ - 1;
+            size_t bucket_idx = hash >> shift_;  // HIGH bits for bucket index
+            auto dist_and_fp = detail::Bucket::make_dist_and_fingerprint(hash);
+            const auto* bucket = buckets_ + bucket_idx;
+
+            // Main loop - Robin Hood invariant: if our distance > bucket's distance, key doesn't exist
+            while (dist_and_fp <= bucket->dist_and_fingerprint) {
+                if (dist_and_fp == bucket->dist_and_fingerprint &&
+                    DENSE_MAP_LIKELY(key_equal_(key, values_[bucket->value_idx].first))) {
+                    return values_ + bucket->value_idx;
+                }
+                dist_and_fp = detail::Bucket::inc_dist(dist_and_fp);
+                bucket_idx = (bucket_idx + 1) & mask;
+                bucket = buckets_ + bucket_idx;
+            }
+            return end();
+        } else {
+            // Swiss Table + Indirect: SIMD probing with value_indices lookup
+            const size_t hash = hash_(key);
+            const int8_t h2_val = detail::h2(hash);
+            const size_t mask = capacity_ - 1;
+
+            detail::ProbeSeq seq(hash, mask);
+            for (;;) {
+                const detail::Group g(ctrl_ + seq.offset());
+                for (auto match_mask = g.match(h2_val); match_mask; match_mask.remove_lowest_bit()) {
+                    const size_t idx = seq.offset(match_mask.lowest_set_bit());
+                    const uint32_t value_idx = value_indices_[idx];
+                    if (DENSE_MAP_LIKELY(key_equal_(key, values_[value_idx].first))) {
+                        return values_ + value_idx;
+                    }
+                }
+                if (DENSE_MAP_LIKELY(g.match_empty())) {
+                    return end();
+                }
+                seq.next();
+            }
+        }
+    }
+
+    template <typename K>
+    DENSE_MAP_ALWAYS_INLINE size_t find_slot_for_insert(const K& key, size_t hash) {
+        const int8_t h2_val = detail::h2(hash);
+        const size_t mask = capacity_ - 1;
+        const size_t pos = hash & mask;
+
+        // Fast path: if first position is empty, use it directly (common case)
+        if (DENSE_MAP_LIKELY(detail::is_empty(ctrl_[pos]))) {
+            return pos;
+        }
+
+        // Check if first position has matching key
+        if (ctrl_[pos] == h2_val && key_equal_(key, slots_[pos].first)) {
+            return pos;
+        }
+
+        // Fall back to SIMD probing
+        size_t first_available = detail::is_deleted(ctrl_[pos]) ? pos : ~size_t{0};
+        detail::ProbeSeq seq(hash, mask);
+
+        for (;;) {
+            const detail::Group g(ctrl_ + seq.offset());
+
+            // Check for matching keys
+            for (auto match_mask = g.match(h2_val); match_mask; match_mask.remove_lowest_bit()) {
+                const size_t idx = seq.offset(match_mask.lowest_set_bit());
+                if (key_equal_(key, slots_[idx].first)) {
+                    return idx;
+                }
+            }
+
+            // Track first available slot
+            if (first_available == ~size_t{0}) {
+                if (auto empty_mask = g.match_empty_or_deleted()) {
+                    first_available = seq.offset(empty_mask.lowest_set_bit());
+                }
+            }
+
+            // If we found an empty slot, we know key doesn't exist
+            if (g.match_empty()) {
+                return first_available;
+            }
+            seq.next();
+        }
+    }
+
+    template <typename K, typename V>
+    std::pair<iterator, bool> emplace_impl(const K& key, V&& value) {
+        if (capacity_ == 0) {
+            initialize(kMinCapacity);
+        } else if (growth_left_ == 0) {
+            rehash_impl(capacity_ * 2);
+        }
+
+        if constexpr (kUseInline) {
+            // Swiss Table: inline storage
+            size_t hash = hash_(key);
+            size_t idx = find_slot_for_insert(key, hash);
+
+            if (detail::is_full(ctrl_[idx])) {
+                return {iterator(ctrl_ + idx, slots_ + idx, ctrl_ + capacity_), false};
+            }
+
+            const bool was_deleted = detail::is_deleted(ctrl_[idx]);
+            const int8_t h2_val = detail::h2(hash);
+            ctrl_[idx] = h2_val;
+            // Mirror first kGroupWidth control bytes for SIMD wrap-around
+            if (idx < kGroupWidth) {
+                ctrl_[capacity_ + idx] = h2_val;
+            }
+
+            AllocTraits::construct(alloc_, slots_ + idx, std::forward<V>(value));
+
+            ++size_;
+            growth_left_ -= !was_deleted;
+
+            return {iterator(ctrl_ + idx, slots_ + idx, ctrl_ + capacity_), true};
+        } else if constexpr (kUseFlat) {
+            // Flat storage: Robin Hood linear probing (ankerl-style optimized)
+            // Use HIGH bits for bucket index, LOW 8 bits for fingerprint
+            const size_t hash = hash_(key);
+            const size_t mask = capacity_ - 1;
+            size_t bucket_idx = hash >> shift_;  // HIGH bits for bucket index
+            auto dist_and_fp = detail::Bucket::make_dist_and_fingerprint(hash);
+            auto* bucket = buckets_ + bucket_idx;
+
+            // Find existing key or insertion point - cache bucket pointer
+            while (dist_and_fp <= bucket->dist_and_fingerprint) {
+                if (dist_and_fp == bucket->dist_and_fingerprint &&
+                    DENSE_MAP_LIKELY(key_equal_(key, values_[bucket->value_idx].first))) {
+                    return {values_ + bucket->value_idx, false};  // Key exists
+                }
+                dist_and_fp = detail::Bucket::inc_dist(dist_and_fp);
+                bucket_idx = (bucket_idx + 1) & mask;
+                bucket = buckets_ + bucket_idx;
+            }
+
+            // Insert the value at end of values array
+            const uint32_t new_value_idx = static_cast<uint32_t>(size_);
+            value_type* result_ptr = values_ + new_value_idx;
+            AllocTraits::construct(alloc_, result_ptr, std::forward<V>(value));
+            ++size_;
+            --growth_left_;
+
+            // Robin Hood insertion: inline shift for better optimization
+            if (DENSE_MAP_LIKELY(bucket->dist_and_fingerprint == 0)) {
+                bucket->dist_and_fingerprint = dist_and_fp;
+                bucket->value_idx = new_value_idx;
+            } else {
+                detail::Bucket to_insert{dist_and_fp, new_value_idx};
+                do {
+                    std::swap(to_insert, *bucket);
+                    to_insert.dist_and_fingerprint = detail::Bucket::inc_dist(to_insert.dist_and_fingerprint);
+                    bucket_idx = (bucket_idx + 1) & mask;
+                    bucket = buckets_ + bucket_idx;
+                } while (bucket->dist_and_fingerprint != 0);
+                *bucket = to_insert;
+            }
+
+            return {result_ptr, true};
+        } else {
+            // Indirect storage
+            size_t hash = hash_(key);
+            size_t idx = find_slot_for_insert(key, hash);
+
+            if (detail::is_full(ctrl_[idx])) {
+                return {values_ + slots_[idx], false};
+            }
+
+            const bool was_deleted = detail::is_deleted(ctrl_[idx]);
+            const int8_t h2_val = detail::h2(hash);
+            ctrl_[idx] = h2_val;
+            if (idx < kGroupWidth) {
+                ctrl_[capacity_ + idx] = h2_val;
+            }
+
+            slots_[idx] = static_cast<uint32_t>(size_);
+            AllocTraits::construct(alloc_, values_ + size_, std::forward<V>(value));
+
+            ++size_;
+            growth_left_ -= !was_deleted;
+
+            return {values_ + slots_[idx], true};
+        }
+    }
+
+    template <typename K, typename... Args>
+    std::pair<iterator, bool> try_emplace_impl(K&& key, Args&&... args) {
+        if (capacity_ == 0) {
+            initialize(kMinCapacity);
+        } else if (growth_left_ == 0) {
+            rehash_impl(capacity_ * 2);
+        }
+
+        if constexpr (kUseInline) {
+            // Swiss Table: inline storage
+            size_t hash = hash_(key);
+            size_t idx = find_slot_for_insert(key, hash);
+
+            if (detail::is_full(ctrl_[idx])) {
+                return {iterator(ctrl_ + idx, slots_ + idx, ctrl_ + capacity_), false};
+            }
+
+            const bool was_deleted = detail::is_deleted(ctrl_[idx]);
+            const int8_t h2_val = detail::h2(hash);
+            ctrl_[idx] = h2_val;
+            if (idx < kGroupWidth) {
+                ctrl_[capacity_ + idx] = h2_val;
+            }
+
+            AllocTraits::construct(alloc_, slots_ + idx,
+                                   std::piecewise_construct,
+                                   std::forward_as_tuple(std::forward<K>(key)),
+                                   std::forward_as_tuple(std::forward<Args>(args)...));
+
+            ++size_;
+            growth_left_ -= !was_deleted;
+
+            return {iterator(ctrl_ + idx, slots_ + idx, ctrl_ + capacity_), true};
+        } else if constexpr (kUseFlat) {
+            // Flat storage: Robin Hood linear probing (ankerl-style optimized)
+            // Use HIGH bits for bucket index, LOW 8 bits for fingerprint
+            const size_t hash = hash_(key);
+            const size_t mask = capacity_ - 1;
+            size_t bucket_idx = hash >> shift_;  // HIGH bits for bucket index
+            auto dist_and_fp = detail::Bucket::make_dist_and_fingerprint(hash);
+            auto* bucket = buckets_ + bucket_idx;
+
+            // Find existing key or insertion point - cache bucket pointer
+            while (dist_and_fp <= bucket->dist_and_fingerprint) {
+                if (dist_and_fp == bucket->dist_and_fingerprint &&
+                    DENSE_MAP_LIKELY(key_equal_(key, values_[bucket->value_idx].first))) {
+                    return {values_ + bucket->value_idx, false};  // Key exists
+                }
+                dist_and_fp = detail::Bucket::inc_dist(dist_and_fp);
+                bucket_idx = (bucket_idx + 1) & mask;
+                bucket = buckets_ + bucket_idx;
+            }
+
+            // Ensure values array has capacity
+            if (DENSE_MAP_UNLIKELY(size_ >= values_capacity_)) {
+                grow_values_array();
+            }
+
+            // Construct new value at end of values array
+            const uint32_t new_value_idx = static_cast<uint32_t>(size_);
+            AllocTraits::construct(alloc_, values_ + new_value_idx,
+                                   std::piecewise_construct,
+                                   std::forward_as_tuple(std::forward<K>(key)),
+                                   std::forward_as_tuple(std::forward<Args>(args)...));
+            ++size_;
+            --growth_left_;
+
+            // Robin Hood insertion: inline shift for better optimization
+            // Most insertions don't need displacement (fast path)
+            if (DENSE_MAP_LIKELY(bucket->dist_and_fingerprint == 0)) {
+                bucket->dist_and_fingerprint = dist_and_fp;
+                bucket->value_idx = new_value_idx;
+            } else {
+                // Slow path: need to displace existing entries
+                detail::Bucket to_insert{dist_and_fp, new_value_idx};
+                do {
+                    std::swap(to_insert, *bucket);
+                    to_insert.dist_and_fingerprint = detail::Bucket::inc_dist(to_insert.dist_and_fingerprint);
+                    bucket_idx = (bucket_idx + 1) & mask;
+                    bucket = buckets_ + bucket_idx;
+                } while (bucket->dist_and_fingerprint != 0);
+                *bucket = to_insert;
+            }
+
+            return {values_ + new_value_idx, true};
+        } else {
+            // Swiss Table + Indirect: SIMD probing with values array
+            const size_t hash = hash_(key);
+            const int8_t h2_val = detail::h2(hash);
+            const size_t mask = capacity_ - 1;
+
+            // Find existing key or insertion slot
+            size_t insert_slot = ~size_t{0};
+            detail::ProbeSeq seq(hash, mask);
+            for (;;) {
+                const detail::Group g(ctrl_ + seq.offset());
+
+                // Check for matching keys
+                for (auto match_mask = g.match(h2_val); match_mask; match_mask.remove_lowest_bit()) {
+                    const size_t idx = seq.offset(match_mask.lowest_set_bit());
+                    const uint32_t vidx = value_indices_[idx];
+                    if (key_equal_(key, values_[vidx].first)) {
+                        return {values_ + vidx, false};  // Key exists
+                    }
+                }
+
+                // Track first available slot
+                if (insert_slot == ~size_t{0}) {
+                    if (auto empty_mask = g.match_empty_or_deleted()) {
+                        insert_slot = seq.offset(empty_mask.lowest_set_bit());
+                    }
+                }
+
+                // If we found an empty slot, key doesn't exist
+                if (g.match_empty()) {
+                    break;
+                }
+                seq.next();
+            }
+
+            // Ensure values array has capacity
+            if (size_ >= values_capacity_) {
+                grow_values_array();
+            }
+
+            // Construct new value at end of values array
+            const uint32_t new_value_idx = static_cast<uint32_t>(size_);
+            AllocTraits::construct(alloc_, values_ + new_value_idx,
+                                   std::piecewise_construct,
+                                   std::forward_as_tuple(std::forward<K>(key)),
+                                   std::forward_as_tuple(std::forward<Args>(args)...));
+
+            // Insert into slot
+            const bool was_deleted = detail::is_deleted(ctrl_[insert_slot]);
+            ctrl_[insert_slot] = h2_val;
+            if (insert_slot < kGroupWidth) {
+                ctrl_[capacity_ + insert_slot] = h2_val;
+            }
+            value_indices_[insert_slot] = new_value_idx;
+
+            ++size_;
+            growth_left_ -= !was_deleted;
+
+            return {values_ + new_value_idx, true};
+        }
+    }
+
+    // Grow values array for indirect storage
+    void grow_values_array() {
+        size_t new_capacity = values_capacity_ == 0 ? 8 : values_capacity_ * 2;
+        SlotAlloc slot_alloc(alloc_);
+        value_type* new_values = std::allocator_traits<SlotAlloc>::allocate(slot_alloc, new_capacity);
+
+        // Move existing values
+        for (size_t i = 0; i < size_; ++i) {
+            AllocTraits::construct(alloc_, new_values + i, std::move(values_[i]));
+            AllocTraits::destroy(alloc_, values_ + i);
+        }
+
+        if (values_) {
+            std::allocator_traits<SlotAlloc>::deallocate(slot_alloc, values_, values_capacity_);
+        }
+
+        values_ = new_values;
+        values_capacity_ = new_capacity;
+    }
+
+    // Erase at slot index (inline storage only)
+    void erase_at(size_t idx) {
+        static_assert(kUseInline, "erase_at only for inline storage");
+        assert(detail::is_full(ctrl_[idx]));
+        AllocTraits::destroy(alloc_, slots_ + idx);
+
+        size_t mask = capacity_ - 1;
+        size_t next_idx = (idx + 1) & mask;
+        bool should_delete = detail::is_full(ctrl_[next_idx]) ||
+                             detail::is_deleted(ctrl_[next_idx]);
+
+        ctrl_[idx] = should_delete ? detail::kDeleted : detail::kEmpty;
+        if (idx < kGroupWidth) {
+            ctrl_[capacity_ + idx] = ctrl_[idx];
+        }
+
+        --size_;
+        if (!should_delete) {
+            ++growth_left_;
+        }
+    }
+
+    // Erase value at index in values array (indirect storage only)
+    void erase_value_at(size_t value_idx) {
+        static_assert(!kUseInline, "erase_value_at only for indirect/flat storage");
+        const size_t mask = capacity_ - 1;
+
+        if constexpr (kUseFlat) {
+            // Flat storage: Robin Hood backward shift deletion (ankerl-style)
+            // Find the bucket that points to this value
+            const size_t hash = hash_(values_[value_idx].first);
+            size_t bucket_idx = hash >> shift_;  // HIGH bits for bucket index
+
+            // Find the bucket containing this value
+            while (buckets_[bucket_idx].value_idx != static_cast<uint32_t>(value_idx)) {
+                bucket_idx = (bucket_idx + 1) & mask;
+            }
+
+            // Backward shift deletion: shift subsequent entries back
+            size_t next_idx = (bucket_idx + 1) & mask;
+            while (buckets_[next_idx].dist_and_fingerprint >= detail::Bucket::kDistInc * 2) {
+                // Move next bucket back and decrement its distance
+                buckets_[bucket_idx].value_idx = buckets_[next_idx].value_idx;
+                buckets_[bucket_idx].dist_and_fingerprint =
+                    buckets_[next_idx].dist_and_fingerprint - detail::Bucket::kDistInc;
+                bucket_idx = next_idx;
+                next_idx = (next_idx + 1) & mask;
+            }
+            buckets_[bucket_idx].set_empty();
+
+            // Swap-and-pop: move last value to deleted position
+            const size_t last_idx = size_ - 1;
+            if (value_idx != last_idx) {
+                // Find and update bucket pointing to last value
+                const size_t last_hash = hash_(values_[last_idx].first);
+                size_t last_pos = last_hash >> shift_;  // HIGH bits for bucket index
+
+                while (buckets_[last_pos].value_idx != static_cast<uint32_t>(last_idx)) {
+                    last_pos = (last_pos + 1) & mask;
+                }
+                buckets_[last_pos].value_idx = static_cast<uint32_t>(value_idx);
+
+                // Move last value to deleted position
+                values_[value_idx] = std::move(values_[last_idx]);
+            }
+            AllocTraits::destroy(alloc_, values_ + last_idx);
+
+            --size_;
+            ++growth_left_;
+        } else {
+            // Indirect storage (Swiss Table + Indirect)
+            // Find the slot that points to this value
+            const size_t hash = hash_(values_[value_idx].first);
+            const int8_t h2_val = detail::h2(hash);
+
+            size_t slot_idx = ~size_t{0};
+            detail::ProbeSeq seq(hash, mask);
+            for (;;) {
+                const detail::Group g(ctrl_ + seq.offset());
+                for (auto match_mask = g.match(h2_val); match_mask; match_mask.remove_lowest_bit()) {
+                    const size_t idx = seq.offset(match_mask.lowest_set_bit());
+                    if (value_indices_[idx] == static_cast<uint32_t>(value_idx)) {
+                        slot_idx = idx;
+                        break;
+                    }
+                }
+                if (slot_idx != ~size_t{0}) break;
+                seq.next();
+            }
+
+            // Mark slot as deleted
+            size_t next_idx = (slot_idx + 1) & mask;
+            bool should_delete = detail::is_full(ctrl_[next_idx]) ||
+                                 detail::is_deleted(ctrl_[next_idx]);
+
+            ctrl_[slot_idx] = should_delete ? detail::kDeleted : detail::kEmpty;
+            if (slot_idx < kGroupWidth) {
+                ctrl_[capacity_ + slot_idx] = ctrl_[slot_idx];
+            }
+
+            // Swap-and-pop: move last value to deleted position
+            const size_t last_idx = size_ - 1;
+            if (value_idx != last_idx) {
+                // Find and update slot pointing to last value
+                const size_t last_hash = hash_(values_[last_idx].first);
+                const int8_t last_h2 = detail::h2(last_hash);
+
+                detail::ProbeSeq last_seq(last_hash, mask);
+                for (;;) {
+                    const detail::Group g(ctrl_ + last_seq.offset());
+                    for (auto match_mask = g.match(last_h2); match_mask; match_mask.remove_lowest_bit()) {
+                        const size_t idx = last_seq.offset(match_mask.lowest_set_bit());
+                        if (value_indices_[idx] == static_cast<uint32_t>(last_idx)) {
+                            value_indices_[idx] = static_cast<uint32_t>(value_idx);
+                            goto found_last;
+                        }
+                    }
+                    last_seq.next();
+                }
+                found_last:
+                // Move last value to deleted position
+                values_[value_idx] = std::move(values_[last_idx]);
+            }
+            AllocTraits::destroy(alloc_, values_ + last_idx);
+
+            --size_;
+            ++growth_left_;
+        }
+    }
+
+    void rehash_impl(size_t new_capacity) {
+        new_capacity = normalize_capacity(new_capacity);
+
+        if constexpr (kUseInline) {
+            // Swiss Table: inline storage
+            int8_t* old_ctrl = ctrl_;
+            value_type* old_slots = slots_;
+            size_t old_capacity = capacity_;
+
+            ctrl_ = nullptr;
+            slots_ = nullptr;
+            capacity_ = 0;
+            size_ = 0;
+            growth_left_ = 0;
+
+            initialize(new_capacity);
+
+            for (size_t i = 0; i < old_capacity; ++i) {
+                if (detail::is_full(old_ctrl[i])) {
+                    size_t hash = hash_(old_slots[i].first);
+                    size_t idx = find_first_empty(hash);
+
+                    ctrl_[idx] = detail::h2(hash);
+                    if (idx < kGroupWidth) {
+                        ctrl_[capacity_ + idx] = ctrl_[idx];
+                    }
+
+                    if constexpr (std::is_nothrow_move_constructible_v<value_type>) {
+                        AllocTraits::construct(alloc_, slots_ + idx, std::move(old_slots[i]));
+                    } else {
+                        AllocTraits::construct(alloc_, slots_ + idx, old_slots[i]);
+                    }
+                    AllocTraits::destroy(alloc_, old_slots + i);
+                    ++size_;
+                    --growth_left_;
+                }
+            }
+
+            if (old_ctrl) {
+                CtrlAlloc ctrl_alloc(alloc_);
+                std::allocator_traits<CtrlAlloc>::deallocate(
+                    ctrl_alloc, old_ctrl, old_capacity + kGroupWidth + 1);
+                SlotAlloc slot_alloc(alloc_);
+                std::allocator_traits<SlotAlloc>::deallocate(slot_alloc, old_slots, old_capacity);
+            }
+        } else if constexpr (kUseFlat) {
+            // Flat storage: rehash buckets, keep values array
+            detail::Bucket* old_buckets = buckets_;
+            size_t old_capacity = capacity_;
+            size_t old_size = size_;
+
+            // Allocate new buckets
+            BucketAlloc bucket_alloc(alloc_);
+            buckets_ = std::allocator_traits<BucketAlloc>::allocate(bucket_alloc, new_capacity);
+            for (size_t i = 0; i < new_capacity; ++i) {
+                buckets_[i].set_empty();
+            }
+
+            // Allocate values array if not already allocated
+            if (!values_) {
+                values_capacity_ = new_capacity;
+                SlotAlloc slot_alloc(alloc_);
+                values_ = std::allocator_traits<SlotAlloc>::allocate(slot_alloc, values_capacity_);
+            }
+
+            capacity_ = new_capacity;
+            shift_ = static_cast<uint8_t>(64 - std::countr_zero(new_capacity));  // Update shift for new capacity
+            size_ = 0;
+            growth_left_ = capacity_to_growth(capacity_);
+
+            // Reinsert all values (values stay in place!) using ankerl-style
+            const size_t mask = capacity_ - 1;
+            for (size_t i = 0; i < old_size; ++i) {
+                const size_t hash = hash_(values_[i].first);
+                auto dist_and_fp = detail::Bucket::make_dist_and_fingerprint(hash);
+                size_t bucket_idx = hash >> shift_;  // HIGH bits for bucket index
+
+                // Robin Hood insertion: place and shift up
+                place_and_shift_up(bucket_idx, dist_and_fp, static_cast<uint32_t>(i));
+                ++size_;
+                --growth_left_;
+            }
+
+            // Deallocate old buckets
+            if (old_buckets) {
+                std::allocator_traits<BucketAlloc>::deallocate(
+                    bucket_alloc, old_buckets, old_capacity);
+            }
+        } else {
+            // Swiss Table + Indirect: rehash ctrl + indices, keep values array
+            int8_t* old_ctrl = ctrl_;
+            uint32_t* old_indices = value_indices_;
+            size_t old_capacity = capacity_;
+            size_t old_size = size_;
+
+            // Allocate new ctrl + indices
+            CtrlAlloc ctrl_alloc(alloc_);
+            ctrl_ = std::allocator_traits<CtrlAlloc>::allocate(
+                ctrl_alloc, new_capacity + kGroupWidth + 1);
+            std::memset(ctrl_, static_cast<int>(detail::kEmpty), new_capacity + kGroupWidth);
+            ctrl_[new_capacity + kGroupWidth] = detail::kSentinel;
+
+            IndexAlloc index_alloc(alloc_);
+            value_indices_ = std::allocator_traits<IndexAlloc>::allocate(index_alloc, new_capacity);
+
+            capacity_ = new_capacity;
+            size_ = 0;
+            growth_left_ = capacity_to_growth(capacity_);
+
+            // Reinsert all slots (values stay in place!)
+            const size_t mask = capacity_ - 1;
+            for (size_t i = 0; i < old_size; ++i) {
+                const size_t hash = hash_(values_[i].first);
+                const int8_t h2_val = detail::h2(hash);
+                size_t idx = find_first_empty(hash);
+
+                ctrl_[idx] = h2_val;
+                if (idx < kGroupWidth) {
+                    ctrl_[capacity_ + idx] = h2_val;
+                }
+                value_indices_[idx] = static_cast<uint32_t>(i);
+                ++size_;
+                --growth_left_;
+            }
+
+            // Deallocate old ctrl + indices
+            if (old_ctrl) {
+                std::allocator_traits<CtrlAlloc>::deallocate(
+                    ctrl_alloc, old_ctrl, old_capacity + kGroupWidth + 1);
+                std::allocator_traits<IndexAlloc>::deallocate(
+                    index_alloc, old_indices, old_capacity);
+            }
+        }
+    }
+
+    size_t find_first_empty(size_t hash) {
+        size_t mask = capacity_ - 1;
+        for (detail::ProbeSeq seq(detail::h1(hash), mask);; seq.next()) {
+            detail::Group g(ctrl_ + seq.offset());
+            if (auto mask_bits = g.match_empty_or_deleted()) {
+                return seq.offset(mask_bits.lowest_set_bit());
+            }
+        }
+    }
+};
+
+// Non-member functions
+template <typename K, typename V, typename H, typename E, typename A>
+bool operator==(const dense_map<K, V, H, E, A>& lhs,
+                const dense_map<K, V, H, E, A>& rhs) {
+    if (lhs.size() != rhs.size()) return false;
+    for (const auto& [key, value] : lhs) {
+        auto it = rhs.find(key);
+        if (it == rhs.end() || it->second != value) return false;
+    }
+    return true;
+}
+
+template <typename K, typename V, typename H, typename E, typename A>
+bool operator!=(const dense_map<K, V, H, E, A>& lhs,
+                const dense_map<K, V, H, E, A>& rhs) {
+    return !(lhs == rhs);
+}
+
+template <typename K, typename V, typename H, typename E, typename A>
+void swap(dense_map<K, V, H, E, A>& lhs,
+          dense_map<K, V, H, E, A>& rhs) noexcept {
+    lhs.swap(rhs);
+}
+
+// Type alias for convenience
+template <typename Key, typename Value>
+using fast_map = dense_map<Key, Value>;
+
+}  // namespace stdb::container

--- a/container/devectra.hpp
+++ b/container/devectra.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 #include <algorithm>
+#include <stdexcept>
 
 #include "container_base.hpp"
 

--- a/container/flat_map.hpp
+++ b/container/flat_map.hpp
@@ -1,0 +1,743 @@
+/*
+ * Copyright 2025 ClapDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <initializer_list>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+// Compiler hints
+#if defined(__GNUC__) || defined(__clang__)
+#define FLAT_MAP_LIKELY(x) __builtin_expect(!!(x), 1)
+#define FLAT_MAP_UNLIKELY(x) __builtin_expect(!!(x), 0)
+#define FLAT_MAP_ALWAYS_INLINE [[gnu::always_inline]] inline
+#else
+#define FLAT_MAP_LIKELY(x) (x)
+#define FLAT_MAP_UNLIKELY(x) (x)
+#define FLAT_MAP_ALWAYS_INLINE inline
+#endif
+
+namespace stdb::container {
+
+// ============================================================================
+// Hash functions (reuse from dense_map)
+// ============================================================================
+namespace flat_detail {
+
+// Fast integer hash using 128-bit multiply
+template <typename T>
+FLAT_MAP_ALWAYS_INLINE uint64_t hash_integral(T value) {
+    static_assert(std::is_integral_v<T> || std::is_enum_v<T>);
+#if defined(__SIZEOF_INT128__)
+    __uint128_t prod = static_cast<__uint128_t>(static_cast<uint64_t>(value)) * 0x9e3779b97f4a7c15ull;
+    return static_cast<uint64_t>(prod ^ (prod >> 64));
+#else
+    uint64_t x = static_cast<uint64_t>(value);
+    x ^= x >> 32;
+    x *= 0x9e3779b97f4a7c15ull;
+    x ^= x >> 32;
+    return x;
+#endif
+}
+
+// wyhash for strings/bytes
+FLAT_MAP_ALWAYS_INLINE constexpr uint64_t wymum(uint64_t a, uint64_t b) {
+#if defined(__SIZEOF_INT128__)
+    __uint128_t r = static_cast<__uint128_t>(a) * b;
+    return static_cast<uint64_t>(r ^ (r >> 64));
+#else
+    uint64_t ha = a >> 32, hb = b >> 32;
+    uint64_t la = static_cast<uint32_t>(a), lb = static_cast<uint32_t>(b);
+    uint64_t hi = ha * hb, lo = la * lb;
+    uint64_t rh = ha * lb, rl = la * hb;
+    uint64_t t = rl + (lo >> 32);
+    lo = (t << 32) | static_cast<uint32_t>(lo);
+    hi += rh + (t >> 32) + (t < rl);
+    return hi ^ lo;
+#endif
+}
+
+FLAT_MAP_ALWAYS_INLINE uint64_t wyr8(const uint8_t* p) {
+    uint64_t v;
+    std::memcpy(&v, p, 8);
+    return v;
+}
+
+FLAT_MAP_ALWAYS_INLINE uint64_t wyr4(const uint8_t* p) {
+    uint32_t v;
+    std::memcpy(&v, p, 4);
+    return v;
+}
+
+FLAT_MAP_ALWAYS_INLINE constexpr uint64_t wyr3(const uint8_t* p, size_t k) {
+    return (static_cast<uint64_t>(p[0]) << 16) |
+           (static_cast<uint64_t>(p[k >> 1]) << 8) | p[k - 1];
+}
+
+inline constexpr uint64_t wyp0 = 0xa0761d6478bd642full;
+inline constexpr uint64_t wyp1 = 0xe7037ed1a0b428dbull;
+
+FLAT_MAP_ALWAYS_INLINE uint64_t wyhash(const void* key, size_t len, uint64_t seed = 0) {
+    const auto* p = static_cast<const uint8_t*>(key);
+    seed ^= wyp0;
+    uint64_t a, b;
+    if (FLAT_MAP_LIKELY(len <= 16)) {
+        if (FLAT_MAP_LIKELY(len >= 4)) {
+            a = (wyr4(p) << 32) | wyr4(p + ((len >> 3) << 2));
+            b = (wyr4(p + len - 4) << 32) | wyr4(p + len - 4 - ((len >> 3) << 2));
+        } else if (FLAT_MAP_LIKELY(len > 0)) {
+            a = wyr3(p, len);
+            b = 0;
+        } else {
+            a = b = 0;
+        }
+    } else {
+        size_t i = len;
+        while (FLAT_MAP_UNLIKELY(i > 16)) {
+            seed = wymum(wyr8(p) ^ wyp1, wyr8(p + 8) ^ seed);
+            i -= 16;
+            p += 16;
+        }
+        a = wyr8(p + i - 16);
+        b = wyr8(p + i - 8);
+    }
+    return wymum(wyp1 ^ len, wymum(a ^ wyp1, b ^ seed));
+}
+
+}  // namespace flat_detail
+
+// ============================================================================
+// Default hash function
+// ============================================================================
+template <typename T, typename Enable = void>
+struct flat_hash {
+    size_t operator()(const T& value) const noexcept {
+        return static_cast<size_t>(flat_detail::wyhash(&value, sizeof(T)));
+    }
+};
+
+template <typename T>
+struct flat_hash<T, std::enable_if_t<std::is_integral_v<T> || std::is_enum_v<T>>> {
+    size_t operator()(T value) const noexcept {
+        return static_cast<size_t>(flat_detail::hash_integral(value));
+    }
+};
+
+template <typename T>
+struct flat_hash<T*> {
+    size_t operator()(T* ptr) const noexcept {
+        return static_cast<size_t>(flat_detail::hash_integral(reinterpret_cast<uintptr_t>(ptr)));
+    }
+};
+
+template <>
+struct flat_hash<std::string> {
+    size_t operator()(const std::string& s) const noexcept {
+        return static_cast<size_t>(flat_detail::wyhash(s.data(), s.size()));
+    }
+};
+
+template <>
+struct flat_hash<std::string_view> {
+    size_t operator()(std::string_view s) const noexcept {
+        return static_cast<size_t>(flat_detail::wyhash(s.data(), s.size()));
+    }
+};
+
+// ============================================================================
+// flat_map - Contiguous storage hash map with robin hood hashing
+// ============================================================================
+template <typename Key, typename Value, typename Hash = flat_hash<Key>,
+          typename KeyEqual = std::equal_to<Key>,
+          typename Allocator = std::allocator<std::pair<Key, Value>>>
+class flat_map {
+public:
+    using key_type = Key;
+    using mapped_type = Value;
+    using value_type = std::pair<Key, Value>;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using hasher = Hash;
+    using key_equal = KeyEqual;
+    using allocator_type = Allocator;
+    using reference = value_type&;
+    using const_reference = const value_type&;
+    using pointer = value_type*;
+    using const_pointer = const value_type*;
+
+private:
+    // Bucket structure: stores index into values vector + metadata
+    struct Bucket {
+        static constexpr uint32_t kEmpty = std::numeric_limits<uint32_t>::max();
+
+        uint32_t value_idx = kEmpty;  // Index into values_ vector
+        uint32_t dist_and_h2 = 0;     // [distance:8][h2:24] or [distance:8][fingerprint:24]
+
+        bool is_empty() const { return value_idx == kEmpty; }
+        void set_empty() { value_idx = kEmpty; dist_and_h2 = 0; }
+
+        uint8_t distance() const { return static_cast<uint8_t>(dist_and_h2 >> 24); }
+        uint32_t fingerprint() const { return dist_and_h2 & 0x00FFFFFFu; }
+
+        void set(uint32_t idx, uint8_t dist, uint32_t h2) {
+            value_idx = idx;
+            dist_and_h2 = (static_cast<uint32_t>(dist) << 24) | (h2 & 0x00FFFFFFu);
+        }
+
+        void set_distance(uint8_t dist) {
+            dist_and_h2 = (static_cast<uint32_t>(dist) << 24) | (dist_and_h2 & 0x00FFFFFFu);
+        }
+    };
+
+    using ValueVector = std::vector<value_type, Allocator>;
+    using BucketAlloc = typename std::allocator_traits<Allocator>::template rebind_alloc<Bucket>;
+
+    static constexpr float kMaxLoadFactor = 0.8f;
+    static constexpr size_t kMinBuckets = 8;
+
+    ValueVector values_;
+    Bucket* buckets_ = nullptr;
+    size_t bucket_count_ = 0;
+    size_t bucket_mask_ = 0;
+
+    [[no_unique_address]] Hash hash_;
+    [[no_unique_address]] KeyEqual key_equal_;
+    [[no_unique_address]] BucketAlloc bucket_alloc_;
+
+public:
+    // Iterators - just wrap vector iterators
+    using iterator = typename ValueVector::iterator;
+    using const_iterator = typename ValueVector::const_iterator;
+
+    // Constructors
+    flat_map() = default;
+
+    explicit flat_map(size_type bucket_count, const Hash& hash = Hash(),
+                      const KeyEqual& equal = KeyEqual(),
+                      const Allocator& alloc = Allocator())
+        : values_(alloc), hash_(hash), key_equal_(equal), bucket_alloc_(alloc) {
+        if (bucket_count > 0) {
+            rehash(bucket_count);
+        }
+    }
+
+    flat_map(std::initializer_list<value_type> init, size_type bucket_count = 0,
+             const Hash& hash = Hash(), const KeyEqual& equal = KeyEqual(),
+             const Allocator& alloc = Allocator())
+        : values_(alloc), hash_(hash), key_equal_(equal), bucket_alloc_(alloc) {
+        reserve(std::max(init.size(), bucket_count));
+        for (const auto& item : init) {
+            insert(item);
+        }
+    }
+
+    flat_map(const flat_map& other)
+        : values_(other.values_),
+          hash_(other.hash_),
+          key_equal_(other.key_equal_),
+          bucket_alloc_(std::allocator_traits<BucketAlloc>::select_on_container_copy_construction(other.bucket_alloc_)) {
+        if (other.bucket_count_ > 0) {
+            allocate_buckets(other.bucket_count_);
+            std::memcpy(buckets_, other.buckets_, bucket_count_ * sizeof(Bucket));
+        }
+    }
+
+    flat_map(flat_map&& other) noexcept
+        : values_(std::move(other.values_)),
+          buckets_(other.buckets_),
+          bucket_count_(other.bucket_count_),
+          bucket_mask_(other.bucket_mask_),
+          hash_(std::move(other.hash_)),
+          key_equal_(std::move(other.key_equal_)),
+          bucket_alloc_(std::move(other.bucket_alloc_)) {
+        other.buckets_ = nullptr;
+        other.bucket_count_ = 0;
+        other.bucket_mask_ = 0;
+    }
+
+    ~flat_map() { destroy_buckets(); }
+
+    flat_map& operator=(const flat_map& other) {
+        if (this != &other) {
+            flat_map tmp(other);
+            swap(tmp);
+        }
+        return *this;
+    }
+
+    flat_map& operator=(flat_map&& other) noexcept {
+        if (this != &other) {
+            destroy_buckets();
+            values_ = std::move(other.values_);
+            buckets_ = other.buckets_;
+            bucket_count_ = other.bucket_count_;
+            bucket_mask_ = other.bucket_mask_;
+            hash_ = std::move(other.hash_);
+            key_equal_ = std::move(other.key_equal_);
+            other.buckets_ = nullptr;
+            other.bucket_count_ = 0;
+            other.bucket_mask_ = 0;
+        }
+        return *this;
+    }
+
+    // Iterators - contiguous, so super fast!
+    iterator begin() noexcept { return values_.begin(); }
+    const_iterator begin() const noexcept { return values_.begin(); }
+    const_iterator cbegin() const noexcept { return values_.cbegin(); }
+    iterator end() noexcept { return values_.end(); }
+    const_iterator end() const noexcept { return values_.end(); }
+    const_iterator cend() const noexcept { return values_.cend(); }
+
+    // Capacity
+    [[nodiscard]] bool empty() const noexcept { return values_.empty(); }
+    size_type size() const noexcept { return values_.size(); }
+    size_type max_size() const noexcept { return std::numeric_limits<uint32_t>::max() - 1; }
+    size_type capacity() const noexcept { return values_.capacity(); }
+    size_type bucket_count() const noexcept { return bucket_count_; }
+
+    // Modifiers
+    void clear() noexcept {
+        values_.clear();
+        if (buckets_) {
+            for (size_t i = 0; i < bucket_count_; ++i) {
+                buckets_[i].set_empty();
+            }
+        }
+    }
+
+    std::pair<iterator, bool> insert(const value_type& value) {
+        return emplace(value.first, value.second);
+    }
+
+    std::pair<iterator, bool> insert(value_type&& value) {
+        return emplace(std::move(value.first), std::move(value.second));
+    }
+
+    template <typename InputIt>
+    void insert(InputIt first, InputIt last) {
+        for (; first != last; ++first) {
+            insert(*first);
+        }
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> emplace(Args&&... args) {
+        return emplace_impl(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> try_emplace(const Key& key, Args&&... args) {
+        return try_emplace_impl(key, std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> try_emplace(Key&& key, Args&&... args) {
+        return try_emplace_impl(std::move(key), std::forward<Args>(args)...);
+    }
+
+    iterator erase(const_iterator pos) {
+        size_t idx = static_cast<size_t>(pos - values_.begin());
+        erase_at_index(idx);
+        return values_.begin() + idx;
+    }
+
+    size_type erase(const Key& key) {
+        auto it = find(key);
+        if (it == end()) return 0;
+        erase(it);
+        return 1;
+    }
+
+    void swap(flat_map& other) noexcept {
+        using std::swap;
+        values_.swap(other.values_);
+        swap(buckets_, other.buckets_);
+        swap(bucket_count_, other.bucket_count_);
+        swap(bucket_mask_, other.bucket_mask_);
+        swap(hash_, other.hash_);
+        swap(key_equal_, other.key_equal_);
+    }
+
+    // Lookup
+    mapped_type& at(const Key& key) {
+        auto it = find(key);
+        if (it == end()) {
+            throw std::out_of_range("flat_map::at: key not found");
+        }
+        return it->second;
+    }
+
+    const mapped_type& at(const Key& key) const {
+        auto it = find(key);
+        if (it == end()) {
+            throw std::out_of_range("flat_map::at: key not found");
+        }
+        return it->second;
+    }
+
+    mapped_type& operator[](const Key& key) {
+        auto result = try_emplace(key);
+        return result.first->second;
+    }
+
+    mapped_type& operator[](Key&& key) {
+        auto result = try_emplace(std::move(key));
+        return result.first->second;
+    }
+
+    size_type count(const Key& key) const { return contains(key) ? 1 : 0; }
+
+    FLAT_MAP_ALWAYS_INLINE iterator find(const Key& key) {
+        if (FLAT_MAP_UNLIKELY(bucket_count_ == 0)) return end();
+        return find_impl(key);
+    }
+
+    FLAT_MAP_ALWAYS_INLINE const_iterator find(const Key& key) const {
+        if (FLAT_MAP_UNLIKELY(bucket_count_ == 0)) return end();
+        return const_cast<flat_map*>(this)->find_impl(key);
+    }
+
+    bool contains(const Key& key) const { return find(key) != end(); }
+
+    // Hash policy
+    float load_factor() const noexcept {
+        return bucket_count_ == 0 ? 0.0f : static_cast<float>(size()) / bucket_count_;
+    }
+
+    float max_load_factor() const noexcept { return kMaxLoadFactor; }
+
+    void rehash(size_type count) {
+        size_t min_buckets = static_cast<size_t>(std::ceil(size() / kMaxLoadFactor));
+        count = std::max({count, min_buckets, kMinBuckets});
+        count = next_power_of_2(count);
+        if (count != bucket_count_) {
+            rehash_impl(count);
+        }
+    }
+
+    void reserve(size_type count) {
+        values_.reserve(count);
+        size_t required_buckets = static_cast<size_t>(std::ceil(count / kMaxLoadFactor));
+        if (required_buckets > bucket_count_) {
+            rehash(required_buckets);
+        }
+    }
+
+    // Observers
+    hasher hash_function() const { return hash_; }
+    key_equal key_eq() const { return key_equal_; }
+    allocator_type get_allocator() const noexcept { return values_.get_allocator(); }
+
+private:
+    static size_t next_power_of_2(size_t n) {
+        if (n < kMinBuckets) return kMinBuckets;
+        --n;
+        n |= n >> 1;
+        n |= n >> 2;
+        n |= n >> 4;
+        n |= n >> 8;
+        n |= n >> 16;
+        n |= n >> 32;
+        return n + 1;
+    }
+
+    void allocate_buckets(size_t count) {
+        bucket_count_ = count;
+        bucket_mask_ = count - 1;
+        buckets_ = std::allocator_traits<BucketAlloc>::allocate(bucket_alloc_, count);
+        for (size_t i = 0; i < count; ++i) {
+            buckets_[i].set_empty();
+        }
+    }
+
+    void destroy_buckets() {
+        if (buckets_) {
+            std::allocator_traits<BucketAlloc>::deallocate(bucket_alloc_, buckets_, bucket_count_);
+            buckets_ = nullptr;
+            bucket_count_ = 0;
+            bucket_mask_ = 0;
+        }
+    }
+
+    FLAT_MAP_ALWAYS_INLINE uint32_t fingerprint(size_t hash) const {
+        return static_cast<uint32_t>(hash >> 40) & 0x00FFFFFFu;
+    }
+
+    FLAT_MAP_ALWAYS_INLINE iterator find_impl(const Key& key) {
+        const size_t hash = hash_(key);
+        const uint32_t fp = fingerprint(hash);
+        size_t bucket_idx = hash & bucket_mask_;
+        uint8_t dist = 0;
+
+        while (true) {
+            const Bucket& b = buckets_[bucket_idx];
+
+            if (b.is_empty() || dist > b.distance()) {
+                return end();
+            }
+
+            if (b.fingerprint() == fp && key_equal_(key, values_[b.value_idx].first)) {
+                return values_.begin() + b.value_idx;
+            }
+
+            ++dist;
+            bucket_idx = (bucket_idx + 1) & bucket_mask_;
+        }
+    }
+
+    template <typename K, typename V>
+    std::pair<iterator, bool> emplace_impl(K&& key, V&& value) {
+        maybe_rehash();
+
+        const size_t hash = hash_(key);
+        const uint32_t fp = fingerprint(hash);
+        size_t bucket_idx = hash & bucket_mask_;
+        uint8_t dist = 0;
+
+        while (true) {
+            Bucket& b = buckets_[bucket_idx];
+
+            if (b.is_empty()) {
+                // Insert here
+                uint32_t value_idx = static_cast<uint32_t>(values_.size());
+                values_.emplace_back(std::forward<K>(key), std::forward<V>(value));
+                b.set(value_idx, dist, fp);
+                return {values_.begin() + value_idx, true};
+            }
+
+            if (b.fingerprint() == fp && key_equal_(key, values_[b.value_idx].first)) {
+                // Key exists
+                return {values_.begin() + b.value_idx, false};
+            }
+
+            // Robin hood: steal from rich, give to poor
+            if (dist > b.distance()) {
+                // Insert here and displace current
+                uint32_t value_idx = static_cast<uint32_t>(values_.size());
+                values_.emplace_back(std::forward<K>(key), std::forward<V>(value));
+
+                Bucket to_insert;
+                to_insert.set(value_idx, dist, fp);
+                insert_bucket_displace(bucket_idx, to_insert);
+
+                return {values_.begin() + value_idx, true};
+            }
+
+            ++dist;
+            bucket_idx = (bucket_idx + 1) & bucket_mask_;
+        }
+    }
+
+    template <typename K, typename... Args>
+    std::pair<iterator, bool> try_emplace_impl(K&& key, Args&&... args) {
+        maybe_rehash();
+
+        const size_t hash = hash_(key);
+        const uint32_t fp = fingerprint(hash);
+        size_t bucket_idx = hash & bucket_mask_;
+        uint8_t dist = 0;
+
+        while (true) {
+            Bucket& b = buckets_[bucket_idx];
+
+            if (b.is_empty()) {
+                uint32_t value_idx = static_cast<uint32_t>(values_.size());
+                values_.emplace_back(std::piecewise_construct,
+                                     std::forward_as_tuple(std::forward<K>(key)),
+                                     std::forward_as_tuple(std::forward<Args>(args)...));
+                b.set(value_idx, dist, fp);
+                return {values_.begin() + value_idx, true};
+            }
+
+            if (b.fingerprint() == fp && key_equal_(key, values_[b.value_idx].first)) {
+                return {values_.begin() + b.value_idx, false};
+            }
+
+            if (dist > b.distance()) {
+                uint32_t value_idx = static_cast<uint32_t>(values_.size());
+                values_.emplace_back(std::piecewise_construct,
+                                     std::forward_as_tuple(std::forward<K>(key)),
+                                     std::forward_as_tuple(std::forward<Args>(args)...));
+
+                Bucket to_insert;
+                to_insert.set(value_idx, dist, fp);
+                insert_bucket_displace(bucket_idx, to_insert);
+
+                return {values_.begin() + value_idx, true};
+            }
+
+            ++dist;
+            bucket_idx = (bucket_idx + 1) & bucket_mask_;
+        }
+    }
+
+    void insert_bucket_displace(size_t bucket_idx, Bucket to_insert) {
+        while (true) {
+            Bucket& b = buckets_[bucket_idx];
+
+            if (b.is_empty()) {
+                b = to_insert;
+                return;
+            }
+
+            if (to_insert.distance() > b.distance()) {
+                std::swap(b, to_insert);
+            }
+
+            to_insert.set_distance(to_insert.distance() + 1);
+            bucket_idx = (bucket_idx + 1) & bucket_mask_;
+        }
+    }
+
+    void erase_at_index(size_t value_idx) {
+        // Find and remove the bucket entry
+        const Key& key = values_[value_idx].first;
+        const size_t hash = hash_(key);
+        size_t bucket_idx = hash & bucket_mask_;
+
+        // Find the bucket
+        while (true) {
+            Bucket& b = buckets_[bucket_idx];
+            if (b.value_idx == value_idx) {
+                // Found it - backward shift delete
+                backward_shift_delete(bucket_idx);
+                break;
+            }
+            bucket_idx = (bucket_idx + 1) & bucket_mask_;
+        }
+
+        // Swap with last element if not already last
+        size_t last_idx = values_.size() - 1;
+        if (value_idx != last_idx) {
+            // Update bucket for the moved element
+            const Key& moved_key = values_[last_idx].first;
+            const size_t moved_hash = hash_(moved_key);
+            size_t moved_bucket = moved_hash & bucket_mask_;
+
+            while (true) {
+                Bucket& b = buckets_[moved_bucket];
+                if (b.value_idx == last_idx) {
+                    b.value_idx = static_cast<uint32_t>(value_idx);
+                    break;
+                }
+                moved_bucket = (moved_bucket + 1) & bucket_mask_;
+            }
+
+            values_[value_idx] = std::move(values_[last_idx]);
+        }
+
+        values_.pop_back();
+    }
+
+    void backward_shift_delete(size_t bucket_idx) {
+        size_t next_idx = (bucket_idx + 1) & bucket_mask_;
+
+        while (true) {
+            Bucket& next = buckets_[next_idx];
+
+            if (next.is_empty() || next.distance() == 0) {
+                buckets_[bucket_idx].set_empty();
+                return;
+            }
+
+            // Shift backward
+            buckets_[bucket_idx] = next;
+            buckets_[bucket_idx].set_distance(next.distance() - 1);
+
+            bucket_idx = next_idx;
+            next_idx = (next_idx + 1) & bucket_mask_;
+        }
+    }
+
+    void maybe_rehash() {
+        if (FLAT_MAP_UNLIKELY(bucket_count_ == 0)) {
+            allocate_buckets(kMinBuckets);
+        } else if (FLAT_MAP_UNLIKELY(values_.size() >= bucket_count_ * kMaxLoadFactor)) {
+            rehash_impl(bucket_count_ * 2);
+        }
+    }
+
+    void rehash_impl(size_t new_bucket_count) {
+        Bucket* old_buckets = buckets_;
+        size_t old_bucket_count = bucket_count_;
+
+        allocate_buckets(new_bucket_count);
+
+        // Reinsert all values
+        for (size_t i = 0; i < values_.size(); ++i) {
+            const size_t hash = hash_(values_[i].first);
+            const uint32_t fp = fingerprint(hash);
+            size_t bucket_idx = hash & bucket_mask_;
+            uint8_t dist = 0;
+
+            Bucket to_insert;
+            to_insert.set(static_cast<uint32_t>(i), dist, fp);
+
+            while (true) {
+                Bucket& b = buckets_[bucket_idx];
+
+                if (b.is_empty()) {
+                    b = to_insert;
+                    break;
+                }
+
+                if (to_insert.distance() > b.distance()) {
+                    std::swap(b, to_insert);
+                }
+
+                to_insert.set_distance(to_insert.distance() + 1);
+                bucket_idx = (bucket_idx + 1) & bucket_mask_;
+            }
+        }
+
+        // Free old buckets
+        if (old_buckets) {
+            std::allocator_traits<BucketAlloc>::deallocate(bucket_alloc_, old_buckets, old_bucket_count);
+        }
+    }
+};
+
+// Non-member functions
+template <typename K, typename V, typename H, typename E, typename A>
+bool operator==(const flat_map<K, V, H, E, A>& lhs,
+                const flat_map<K, V, H, E, A>& rhs) {
+    if (lhs.size() != rhs.size()) return false;
+    for (const auto& [key, value] : lhs) {
+        auto it = rhs.find(key);
+        if (it == rhs.end() || it->second != value) return false;
+    }
+    return true;
+}
+
+template <typename K, typename V, typename H, typename E, typename A>
+void swap(flat_map<K, V, H, E, A>& lhs, flat_map<K, V, H, E, A>& rhs) noexcept {
+    lhs.swap(rhs);
+}
+
+}  // namespace stdb::container

--- a/tests/dense_map_test.cc
+++ b/tests/dense_map_test.cc
@@ -1,0 +1,897 @@
+/*
+ * Copyright 2025 ClapDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "container/dense_map.hpp"
+
+#include <random>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "doctest/doctest/doctest.h"
+
+namespace stdb::container {
+
+TEST_CASE("dense_map::basic") {
+    SUBCASE("default constructor") {
+        dense_map<int, int> map;
+        CHECK(map.empty());
+        CHECK_EQ(map.size(), 0);
+    }
+
+    SUBCASE("initializer list") {
+        dense_map<int, std::string> map{{1, "one"}, {2, "two"}, {3, "three"}};
+        CHECK_EQ(map.size(), 3);
+        CHECK_EQ(map.at(1), "one");
+        CHECK_EQ(map.at(2), "two");
+        CHECK_EQ(map.at(3), "three");
+    }
+
+    SUBCASE("capacity constructor") {
+        dense_map<int, int> map(100);
+        CHECK(map.empty());
+        CHECK_GE(map.capacity(), 100);
+    }
+}
+
+TEST_CASE("dense_map::insert") {
+    SUBCASE("insert single value") {
+        dense_map<int, int> map;
+        auto [it, inserted] = map.insert({1, 10});
+        CHECK(inserted);
+        CHECK_EQ(it->first, 1);
+        CHECK_EQ(it->second, 10);
+        CHECK_EQ(map.size(), 1);
+
+        // Insert duplicate
+        auto [it2, inserted2] = map.insert({1, 20});
+        CHECK_FALSE(inserted2);
+        CHECK_EQ(it2->second, 10);  // Original value unchanged
+        CHECK_EQ(map.size(), 1);
+    }
+
+    SUBCASE("insert move") {
+        dense_map<int, std::string> map;
+        std::string value = "hello";
+        auto [it, inserted] = map.insert({1, std::move(value)});
+        CHECK(inserted);
+        CHECK_EQ(it->second, "hello");
+    }
+
+    SUBCASE("insert_or_assign") {
+        dense_map<int, int> map;
+        auto [it1, inserted1] = map.insert_or_assign(1, 10);
+        CHECK(inserted1);
+        CHECK_EQ(it1->second, 10);
+
+        auto [it2, inserted2] = map.insert_or_assign(1, 20);
+        CHECK_FALSE(inserted2);
+        CHECK_EQ(it2->second, 20);  // Value updated
+    }
+
+    SUBCASE("insert range") {
+        std::vector<std::pair<int, int>> vec{{1, 10}, {2, 20}, {3, 30}};
+        dense_map<int, int> map;
+        map.insert(vec.begin(), vec.end());
+        CHECK_EQ(map.size(), 3);
+        CHECK_EQ(map.at(1), 10);
+        CHECK_EQ(map.at(2), 20);
+        CHECK_EQ(map.at(3), 30);
+    }
+}
+
+TEST_CASE("dense_map::emplace") {
+    SUBCASE("emplace") {
+        dense_map<int, std::string> map;
+        auto [it, inserted] = map.emplace(1, "hello");
+        CHECK(inserted);
+        CHECK_EQ(it->first, 1);
+        CHECK_EQ(it->second, "hello");
+
+        // Emplace duplicate
+        auto [it2, inserted2] = map.emplace(1, "world");
+        CHECK_FALSE(inserted2);
+        CHECK_EQ(it2->second, "hello");
+    }
+
+    SUBCASE("try_emplace") {
+        dense_map<int, std::string> map;
+        auto [it1, inserted1] = map.try_emplace(1, "hello");
+        CHECK(inserted1);
+        CHECK_EQ(it1->second, "hello");
+
+        // try_emplace on existing key - should NOT update
+        auto [it2, inserted2] = map.try_emplace(1, "world");
+        CHECK_FALSE(inserted2);
+        CHECK_EQ(it2->second, "hello");  // Original value preserved
+    }
+}
+
+TEST_CASE("dense_map::erase") {
+    SUBCASE("erase by key") {
+        dense_map<int, int> map{{1, 10}, {2, 20}, {3, 30}};
+        auto erased = map.erase(2);
+        CHECK_EQ(erased, 1);
+        CHECK_EQ(map.size(), 2);
+        CHECK_FALSE(map.contains(2));
+        CHECK(map.contains(1));
+        CHECK(map.contains(3));
+
+        // Erase non-existent
+        erased = map.erase(100);
+        CHECK_EQ(erased, 0);
+    }
+
+    SUBCASE("erase by iterator") {
+        dense_map<int, int> map{{1, 10}, {2, 20}, {3, 30}};
+        auto it = map.find(2);
+        REQUIRE(it != map.end());
+        map.erase(it);
+        CHECK_EQ(map.size(), 2);
+        CHECK_FALSE(map.contains(2));
+    }
+
+    SUBCASE("clear") {
+        dense_map<int, int> map{{1, 10}, {2, 20}, {3, 30}};
+        map.clear();
+        CHECK(map.empty());
+        CHECK_EQ(map.size(), 0);
+    }
+}
+
+TEST_CASE("dense_map::lookup") {
+    dense_map<int, std::string> map{{1, "one"}, {2, "two"}, {3, "three"}};
+
+    SUBCASE("find existing") {
+        auto it = map.find(2);
+        REQUIRE(it != map.end());
+        CHECK_EQ(it->first, 2);
+        CHECK_EQ(it->second, "two");
+    }
+
+    SUBCASE("find non-existing") {
+        auto it = map.find(100);
+        CHECK(it == map.end());
+    }
+
+    SUBCASE("contains") {
+        CHECK(map.contains(1));
+        CHECK(map.contains(2));
+        CHECK(map.contains(3));
+        CHECK_FALSE(map.contains(100));
+    }
+
+    SUBCASE("at") {
+        CHECK_EQ(map.at(1), "one");
+        CHECK_THROWS_AS(map.at(100), std::out_of_range);
+    }
+
+    SUBCASE("operator[]") {
+        CHECK_EQ(map[1], "one");
+        // operator[] inserts default value for non-existent key
+        map[100] = "hundred";
+        CHECK(map.contains(100));
+        CHECK_EQ(map[100], "hundred");
+    }
+
+    SUBCASE("count") {
+        CHECK_EQ(map.count(1), 1);
+        CHECK_EQ(map.count(100), 0);
+    }
+
+    SUBCASE("equal_range") {
+        auto [first, last] = map.equal_range(2);
+        REQUIRE(first != last);
+        CHECK_EQ(first->first, 2);
+        ++first;
+        CHECK(first == last);
+
+        auto [f2, l2] = map.equal_range(100);
+        CHECK(f2 == l2);
+    }
+}
+
+TEST_CASE("dense_map::iterator") {
+    SUBCASE("iteration") {
+        dense_map<int, int> map{{1, 10}, {2, 20}, {3, 30}};
+        std::unordered_map<int, int> found;
+        for (const auto& [k, v] : map) {
+            found[k] = v;
+        }
+        CHECK_EQ(found.size(), 3);
+        CHECK_EQ(found[1], 10);
+        CHECK_EQ(found[2], 20);
+        CHECK_EQ(found[3], 30);
+    }
+
+    SUBCASE("empty iteration") {
+        dense_map<int, int> map;
+        int count = 0;
+        for ([[maybe_unused]] const auto& kv : map) {
+            ++count;
+        }
+        CHECK_EQ(count, 0);
+    }
+
+    SUBCASE("const iteration") {
+        const dense_map<int, int> map{{1, 10}, {2, 20}};
+        std::unordered_map<int, int> found;
+        for (const auto& [k, v] : map) {
+            found[k] = v;
+        }
+        CHECK_EQ(found.size(), 2);
+    }
+}
+
+TEST_CASE("dense_map::copy_and_move") {
+    SUBCASE("copy constructor") {
+        dense_map<int, std::string> original{{1, "one"}, {2, "two"}};
+        dense_map<int, std::string> copy(original);
+        CHECK_EQ(copy.size(), 2);
+        CHECK_EQ(copy.at(1), "one");
+        CHECK_EQ(copy.at(2), "two");
+
+        // Modify original, copy unchanged
+        original[1] = "ONE";
+        CHECK_EQ(copy.at(1), "one");
+    }
+
+    SUBCASE("copy assignment") {
+        dense_map<int, int> original{{1, 10}, {2, 20}};
+        dense_map<int, int> copy;
+        copy = original;
+        CHECK_EQ(copy.size(), 2);
+        CHECK_EQ(copy.at(1), 10);
+    }
+
+    SUBCASE("move constructor") {
+        dense_map<int, std::string> original{{1, "one"}, {2, "two"}};
+        dense_map<int, std::string> moved(std::move(original));
+        CHECK_EQ(moved.size(), 2);
+        CHECK_EQ(moved.at(1), "one");
+        CHECK(original.empty());  // NOLINT
+    }
+
+    SUBCASE("move assignment") {
+        dense_map<int, int> original{{1, 10}, {2, 20}};
+        dense_map<int, int> moved;
+        moved = std::move(original);
+        CHECK_EQ(moved.size(), 2);
+        CHECK(original.empty());  // NOLINT
+    }
+
+    SUBCASE("swap") {
+        dense_map<int, int> a{{1, 10}};
+        dense_map<int, int> b{{2, 20}, {3, 30}};
+        a.swap(b);
+        CHECK_EQ(a.size(), 2);
+        CHECK_EQ(b.size(), 1);
+        CHECK(a.contains(2));
+        CHECK(b.contains(1));
+    }
+}
+
+TEST_CASE("dense_map::hash_policy") {
+    SUBCASE("load_factor") {
+        dense_map<int, int> map;
+        CHECK_EQ(map.load_factor(), 0.0f);
+
+        map[1] = 10;
+        CHECK_GT(map.load_factor(), 0.0f);
+        CHECK_LE(map.load_factor(), map.max_load_factor());
+    }
+
+    SUBCASE("reserve") {
+        dense_map<int, int> map;
+        map.reserve(1000);
+        CHECK_GE(map.capacity(), 1000);
+        size_t cap = map.capacity();
+
+        // Inserting up to reserved amount shouldn't reallocate
+        for (int i = 0; i < 800; ++i) {
+            map[i] = i * 10;
+        }
+        CHECK_EQ(map.capacity(), cap);
+    }
+
+    SUBCASE("rehash") {
+        dense_map<int, int> map;
+        for (int i = 0; i < 100; ++i) {
+            map[i] = i;
+        }
+        size_t old_cap = map.capacity();
+
+        map.rehash(old_cap * 2);
+        CHECK_GE(map.capacity(), old_cap * 2);
+
+        // All elements should still be accessible
+        for (int i = 0; i < 100; ++i) {
+            CHECK_EQ(map.at(i), i);
+        }
+    }
+}
+
+TEST_CASE("dense_map::stress_test") {
+    SUBCASE("large insert and lookup") {
+        constexpr int N = 10000;
+        dense_map<int, int> map;
+        map.reserve(N);
+
+        for (int i = 0; i < N; ++i) {
+            map[i] = i * 2;
+        }
+        CHECK_EQ(map.size(), N);
+
+        for (int i = 0; i < N; ++i) {
+            CHECK_EQ(map.at(i), i * 2);
+        }
+    }
+
+    SUBCASE("random operations") {
+        std::mt19937 gen(42);
+        std::uniform_int_distribution<int> dist(0, 10000);
+
+        dense_map<int, int> map;
+        std::unordered_map<int, int> reference;
+
+        for (int i = 0; i < 5000; ++i) {
+            int key = dist(gen);
+            int value = dist(gen);
+
+            if (dist(gen) % 3 == 0 && !reference.empty()) {
+                // Erase
+                auto it = reference.begin();
+                map.erase(it->first);
+                reference.erase(it);
+            } else {
+                // Insert
+                map[key] = value;
+                reference[key] = value;
+            }
+        }
+
+        CHECK_EQ(map.size(), reference.size());
+        for (const auto& [k, v] : reference) {
+            CHECK_EQ(map.at(k), v);
+        }
+    }
+
+    SUBCASE("insert and erase interleaved") {
+        dense_map<int, int> map;
+
+        // Insert 1000 elements
+        for (int i = 0; i < 1000; ++i) {
+            map[i] = i;
+        }
+
+        // Erase even numbers
+        for (int i = 0; i < 1000; i += 2) {
+            map.erase(i);
+        }
+        CHECK_EQ(map.size(), 500);
+
+        // Verify odd numbers remain
+        for (int i = 1; i < 1000; i += 2) {
+            CHECK_EQ(map.at(i), i);
+        }
+
+        // Reinsert evens
+        for (int i = 0; i < 1000; i += 2) {
+            map[i] = i * 10;
+        }
+        CHECK_EQ(map.size(), 1000);
+
+        // Verify all
+        for (int i = 0; i < 1000; ++i) {
+            if (i % 2 == 0) {
+                CHECK_EQ(map.at(i), i * 10);
+            } else {
+                CHECK_EQ(map.at(i), i);
+            }
+        }
+    }
+}
+
+TEST_CASE("dense_map::string_keys") {
+    SUBCASE("basic string operations") {
+        dense_map<std::string, int> map;
+        map["hello"] = 1;
+        map["world"] = 2;
+        map["test"] = 3;
+
+        CHECK_EQ(map.size(), 3);
+        CHECK_EQ(map.at("hello"), 1);
+        CHECK_EQ(map.at("world"), 2);
+        CHECK(map.contains("test"));
+        CHECK_FALSE(map.contains("missing"));
+    }
+
+    SUBCASE("string stress test") {
+        dense_map<std::string, int> map;
+        for (int i = 0; i < 1000; ++i) {
+            map["key_" + std::to_string(i)] = i;
+        }
+        CHECK_EQ(map.size(), 1000);
+
+        for (int i = 0; i < 1000; ++i) {
+            CHECK_EQ(map.at("key_" + std::to_string(i)), i);
+        }
+    }
+}
+
+TEST_CASE("dense_map::transparent_lookup") {
+    SUBCASE("string_hash transparent lookup") {
+        dense_map<std::string, int, string_hash, std::equal_to<>> map;
+        map["hello"] = 1;
+        map["world"] = 2;
+
+        // Lookup with string_view
+        std::string_view sv = "hello";
+        CHECK(map.contains(sv));
+        CHECK_EQ(map.find(sv)->second, 1);
+
+        // Lookup with const char*
+        CHECK(map.contains("world"));
+    }
+}
+
+TEST_CASE("dense_map::equality") {
+    SUBCASE("equal maps") {
+        dense_map<int, int> a{{1, 10}, {2, 20}, {3, 30}};
+        dense_map<int, int> b{{3, 30}, {1, 10}, {2, 20}};  // Different order
+        CHECK(a == b);
+        CHECK_FALSE(a != b);
+    }
+
+    SUBCASE("different sizes") {
+        dense_map<int, int> a{{1, 10}, {2, 20}};
+        dense_map<int, int> b{{1, 10}};
+        CHECK(a != b);
+        CHECK_FALSE(a == b);
+    }
+
+    SUBCASE("different values") {
+        dense_map<int, int> a{{1, 10}};
+        dense_map<int, int> b{{1, 20}};
+        CHECK(a != b);
+    }
+
+    SUBCASE("different keys") {
+        dense_map<int, int> a{{1, 10}};
+        dense_map<int, int> b{{2, 10}};
+        CHECK(a != b);
+    }
+}
+
+TEST_CASE("dense_map::hash_quality") {
+    // Test that hash distribution is reasonable
+    SUBCASE("sequential keys") {
+        dense_map<int, int> map;
+        for (int i = 0; i < 10000; ++i) {
+            map[i] = i;
+        }
+        CHECK_EQ(map.size(), 10000);
+        CHECK_LE(map.load_factor(), map.max_load_factor());
+    }
+
+    SUBCASE("sparse keys") {
+        dense_map<int, int> map;
+        for (int i = 0; i < 1000; ++i) {
+            map[i * 1000] = i;
+        }
+        CHECK_EQ(map.size(), 1000);
+    }
+}
+
+// Additional comprehensive tests based on tsl/ankerl patterns
+
+TEST_CASE("dense_map::edge_cases") {
+    SUBCASE("operations on empty map") {
+        dense_map<int, int> map;
+        CHECK(map.find(1) == map.end());
+        CHECK_EQ(map.erase(1), 0);
+        CHECK_EQ(map.count(1), 0);
+        CHECK_FALSE(map.contains(1));
+        map.clear();  // Should not crash
+        CHECK(map.empty());
+    }
+
+    SUBCASE("single element") {
+        dense_map<int, int> map;
+        map[42] = 100;
+        CHECK_EQ(map.size(), 1);
+        CHECK_EQ(map.at(42), 100);
+
+        // Erase and re-insert
+        map.erase(42);
+        CHECK(map.empty());
+        map[42] = 200;
+        CHECK_EQ(map.at(42), 200);
+    }
+
+    SUBCASE("erase all elements") {
+        dense_map<int, int> map;
+        for (int i = 0; i < 100; ++i) {
+            map[i] = i;
+        }
+
+        // Erase all one by one
+        for (int i = 0; i < 100; ++i) {
+            CHECK_EQ(map.erase(i), 1);
+        }
+        CHECK(map.empty());
+        CHECK_EQ(map.size(), 0);
+
+        // Insert again
+        map[0] = 0;
+        CHECK_EQ(map.size(), 1);
+    }
+
+    SUBCASE("rehash to smaller") {
+        dense_map<int, int> map;
+        map.reserve(1000);
+        for (int i = 0; i < 10; ++i) {
+            map[i] = i;
+        }
+        map.rehash(16);
+        CHECK_EQ(map.size(), 10);
+        for (int i = 0; i < 10; ++i) {
+            CHECK_EQ(map.at(i), i);
+        }
+    }
+}
+
+TEST_CASE("dense_map::various_key_types") {
+    SUBCASE("int8 keys") {
+        dense_map<int8_t, int> map;
+        for (int8_t i = -100; i < 100; ++i) {
+            map[i] = i * 2;
+        }
+        CHECK_EQ(map.size(), 200);
+        for (int8_t i = -100; i < 100; ++i) {
+            CHECK_EQ(map.at(i), i * 2);
+        }
+    }
+
+    SUBCASE("int64 keys") {
+        dense_map<int64_t, int> map;
+        for (int64_t i = 0; i < 1000; ++i) {
+            map[i * 1000000000LL] = static_cast<int>(i);
+        }
+        CHECK_EQ(map.size(), 1000);
+        for (int64_t i = 0; i < 1000; ++i) {
+            CHECK_EQ(map.at(i * 1000000000LL), static_cast<int>(i));
+        }
+    }
+
+    SUBCASE("pointer keys") {
+        std::vector<int> values(100);
+        dense_map<int*, int> map;
+        for (int i = 0; i < 100; ++i) {
+            values[i] = i;
+            map[&values[i]] = i * 10;
+        }
+        CHECK_EQ(map.size(), 100);
+        for (int i = 0; i < 100; ++i) {
+            CHECK_EQ(map.at(&values[i]), i * 10);
+        }
+    }
+
+    SUBCASE("size_t keys") {
+        dense_map<size_t, int> map;
+        for (size_t i = 0; i < 1000; ++i) {
+            map[i] = static_cast<int>(i);
+        }
+        CHECK_EQ(map.size(), 1000);
+    }
+}
+
+TEST_CASE("dense_map::collision_handling") {
+    // Custom hash that forces collisions
+    struct BadHash {
+        size_t operator()(int key) const noexcept {
+            return static_cast<size_t>(key % 8);  // Only 8 different hash values
+        }
+    };
+
+    SUBCASE("many collisions insert") {
+        dense_map<int, int, BadHash> map;
+        for (int i = 0; i < 1000; ++i) {
+            map[i] = i * 2;
+        }
+        CHECK_EQ(map.size(), 1000);
+        for (int i = 0; i < 1000; ++i) {
+            CHECK_EQ(map.at(i), i * 2);
+        }
+    }
+
+    SUBCASE("many collisions erase") {
+        dense_map<int, int, BadHash> map;
+        for (int i = 0; i < 1000; ++i) {
+            map[i] = i;
+        }
+
+        // Erase every other element
+        for (int i = 0; i < 1000; i += 2) {
+            map.erase(i);
+        }
+        CHECK_EQ(map.size(), 500);
+
+        // Check remaining
+        for (int i = 1; i < 1000; i += 2) {
+            CHECK_EQ(map.at(i), i);
+        }
+    }
+}
+
+TEST_CASE("dense_map::complex_values") {
+    SUBCASE("vector value") {
+        dense_map<int, std::vector<int>> map;
+        map[1] = {1, 2, 3};
+        map[2] = {4, 5, 6, 7, 8};
+
+        CHECK_EQ(map.at(1).size(), 3);
+        CHECK_EQ(map.at(2).size(), 5);
+        CHECK_EQ(map.at(1)[0], 1);
+        CHECK_EQ(map.at(2)[4], 8);
+    }
+
+    SUBCASE("map value") {
+        dense_map<int, std::unordered_map<std::string, int>> map;
+        map[1]["a"] = 1;
+        map[1]["b"] = 2;
+        map[2]["x"] = 10;
+
+        CHECK_EQ(map.at(1).size(), 2);
+        CHECK_EQ(map.at(2).at("x"), 10);
+    }
+
+    SUBCASE("pair value") {
+        dense_map<int, std::pair<std::string, double>> map;
+        map[1] = {"hello", 3.14};
+        map[2] = {"world", 2.71};
+
+        CHECK_EQ(map.at(1).first, "hello");
+        CHECK_EQ(map.at(1).second, doctest::Approx(3.14));
+    }
+}
+
+TEST_CASE("dense_map::move_only_values") {
+    SUBCASE("unique_ptr value") {
+        dense_map<int, std::unique_ptr<int>> map;
+        map.emplace(1, std::make_unique<int>(100));
+        map.emplace(2, std::make_unique<int>(200));
+
+        CHECK_EQ(map.size(), 2);
+        CHECK_EQ(*map.at(1), 100);
+        CHECK_EQ(*map.at(2), 200);
+
+        // Move out
+        auto ptr = std::move(map[1]);
+        CHECK_EQ(*ptr, 100);
+        CHECK(map[1] == nullptr);
+    }
+}
+
+TEST_CASE("dense_map::iterator_validity") {
+    SUBCASE("erase maintains iteration") {
+        dense_map<int, int> map;
+        for (int i = 0; i < 100; ++i) {
+            map[i] = i;
+        }
+
+        // Count elements during iteration
+        int count = 0;
+        for (auto it = map.begin(); it != map.end(); ++it) {
+            ++count;
+        }
+        CHECK_EQ(count, 100);
+    }
+
+    SUBCASE("modification during iteration via reference") {
+        dense_map<int, int> map;
+        for (int i = 0; i < 100; ++i) {
+            map[i] = i;
+        }
+
+        for (auto& [k, v] : map) {
+            v *= 2;
+        }
+
+        for (int i = 0; i < 100; ++i) {
+            CHECK_EQ(map.at(i), i * 2);
+        }
+    }
+}
+
+TEST_CASE("dense_map::high_load_factor") {
+    SUBCASE("insert at high load") {
+        dense_map<int, int> map;
+        map.reserve(16);  // Small initial capacity
+
+        // Insert up to near max load
+        for (int i = 0; i < 13; ++i) {  // ~81% load
+            map[i] = i;
+        }
+        CHECK_EQ(map.size(), 13);
+
+        // Insert more to trigger rehash
+        for (int i = 13; i < 30; ++i) {
+            map[i] = i;
+        }
+        CHECK_EQ(map.size(), 30);
+
+        // Verify all
+        for (int i = 0; i < 30; ++i) {
+            CHECK_EQ(map.at(i), i);
+        }
+    }
+}
+
+TEST_CASE("dense_map::negative_keys") {
+    SUBCASE("negative int keys") {
+        dense_map<int, int> map;
+        for (int i = -1000; i < 1000; ++i) {
+            map[i] = i * 2;
+        }
+        CHECK_EQ(map.size(), 2000);
+
+        for (int i = -1000; i < 1000; ++i) {
+            CHECK_EQ(map.at(i), i * 2);
+        }
+    }
+}
+
+TEST_CASE("dense_map::erase_patterns") {
+    SUBCASE("erase from beginning") {
+        dense_map<int, int> map;
+        for (int i = 0; i < 100; ++i) {
+            map[i] = i;
+        }
+
+        for (int i = 0; i < 50; ++i) {
+            map.erase(i);
+        }
+        CHECK_EQ(map.size(), 50);
+
+        for (int i = 50; i < 100; ++i) {
+            CHECK_EQ(map.at(i), i);
+        }
+    }
+
+    SUBCASE("erase from end") {
+        dense_map<int, int> map;
+        for (int i = 0; i < 100; ++i) {
+            map[i] = i;
+        }
+
+        for (int i = 99; i >= 50; --i) {
+            map.erase(i);
+        }
+        CHECK_EQ(map.size(), 50);
+
+        for (int i = 0; i < 50; ++i) {
+            CHECK_EQ(map.at(i), i);
+        }
+    }
+
+    SUBCASE("erase random order") {
+        dense_map<int, int> map;
+        std::vector<int> keys;
+        for (int i = 0; i < 100; ++i) {
+            map[i] = i;
+            keys.push_back(i);
+        }
+
+        std::mt19937 gen(42);
+        std::shuffle(keys.begin(), keys.end(), gen);
+
+        // Erase half in random order
+        for (int i = 0; i < 50; ++i) {
+            map.erase(keys[i]);
+        }
+        CHECK_EQ(map.size(), 50);
+
+        // Verify remaining
+        for (int i = 50; i < 100; ++i) {
+            CHECK(map.contains(keys[i]));
+        }
+    }
+}
+
+TEST_CASE("dense_map::large_scale") {
+    SUBCASE("100K elements") {
+        constexpr int N = 100000;
+        dense_map<int64_t, int64_t> map;
+
+        for (int64_t i = 0; i < N; ++i) {
+            map[i] = i * 2;
+        }
+        CHECK_EQ(map.size(), N);
+
+        for (int64_t i = 0; i < N; ++i) {
+            CHECK_EQ(map.at(i), i * 2);
+        }
+
+        // Erase half
+        for (int64_t i = 0; i < N; i += 2) {
+            map.erase(i);
+        }
+        CHECK_EQ(map.size(), N / 2);
+    }
+}
+
+TEST_CASE("dense_map::duplicate_insert_behavior") {
+    SUBCASE("insert does not overwrite") {
+        dense_map<int, int> map;
+        map.insert({1, 100});
+        auto [it, inserted] = map.insert({1, 200});
+
+        CHECK_FALSE(inserted);
+        CHECK_EQ(it->second, 100);  // Original value
+    }
+
+    SUBCASE("insert_or_assign does overwrite") {
+        dense_map<int, int> map;
+        map.insert({1, 100});
+        auto [it, inserted] = map.insert_or_assign(1, 200);
+
+        CHECK_FALSE(inserted);
+        CHECK_EQ(it->second, 200);  // New value
+    }
+
+    SUBCASE("try_emplace does not construct on duplicate") {
+        static int construct_count = 0;
+        struct Counter {
+            Counter() { ++construct_count; }
+            Counter(int) { ++construct_count; }
+            Counter(const Counter&) { ++construct_count; }
+            Counter(Counter&&) noexcept { ++construct_count; }
+        };
+
+        construct_count = 0;
+        dense_map<int, Counter> map;
+        map.try_emplace(1, 100);
+        int after_first = construct_count;
+
+        map.try_emplace(1, 200);  // Should not construct
+        CHECK_EQ(construct_count, after_first);
+    }
+}
+
+TEST_CASE("dense_map::find_patterns") {
+    dense_map<int, int> map;
+    for (int i = 0; i < 1000; ++i) {
+        map[i * 2] = i;  // Only even keys
+    }
+
+    SUBCASE("find existing keys") {
+        for (int i = 0; i < 1000; ++i) {
+            auto it = map.find(i * 2);
+            REQUIRE(it != map.end());
+            CHECK_EQ(it->second, i);
+        }
+    }
+
+    SUBCASE("find non-existing keys") {
+        for (int i = 0; i < 1000; ++i) {
+            auto it = map.find(i * 2 + 1);  // Odd keys don't exist
+            CHECK(it == map.end());
+        }
+    }
+}
+
+}  // namespace stdb::container

--- a/third_party/robin_growth_policy.h
+++ b/third_party/robin_growth_policy.h
@@ -1,0 +1,415 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017 Thibaut Goetghebuer-Planchon <tessil@gmx.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef TSL_ROBIN_GROWTH_POLICY_H
+#define TSL_ROBIN_GROWTH_POLICY_H
+
+#include <algorithm>
+#include <array>
+#include <climits>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <limits>
+#include <ratio>
+#include <stdexcept>
+
+// A change of the major version indicates an API and/or ABI break (change of
+// in-memory layout of the data structure)
+#define TSL_RH_VERSION_MAJOR 1
+// A change of the minor version indicates the addition of a feature without
+// impact on the API/ABI
+#define TSL_RH_VERSION_MINOR 4
+// A change of the patch version indicates a bugfix without additional
+// functionality
+#define TSL_RH_VERSION_PATCH 1
+
+#ifdef TSL_DEBUG
+#define tsl_rh_assert(expr) assert(expr)
+#else
+#define tsl_rh_assert(expr) (static_cast<void>(0))
+#endif
+
+/**
+ * If exceptions are enabled, throw the exception passed in parameter, otherwise
+ * call std::terminate.
+ */
+#if (defined(__cpp_exceptions) || defined(__EXCEPTIONS) || \
+     (defined(_MSC_VER) && defined(_CPPUNWIND))) &&        \
+    !defined(TSL_NO_EXCEPTIONS)
+#define TSL_RH_THROW_OR_TERMINATE(ex, msg) throw ex(msg)
+#else
+#define TSL_RH_NO_EXCEPTIONS
+#ifdef TSL_DEBUG
+#include <iostream>
+#define TSL_RH_THROW_OR_TERMINATE(ex, msg) \
+  do {                                     \
+    std::cerr << msg << std::endl;         \
+    std::terminate();                      \
+  } while (0)
+#else
+#define TSL_RH_THROW_OR_TERMINATE(ex, msg) std::terminate()
+#endif
+#endif
+
+#if defined(__GNUC__) || defined(__clang__)
+#define TSL_RH_LIKELY(exp) (__builtin_expect(!!(exp), true))
+#else
+#define TSL_RH_LIKELY(exp) (exp)
+#endif
+
+#define TSL_RH_UNUSED(x) static_cast<void>(x)
+
+namespace tsl {
+namespace rh {
+
+/**
+ * Grow the hash table by a factor of GrowthFactor keeping the bucket count to a
+ * power of two. It allows the table to use a mask operation instead of a modulo
+ * operation to map a hash to a bucket.
+ *
+ * GrowthFactor must be a power of two >= 2.
+ */
+template <std::size_t GrowthFactor>
+class power_of_two_growth_policy {
+ public:
+  /**
+   * Called on the hash table creation and on rehash. The number of buckets for
+   * the table is passed in parameter. This number is a minimum, the policy may
+   * update this value with a higher value if needed (but not lower).
+   *
+   * If 0 is given, min_bucket_count_in_out must still be 0 after the policy
+   * creation and bucket_for_hash must always return 0 in this case.
+   */
+  explicit power_of_two_growth_policy(std::size_t& min_bucket_count_in_out) {
+    if (min_bucket_count_in_out > max_bucket_count()) {
+      TSL_RH_THROW_OR_TERMINATE(std::length_error,
+                                "The hash table exceeds its maximum size.");
+    }
+
+    if (min_bucket_count_in_out > 0) {
+      min_bucket_count_in_out =
+          round_up_to_power_of_two(min_bucket_count_in_out);
+      m_mask = min_bucket_count_in_out - 1;
+    } else {
+      m_mask = 0;
+    }
+  }
+
+  /**
+   * Return the bucket [0, bucket_count()) to which the hash belongs.
+   * If bucket_count() is 0, it must always return 0.
+   */
+  std::size_t bucket_for_hash(std::size_t hash) const noexcept {
+    return hash & m_mask;
+  }
+
+  /**
+   * Return the number of buckets that should be used on next growth.
+   */
+  std::size_t next_bucket_count() const {
+    if ((m_mask + 1) > max_bucket_count() / GrowthFactor) {
+      TSL_RH_THROW_OR_TERMINATE(std::length_error,
+                                "The hash table exceeds its maximum size.");
+    }
+
+    return (m_mask + 1) * GrowthFactor;
+  }
+
+  /**
+   * Return the maximum number of buckets supported by the policy.
+   */
+  std::size_t max_bucket_count() const {
+    // Largest power of two.
+    return (std::numeric_limits<std::size_t>::max() / 2) + 1;
+  }
+
+  /**
+   * Reset the growth policy as if it was created with a bucket count of 0.
+   * After a clear, the policy must always return 0 when bucket_for_hash is
+   * called.
+   */
+  void clear() noexcept { m_mask = 0; }
+
+ private:
+  static std::size_t round_up_to_power_of_two(std::size_t value) {
+    if (is_power_of_two(value)) {
+      return value;
+    }
+
+    if (value == 0) {
+      return 1;
+    }
+
+    --value;
+    for (std::size_t i = 1; i < sizeof(std::size_t) * CHAR_BIT; i *= 2) {
+      value |= value >> i;
+    }
+
+    return value + 1;
+  }
+
+  static constexpr bool is_power_of_two(std::size_t value) {
+    return value != 0 && (value & (value - 1)) == 0;
+  }
+
+ protected:
+  static_assert(is_power_of_two(GrowthFactor) && GrowthFactor >= 2,
+                "GrowthFactor must be a power of two >= 2.");
+
+  std::size_t m_mask;
+};
+
+/**
+ * Grow the hash table by GrowthFactor::num / GrowthFactor::den and use a modulo
+ * to map a hash to a bucket. Slower but it can be useful if you want a slower
+ * growth.
+ */
+template <class GrowthFactor = std::ratio<3, 2>>
+class mod_growth_policy {
+ public:
+  explicit mod_growth_policy(std::size_t& min_bucket_count_in_out) {
+    if (min_bucket_count_in_out > max_bucket_count()) {
+      TSL_RH_THROW_OR_TERMINATE(std::length_error,
+                                "The hash table exceeds its maximum size.");
+    }
+
+    if (min_bucket_count_in_out > 0) {
+      m_mod = min_bucket_count_in_out;
+    } else {
+      m_mod = 1;
+    }
+  }
+
+  std::size_t bucket_for_hash(std::size_t hash) const noexcept {
+    return hash % m_mod;
+  }
+
+  std::size_t next_bucket_count() const {
+    if (m_mod == max_bucket_count()) {
+      TSL_RH_THROW_OR_TERMINATE(std::length_error,
+                                "The hash table exceeds its maximum size.");
+    }
+
+    const double next_bucket_count =
+        std::ceil(double(m_mod) * REHASH_SIZE_MULTIPLICATION_FACTOR);
+    if (!std::isnormal(next_bucket_count)) {
+      TSL_RH_THROW_OR_TERMINATE(std::length_error,
+                                "The hash table exceeds its maximum size.");
+    }
+
+    if (next_bucket_count > double(max_bucket_count())) {
+      return max_bucket_count();
+    } else {
+      return std::size_t(next_bucket_count);
+    }
+  }
+
+  std::size_t max_bucket_count() const { return MAX_BUCKET_COUNT; }
+
+  void clear() noexcept { m_mod = 1; }
+
+ private:
+  static constexpr double REHASH_SIZE_MULTIPLICATION_FACTOR =
+      1.0 * GrowthFactor::num / GrowthFactor::den;
+  static const std::size_t MAX_BUCKET_COUNT =
+      std::size_t(double(std::numeric_limits<std::size_t>::max() /
+                         REHASH_SIZE_MULTIPLICATION_FACTOR));
+
+  static_assert(REHASH_SIZE_MULTIPLICATION_FACTOR >= 1.1,
+                "Growth factor should be >= 1.1.");
+
+  std::size_t m_mod;
+};
+
+namespace detail {
+
+#if SIZE_MAX >= ULLONG_MAX
+#define TSL_RH_NB_PRIMES 51
+#elif SIZE_MAX >= ULONG_MAX
+#define TSL_RH_NB_PRIMES 40
+#else
+#define TSL_RH_NB_PRIMES 23
+#endif
+
+inline constexpr std::array<std::size_t, TSL_RH_NB_PRIMES> PRIMES = {{
+    1u,
+    5u,
+    17u,
+    29u,
+    37u,
+    53u,
+    67u,
+    79u,
+    97u,
+    131u,
+    193u,
+    257u,
+    389u,
+    521u,
+    769u,
+    1031u,
+    1543u,
+    2053u,
+    3079u,
+    6151u,
+    12289u,
+    24593u,
+    49157u,
+#if SIZE_MAX >= ULONG_MAX
+    98317ul,
+    196613ul,
+    393241ul,
+    786433ul,
+    1572869ul,
+    3145739ul,
+    6291469ul,
+    12582917ul,
+    25165843ul,
+    50331653ul,
+    100663319ul,
+    201326611ul,
+    402653189ul,
+    805306457ul,
+    1610612741ul,
+    3221225473ul,
+    4294967291ul,
+#endif
+#if SIZE_MAX >= ULLONG_MAX
+    6442450939ull,
+    12884901893ull,
+    25769803751ull,
+    51539607551ull,
+    103079215111ull,
+    206158430209ull,
+    412316860441ull,
+    824633720831ull,
+    1649267441651ull,
+    3298534883309ull,
+    6597069766657ull,
+#endif
+}};
+
+template <unsigned int IPrime>
+static constexpr std::size_t mod(std::size_t hash) {
+  return hash % PRIMES[IPrime];
+}
+
+// MOD_PRIME[iprime](hash) returns hash % PRIMES[iprime]. This table allows for
+// faster modulo as the compiler can optimize the modulo code better with a
+// constant known at the compilation.
+inline constexpr std::array<std::size_t (*)(std::size_t), TSL_RH_NB_PRIMES>
+    MOD_PRIME = {{
+        &mod<0>,  &mod<1>,  &mod<2>,  &mod<3>,  &mod<4>,  &mod<5>,
+        &mod<6>,  &mod<7>,  &mod<8>,  &mod<9>,  &mod<10>, &mod<11>,
+        &mod<12>, &mod<13>, &mod<14>, &mod<15>, &mod<16>, &mod<17>,
+        &mod<18>, &mod<19>, &mod<20>, &mod<21>, &mod<22>,
+#if SIZE_MAX >= ULONG_MAX
+        &mod<23>, &mod<24>, &mod<25>, &mod<26>, &mod<27>, &mod<28>,
+        &mod<29>, &mod<30>, &mod<31>, &mod<32>, &mod<33>, &mod<34>,
+        &mod<35>, &mod<36>, &mod<37>, &mod<38>, &mod<39>,
+#endif
+#if SIZE_MAX >= ULLONG_MAX
+        &mod<40>, &mod<41>, &mod<42>, &mod<43>, &mod<44>, &mod<45>,
+        &mod<46>, &mod<47>, &mod<48>, &mod<49>, &mod<50>,
+#endif
+    }};
+
+}  // namespace detail
+
+/**
+ * Grow the hash table by using prime numbers as bucket count. Slower than
+ * tsl::rh::power_of_two_growth_policy in general but will probably distribute
+ * the values around better in the buckets with a poor hash function.
+ *
+ * To allow the compiler to optimize the modulo operation, a lookup table is
+ * used with constant primes numbers.
+ *
+ * With a switch the code would look like:
+ * \code
+ * switch(iprime) { // iprime is the current prime of the hash table
+ *     case 0: hash % 5ul;
+ *             break;
+ *     case 1: hash % 17ul;
+ *             break;
+ *     case 2: hash % 29ul;
+ *             break;
+ *     ...
+ * }
+ * \endcode
+ *
+ * Due to the constant variable in the modulo the compiler is able to optimize
+ * the operation by a series of multiplications, substractions and shifts.
+ *
+ * The 'hash % 5' could become something like 'hash - (hash * 0xCCCCCCCD) >> 34)
+ * * 5' in a 64 bits environment.
+ */
+class prime_growth_policy {
+ public:
+  explicit prime_growth_policy(std::size_t& min_bucket_count_in_out) {
+    auto it_prime = std::lower_bound(
+        detail::PRIMES.begin(), detail::PRIMES.end(), min_bucket_count_in_out);
+    if (it_prime == detail::PRIMES.end()) {
+      TSL_RH_THROW_OR_TERMINATE(std::length_error,
+                                "The hash table exceeds its maximum size.");
+    }
+
+    m_iprime = static_cast<unsigned int>(
+        std::distance(detail::PRIMES.begin(), it_prime));
+    if (min_bucket_count_in_out > 0) {
+      min_bucket_count_in_out = *it_prime;
+    } else {
+      min_bucket_count_in_out = 0;
+    }
+  }
+
+  std::size_t bucket_for_hash(std::size_t hash) const noexcept {
+    return detail::MOD_PRIME[m_iprime](hash);
+  }
+
+  std::size_t next_bucket_count() const {
+    if (m_iprime + 1 >= detail::PRIMES.size()) {
+      TSL_RH_THROW_OR_TERMINATE(std::length_error,
+                                "The hash table exceeds its maximum size.");
+    }
+
+    return detail::PRIMES[m_iprime + 1];
+  }
+
+  std::size_t max_bucket_count() const { return detail::PRIMES.back(); }
+
+  void clear() noexcept { m_iprime = 0; }
+
+ private:
+  unsigned int m_iprime;
+
+  static_assert(std::numeric_limits<decltype(m_iprime)>::max() >=
+                    detail::PRIMES.size(),
+                "The type of m_iprime is not big enough.");
+};
+
+}  // namespace rh
+}  // namespace tsl
+
+#endif

--- a/third_party/robin_hash.h
+++ b/third_party/robin_hash.h
@@ -1,0 +1,1589 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017 Thibaut Goetghebuer-Planchon <tessil@gmx.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef TSL_ROBIN_HASH_H
+#define TSL_ROBIN_HASH_H
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <new>
+#include <stdexcept>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "robin_growth_policy.h"
+
+namespace tsl {
+
+namespace detail_robin_hash {
+
+template <typename T>
+struct make_void {
+  using type = void;
+};
+
+template <typename T, typename = void>
+struct has_is_transparent : std::false_type {};
+
+template <typename T>
+struct has_is_transparent<T,
+                          typename make_void<typename T::is_transparent>::type>
+    : std::true_type {};
+
+template <typename U>
+struct is_power_of_two_policy : std::false_type {};
+
+template <std::size_t GrowthFactor>
+struct is_power_of_two_policy<tsl::rh::power_of_two_growth_policy<GrowthFactor>>
+    : std::true_type {};
+
+template <typename T, typename U>
+static T numeric_cast(U value,
+                      const char* error_message = "numeric_cast() failed.") {
+  T ret = static_cast<T>(value);
+  if (static_cast<U>(ret) != value) {
+    TSL_RH_THROW_OR_TERMINATE(std::runtime_error, error_message);
+  }
+
+  const bool is_same_signedness =
+      (std::is_unsigned<T>::value && std::is_unsigned<U>::value) ||
+      (std::is_signed<T>::value && std::is_signed<U>::value);
+  if (!is_same_signedness && (ret < T{}) != (value < U{})) {
+    TSL_RH_THROW_OR_TERMINATE(std::runtime_error, error_message);
+  }
+
+  TSL_RH_UNUSED(error_message);
+
+  return ret;
+}
+
+template <class T, class Deserializer>
+static T deserialize_value(Deserializer& deserializer) {
+  // MSVC < 2017 is not conformant, circumvent the problem by removing the
+  // template keyword
+#if defined(_MSC_VER) && _MSC_VER < 1910
+  return deserializer.Deserializer::operator()<T>();
+#else
+  return deserializer.Deserializer::template operator()<T>();
+#endif
+}
+
+/**
+ * Fixed size type used to represent size_type values on serialization. Need to
+ * be big enough to represent a std::size_t on 32 and 64 bits platforms, and
+ * must be the same size on both platforms.
+ */
+using slz_size_type = std::uint64_t;
+static_assert(std::numeric_limits<slz_size_type>::max() >=
+                  std::numeric_limits<std::size_t>::max(),
+              "slz_size_type must be >= std::size_t");
+
+using truncated_hash_type = std::uint32_t;
+
+/**
+ * Helper class that stores a truncated hash if StoreHash is true and nothing
+ * otherwise.
+ */
+template <bool StoreHash>
+class bucket_entry_hash {
+ public:
+  bool bucket_hash_equal(std::size_t /*hash*/) const noexcept { return true; }
+
+  truncated_hash_type truncated_hash() const noexcept { return 0; }
+
+ protected:
+  void set_hash(truncated_hash_type /*hash*/) noexcept {}
+};
+
+template <>
+class bucket_entry_hash<true> {
+ public:
+  bool bucket_hash_equal(std::size_t hash) const noexcept {
+    return m_hash == truncated_hash_type(hash);
+  }
+
+  truncated_hash_type truncated_hash() const noexcept { return m_hash; }
+
+ protected:
+  void set_hash(truncated_hash_type hash) noexcept {
+    m_hash = truncated_hash_type(hash);
+  }
+
+ private:
+  truncated_hash_type m_hash;
+};
+
+/**
+ * Each bucket entry has:
+ * - A value of type `ValueType`.
+ * - An integer to store how far the value of the bucket, if any, is from its
+ * ideal bucket (ex: if the current bucket 5 has the value 'foo' and
+ * `hash('foo') % nb_buckets` == 3, `dist_from_ideal_bucket()` will return 2 as
+ * the current value of the bucket is two buckets away from its ideal bucket) If
+ * there is no value in the bucket (i.e. `empty()` is true)
+ * `dist_from_ideal_bucket()` will be < 0.
+ * - A marker which tells us if the bucket is the last bucket of the bucket
+ * array (useful for the iterator of the hash table).
+ * - If `StoreHash` is true, 32 bits of the hash of the value, if any, are also
+ * stored in the bucket. If the size of the hash is more than 32 bits, it is
+ * truncated. We don't store the full hash as storing the hash is a potential
+ * opportunity to use the unused space due to the alignment of the bucket_entry
+ * structure. We can thus potentially store the hash without any extra space
+ *   (which would not be possible with 64 bits of the hash).
+ */
+template <typename ValueType, bool StoreHash>
+class bucket_entry : public bucket_entry_hash<StoreHash> {
+  using bucket_hash = bucket_entry_hash<StoreHash>;
+
+ public:
+  using value_type = ValueType;
+  using distance_type = std::int16_t;
+
+  bucket_entry() noexcept
+      : bucket_hash(),
+        m_dist_from_ideal_bucket(EMPTY_MARKER_DIST_FROM_IDEAL_BUCKET),
+        m_last_bucket(false) {
+    tsl_rh_assert(empty());
+  }
+
+  bucket_entry(bool last_bucket) noexcept
+      : bucket_hash(),
+        m_dist_from_ideal_bucket(EMPTY_MARKER_DIST_FROM_IDEAL_BUCKET),
+        m_last_bucket(last_bucket) {
+    tsl_rh_assert(empty());
+  }
+
+  bucket_entry(const bucket_entry& other) noexcept(
+      std::is_nothrow_copy_constructible<value_type>::value)
+      : bucket_hash(other),
+        m_dist_from_ideal_bucket(EMPTY_MARKER_DIST_FROM_IDEAL_BUCKET),
+        m_last_bucket(other.m_last_bucket) {
+    if (!other.empty()) {
+      ::new (static_cast<void*>(std::addressof(m_value)))
+          value_type(other.value());
+      m_dist_from_ideal_bucket = other.m_dist_from_ideal_bucket;
+    }
+    tsl_rh_assert(empty() == other.empty());
+  }
+
+  /**
+   * Never really used, but still necessary as we must call resize on an empty
+   * `std::vector<bucket_entry>`. and we need to support move-only types. See
+   * robin_hash constructor for details.
+   */
+  bucket_entry(bucket_entry&& other) noexcept(
+      std::is_nothrow_move_constructible<value_type>::value)
+      : bucket_hash(std::move(other)),
+        m_dist_from_ideal_bucket(EMPTY_MARKER_DIST_FROM_IDEAL_BUCKET),
+        m_last_bucket(other.m_last_bucket) {
+    if (!other.empty()) {
+      ::new (static_cast<void*>(std::addressof(m_value)))
+          value_type(std::move(other.value()));
+      m_dist_from_ideal_bucket = other.m_dist_from_ideal_bucket;
+    }
+    tsl_rh_assert(empty() == other.empty());
+  }
+
+  bucket_entry& operator=(const bucket_entry& other) noexcept(
+      std::is_nothrow_copy_constructible<value_type>::value) {
+    if (this != &other) {
+      clear();
+
+      bucket_hash::operator=(other);
+      if (!other.empty()) {
+        ::new (static_cast<void*>(std::addressof(m_value)))
+            value_type(other.value());
+      }
+
+      m_dist_from_ideal_bucket = other.m_dist_from_ideal_bucket;
+      m_last_bucket = other.m_last_bucket;
+    }
+
+    return *this;
+  }
+
+  bucket_entry& operator=(bucket_entry&&) = delete;
+
+  ~bucket_entry() noexcept { clear(); }
+
+  void clear() noexcept {
+    if (!empty()) {
+      destroy_value();
+      m_dist_from_ideal_bucket = EMPTY_MARKER_DIST_FROM_IDEAL_BUCKET;
+    }
+  }
+
+  bool empty() const noexcept {
+    return m_dist_from_ideal_bucket == EMPTY_MARKER_DIST_FROM_IDEAL_BUCKET;
+  }
+
+  value_type& value() noexcept {
+    tsl_rh_assert(!empty());
+    return *std::launder(
+        reinterpret_cast<value_type*>(std::addressof(m_value)));
+  }
+
+  const value_type& value() const noexcept {
+    tsl_rh_assert(!empty());
+    return *std::launder(
+        reinterpret_cast<const value_type*>(std::addressof(m_value)));
+  }
+
+  distance_type dist_from_ideal_bucket() const noexcept {
+    return m_dist_from_ideal_bucket;
+  }
+
+  bool last_bucket() const noexcept { return m_last_bucket; }
+
+  void set_as_last_bucket() noexcept { m_last_bucket = true; }
+
+  template <typename... Args>
+  void set_value_of_empty_bucket(distance_type dist_from_ideal_bucket,
+                                 truncated_hash_type hash,
+                                 Args&&... value_type_args) {
+    tsl_rh_assert(dist_from_ideal_bucket >= 0);
+    tsl_rh_assert(empty());
+
+    ::new (static_cast<void*>(std::addressof(m_value)))
+        value_type(std::forward<Args>(value_type_args)...);
+    this->set_hash(hash);
+    m_dist_from_ideal_bucket = dist_from_ideal_bucket;
+
+    tsl_rh_assert(!empty());
+  }
+
+  void swap_with_value_in_bucket(distance_type& dist_from_ideal_bucket,
+                                 truncated_hash_type& hash, value_type& value) {
+    tsl_rh_assert(!empty());
+    tsl_rh_assert(dist_from_ideal_bucket > m_dist_from_ideal_bucket);
+
+    using std::swap;
+    swap(value, this->value());
+    swap(dist_from_ideal_bucket, m_dist_from_ideal_bucket);
+
+    if (StoreHash) {
+      const truncated_hash_type tmp_hash = this->truncated_hash();
+      this->set_hash(hash);
+      hash = tmp_hash;
+    } else {
+      // Avoid warning of unused variable if StoreHash is false
+      TSL_RH_UNUSED(hash);
+    }
+  }
+
+  static truncated_hash_type truncate_hash(std::size_t hash) noexcept {
+    return truncated_hash_type(hash);
+  }
+
+ private:
+  void destroy_value() noexcept {
+    tsl_rh_assert(!empty());
+    value().~value_type();
+  }
+
+ public:
+  static const distance_type EMPTY_MARKER_DIST_FROM_IDEAL_BUCKET = -1;
+  static const distance_type DIST_FROM_IDEAL_BUCKET_LIMIT = 8192;
+  static_assert(DIST_FROM_IDEAL_BUCKET_LIMIT <=
+                    std::numeric_limits<distance_type>::max() - 1,
+                "DIST_FROM_IDEAL_BUCKET_LIMIT must be <= "
+                "std::numeric_limits<distance_type>::max() - 1.");
+
+ private:
+  distance_type m_dist_from_ideal_bucket;
+  bool m_last_bucket;
+  alignas(value_type) unsigned char m_value[sizeof(value_type)];
+};
+
+/**
+ * Internal common class used by `robin_map` and `robin_set`.
+ *
+ * ValueType is what will be stored by `robin_hash` (usually `std::pair<Key, T>`
+ * for map and `Key` for set).
+ *
+ * `KeySelect` should be a `FunctionObject` which takes a `ValueType` in
+ * parameter and returns a reference to the key.
+ *
+ * `ValueSelect` should be a `FunctionObject` which takes a `ValueType` in
+ * parameter and returns a reference to the value. `ValueSelect` should be void
+ * if there is no value (in a set for example).
+ *
+ * The strong exception guarantee only holds if the expression
+ * `std::is_nothrow_swappable<ValueType>::value &&
+ * std::is_nothrow_move_constructible<ValueType>::value` is true.
+ *
+ * Behaviour is undefined if the destructor of `ValueType` throws.
+ */
+template <class ValueType, class KeySelect, class ValueSelect, class Hash,
+          class KeyEqual, class Allocator, bool StoreHash, class GrowthPolicy>
+class robin_hash : private Hash, private KeyEqual, private GrowthPolicy {
+ private:
+  template <typename U>
+  using has_mapped_type =
+      typename std::integral_constant<bool, !std::is_same<U, void>::value>;
+
+  static_assert(
+      noexcept(std::declval<GrowthPolicy>().bucket_for_hash(std::size_t(0))),
+      "GrowthPolicy::bucket_for_hash must be noexcept.");
+  static_assert(noexcept(std::declval<GrowthPolicy>().clear()),
+                "GrowthPolicy::clear must be noexcept.");
+
+ public:
+  template <bool IsConst>
+  class robin_iterator;
+
+  using key_type = typename KeySelect::key_type;
+  using value_type = ValueType;
+  using size_type = std::size_t;
+  using difference_type = std::ptrdiff_t;
+  using hasher = Hash;
+  using key_equal = KeyEqual;
+  using allocator_type = Allocator;
+  using reference = value_type&;
+  using const_reference = const value_type&;
+  using pointer = value_type*;
+  using const_pointer = const value_type*;
+  using iterator = robin_iterator<false>;
+  using const_iterator = robin_iterator<true>;
+
+ private:
+  /**
+   * Either store the hash because we are asked by the `StoreHash` template
+   * parameter or store the hash because it doesn't cost us anything in size and
+   * can be used to speed up rehash.
+   */
+  static constexpr bool STORE_HASH =
+      StoreHash ||
+      ((sizeof(tsl::detail_robin_hash::bucket_entry<value_type, true>) ==
+        sizeof(tsl::detail_robin_hash::bucket_entry<value_type, false>)) &&
+       (sizeof(std::size_t) == sizeof(truncated_hash_type) ||
+        is_power_of_two_policy<GrowthPolicy>::value) &&
+       // Don't store the hash for primitive types with default hash.
+       (!std::is_arithmetic<key_type>::value ||
+        !std::is_same<Hash, std::hash<key_type>>::value));
+
+  /**
+   * Only use the stored hash on lookup if we are explicitly asked. We are not
+   * sure how slow the KeyEqual operation is. An extra comparison may slow
+   * things down with a fast KeyEqual.
+   */
+  static constexpr bool USE_STORED_HASH_ON_LOOKUP = StoreHash;
+
+  /**
+   * We can only use the hash on rehash if the size of the hash type is the same
+   * as the stored one or if we use a power of two modulo. In the case of the
+   * power of two modulo, we just mask the least significant bytes, we just have
+   * to check that the truncated_hash_type didn't truncated more bytes.
+   */
+  static bool USE_STORED_HASH_ON_REHASH(size_type bucket_count) {
+    if (STORE_HASH && sizeof(std::size_t) == sizeof(truncated_hash_type)) {
+      TSL_RH_UNUSED(bucket_count);
+      return true;
+    } else if (STORE_HASH && is_power_of_two_policy<GrowthPolicy>::value) {
+      return bucket_count == 0 ||
+             (bucket_count - 1) <=
+                 std::numeric_limits<truncated_hash_type>::max();
+    } else {
+      TSL_RH_UNUSED(bucket_count);
+      return false;
+    }
+  }
+
+  using bucket_entry =
+      tsl::detail_robin_hash::bucket_entry<value_type, STORE_HASH>;
+  using distance_type = typename bucket_entry::distance_type;
+
+  using buckets_allocator = typename std::allocator_traits<
+      allocator_type>::template rebind_alloc<bucket_entry>;
+  using buckets_container_type = std::vector<bucket_entry, buckets_allocator>;
+
+ public:
+  /**
+   * The 'operator*()' and 'operator->()' methods return a const reference and
+   * const pointer respectively to the stored value type.
+   *
+   * In case of a map, to get a mutable reference to the value associated to a
+   * key (the '.second' in the stored pair), you have to call 'value()'.
+   *
+   * The main reason for this is that if we returned a `std::pair<Key, T>&`
+   * instead of a `const std::pair<Key, T>&`, the user may modify the key which
+   * will put the map in a undefined state.
+   */
+  template <bool IsConst>
+  class robin_iterator {
+    friend class robin_hash;
+
+   private:
+    using bucket_entry_ptr =
+        typename std::conditional<IsConst, const bucket_entry*,
+                                  bucket_entry*>::type;
+
+    robin_iterator(bucket_entry_ptr bucket) noexcept : m_bucket(bucket) {}
+
+   public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = const typename robin_hash::value_type;
+    using difference_type = std::ptrdiff_t;
+    using reference = value_type&;
+    using pointer = value_type*;
+
+    robin_iterator() noexcept {}
+
+    // Copy constructor from iterator to const_iterator.
+    template <bool TIsConst = IsConst,
+              typename std::enable_if<TIsConst>::type* = nullptr>
+    robin_iterator(const robin_iterator<!TIsConst>& other) noexcept
+        : m_bucket(other.m_bucket) {}
+
+    robin_iterator(const robin_iterator& other) = default;
+    robin_iterator(robin_iterator&& other) = default;
+    robin_iterator& operator=(const robin_iterator& other) = default;
+    robin_iterator& operator=(robin_iterator&& other) = default;
+
+    const typename robin_hash::key_type& key() const {
+      return KeySelect()(m_bucket->value());
+    }
+
+    template <class U = ValueSelect,
+              typename std::enable_if<has_mapped_type<U>::value &&
+                                      IsConst>::type* = nullptr>
+    const typename U::value_type& value() const {
+      return U()(m_bucket->value());
+    }
+
+    template <class U = ValueSelect,
+              typename std::enable_if<has_mapped_type<U>::value &&
+                                      !IsConst>::type* = nullptr>
+    typename U::value_type& value() const {
+      return U()(m_bucket->value());
+    }
+
+    reference operator*() const { return m_bucket->value(); }
+
+    pointer operator->() const { return std::addressof(m_bucket->value()); }
+
+    robin_iterator& operator++() {
+      while (true) {
+        if (m_bucket->last_bucket()) {
+          ++m_bucket;
+          return *this;
+        }
+
+        ++m_bucket;
+        if (!m_bucket->empty()) {
+          return *this;
+        }
+      }
+    }
+
+    robin_iterator operator++(int) {
+      robin_iterator tmp(*this);
+      ++*this;
+
+      return tmp;
+    }
+
+    friend bool operator==(const robin_iterator& lhs,
+                           const robin_iterator& rhs) {
+      return lhs.m_bucket == rhs.m_bucket;
+    }
+
+    friend bool operator!=(const robin_iterator& lhs,
+                           const robin_iterator& rhs) {
+      return !(lhs == rhs);
+    }
+
+   private:
+    bucket_entry_ptr m_bucket;
+  };
+
+ public:
+  robin_hash(size_type bucket_count, const Hash& hash, const KeyEqual& equal,
+             const Allocator& alloc,
+             float min_load_factor = DEFAULT_MIN_LOAD_FACTOR,
+             float max_load_factor = DEFAULT_MAX_LOAD_FACTOR)
+      : Hash(hash),
+        KeyEqual(equal),
+        GrowthPolicy(bucket_count),
+        m_buckets_data(bucket_count, alloc),
+        m_buckets(m_buckets_data.empty() ? static_empty_bucket_ptr()
+                                         : m_buckets_data.data()),
+        m_bucket_count(bucket_count),
+        m_nb_elements(0),
+        m_grow_on_next_insert(false),
+        m_try_shrink_on_next_insert(false) {
+    if (bucket_count > max_bucket_count()) {
+      TSL_RH_THROW_OR_TERMINATE(std::length_error,
+                                "The map exceeds its maximum bucket count.");
+    }
+
+    if (m_bucket_count > 0) {
+      tsl_rh_assert(!m_buckets_data.empty());
+      m_buckets_data.back().set_as_last_bucket();
+    }
+
+    this->min_load_factor(min_load_factor);
+    this->max_load_factor(max_load_factor);
+  }
+
+  robin_hash(const robin_hash& other)
+      : Hash(other),
+        KeyEqual(other),
+        GrowthPolicy(other),
+        m_buckets_data(other.m_buckets_data),
+        m_buckets(m_buckets_data.empty() ? static_empty_bucket_ptr()
+                                         : m_buckets_data.data()),
+        m_bucket_count(other.m_bucket_count),
+        m_nb_elements(other.m_nb_elements),
+        m_load_threshold(other.m_load_threshold),
+        m_min_load_factor(other.m_min_load_factor),
+        m_max_load_factor(other.m_max_load_factor),
+        m_grow_on_next_insert(other.m_grow_on_next_insert),
+        m_try_shrink_on_next_insert(other.m_try_shrink_on_next_insert) {}
+
+  robin_hash(robin_hash&& other) noexcept(
+      std::is_nothrow_move_constructible<
+          Hash>::value&& std::is_nothrow_move_constructible<KeyEqual>::value&&
+          std::is_nothrow_move_constructible<GrowthPolicy>::value&&
+              std::is_nothrow_move_constructible<buckets_container_type>::value)
+      : Hash(std::move(static_cast<Hash&>(other))),
+        KeyEqual(std::move(static_cast<KeyEqual&>(other))),
+        GrowthPolicy(std::move(static_cast<GrowthPolicy&>(other))),
+        m_buckets_data(std::move(other.m_buckets_data)),
+        m_buckets(m_buckets_data.empty() ? static_empty_bucket_ptr()
+                                         : m_buckets_data.data()),
+        m_bucket_count(other.m_bucket_count),
+        m_nb_elements(other.m_nb_elements),
+        m_load_threshold(other.m_load_threshold),
+        m_min_load_factor(other.m_min_load_factor),
+        m_max_load_factor(other.m_max_load_factor),
+        m_grow_on_next_insert(other.m_grow_on_next_insert),
+        m_try_shrink_on_next_insert(other.m_try_shrink_on_next_insert) {
+    other.clear_and_shrink();
+  }
+
+  robin_hash& operator=(const robin_hash& other) {
+    if (&other != this) {
+      Hash::operator=(other);
+      KeyEqual::operator=(other);
+      GrowthPolicy::operator=(other);
+
+      m_buckets_data = other.m_buckets_data;
+      m_buckets = m_buckets_data.empty() ? static_empty_bucket_ptr()
+                                         : m_buckets_data.data();
+      m_bucket_count = other.m_bucket_count;
+      m_nb_elements = other.m_nb_elements;
+
+      m_load_threshold = other.m_load_threshold;
+      m_min_load_factor = other.m_min_load_factor;
+      m_max_load_factor = other.m_max_load_factor;
+
+      m_grow_on_next_insert = other.m_grow_on_next_insert;
+      m_try_shrink_on_next_insert = other.m_try_shrink_on_next_insert;
+    }
+
+    return *this;
+  }
+
+  robin_hash& operator=(robin_hash&& other) {
+    other.swap(*this);
+    other.clear_and_shrink();
+
+    return *this;
+  }
+
+  allocator_type get_allocator() const {
+    return m_buckets_data.get_allocator();
+  }
+
+  /*
+   * Iterators
+   */
+  iterator begin() noexcept {
+    std::size_t i = 0;
+    while (i < m_bucket_count && m_buckets[i].empty()) {
+      i++;
+    }
+
+    return iterator(m_buckets + i);
+  }
+
+  const_iterator begin() const noexcept { return cbegin(); }
+
+  const_iterator cbegin() const noexcept {
+    std::size_t i = 0;
+    while (i < m_bucket_count && m_buckets[i].empty()) {
+      i++;
+    }
+
+    return const_iterator(m_buckets + i);
+  }
+
+  iterator end() noexcept { return iterator(m_buckets + m_bucket_count); }
+
+  const_iterator end() const noexcept { return cend(); }
+
+  const_iterator cend() const noexcept {
+    return const_iterator(m_buckets + m_bucket_count);
+  }
+
+  /*
+   * Capacity
+   */
+  bool empty() const noexcept { return m_nb_elements == 0; }
+
+  size_type size() const noexcept { return m_nb_elements; }
+
+  size_type max_size() const noexcept { return m_buckets_data.max_size(); }
+
+  /*
+   * Modifiers
+   */
+  void clear() noexcept {
+    if (m_min_load_factor > 0.0f) {
+      clear_and_shrink();
+    } else {
+      for (auto& bucket : m_buckets_data) {
+        bucket.clear();
+      }
+
+      m_nb_elements = 0;
+      m_grow_on_next_insert = false;
+    }
+  }
+
+  template <typename P>
+  std::pair<iterator, bool> insert(P&& value) {
+    return insert_impl(KeySelect()(value), std::forward<P>(value));
+  }
+
+  template <typename P>
+  iterator insert_hint(const_iterator hint, P&& value) {
+    if (hint != cend() &&
+        compare_keys(KeySelect()(*hint), KeySelect()(value))) {
+      return mutable_iterator(hint);
+    }
+
+    return insert(std::forward<P>(value)).first;
+  }
+
+  template <class InputIt>
+  void insert(InputIt first, InputIt last) {
+    if (std::is_base_of<
+            std::forward_iterator_tag,
+            typename std::iterator_traits<InputIt>::iterator_category>::value) {
+      const auto nb_elements_insert = std::distance(first, last);
+      const size_type nb_free_buckets = m_load_threshold - size();
+      tsl_rh_assert(m_load_threshold >= size());
+
+      if (nb_elements_insert > 0 &&
+          nb_free_buckets < size_type(nb_elements_insert)) {
+        reserve(size() + size_type(nb_elements_insert));
+      }
+    }
+
+    for (; first != last; ++first) {
+      insert(*first);
+    }
+  }
+
+  template <class K, class M>
+  std::pair<iterator, bool> insert_or_assign(K&& key, M&& obj) {
+    auto it = try_emplace(std::forward<K>(key), std::forward<M>(obj));
+    if (!it.second) {
+      it.first.value() = std::forward<M>(obj);
+    }
+
+    return it;
+  }
+
+  template <class K, class M>
+  iterator insert_or_assign(const_iterator hint, K&& key, M&& obj) {
+    if (hint != cend() && compare_keys(KeySelect()(*hint), key)) {
+      auto it = mutable_iterator(hint);
+      it.value() = std::forward<M>(obj);
+
+      return it;
+    }
+
+    return insert_or_assign(std::forward<K>(key), std::forward<M>(obj)).first;
+  }
+
+  template <class... Args>
+  std::pair<iterator, bool> emplace(Args&&... args) {
+    return insert(value_type(std::forward<Args>(args)...));
+  }
+
+  template <class... Args>
+  iterator emplace_hint(const_iterator hint, Args&&... args) {
+    return insert_hint(hint, value_type(std::forward<Args>(args)...));
+  }
+
+  template <class K, class... Args>
+  std::pair<iterator, bool> try_emplace(K&& key, Args&&... args) {
+    return insert_impl(key, std::piecewise_construct,
+                       std::forward_as_tuple(std::forward<K>(key)),
+                       std::forward_as_tuple(std::forward<Args>(args)...));
+  }
+
+  template <class K, class... Args>
+  iterator try_emplace_hint(const_iterator hint, K&& key, Args&&... args) {
+    if (hint != cend() && compare_keys(KeySelect()(*hint), key)) {
+      return mutable_iterator(hint);
+    }
+
+    return try_emplace(std::forward<K>(key), std::forward<Args>(args)...).first;
+  }
+
+  void erase_fast(iterator pos) {
+    erase_from_bucket(pos);
+  }
+
+  /**
+   * Here to avoid `template<class K> size_type erase(const K& key)` being used
+   * when we use an `iterator` instead of a `const_iterator`.
+   */
+  iterator erase(iterator pos) {
+    erase_from_bucket(pos);
+
+    /**
+     * Erase bucket used a backward shift after clearing the bucket.
+     * Check if there is a new value in the bucket, if not get the next
+     * non-empty.
+     */
+    if (pos.m_bucket->empty()) {
+      ++pos;
+    }
+
+    return pos;
+  }
+
+  iterator erase(const_iterator pos) { return erase(mutable_iterator(pos)); }
+
+  iterator erase(const_iterator first, const_iterator last) {
+    if (first == last) {
+      return mutable_iterator(first);
+    }
+
+    auto first_mutable = mutable_iterator(first);
+    auto last_mutable = mutable_iterator(last);
+    for (auto it = first_mutable.m_bucket; it != last_mutable.m_bucket; ++it) {
+      if (!it->empty()) {
+        it->clear();
+        m_nb_elements--;
+      }
+    }
+
+    if (last_mutable == end()) {
+      m_try_shrink_on_next_insert = true;
+      return end();
+    }
+
+    /*
+     * Backward shift on the values which come after the deleted values.
+     * We try to move the values closer to their ideal bucket.
+     */
+    std::size_t icloser_bucket =
+        static_cast<std::size_t>(first_mutable.m_bucket - m_buckets);
+    std::size_t ito_move_closer_value =
+        static_cast<std::size_t>(last_mutable.m_bucket - m_buckets);
+    tsl_rh_assert(ito_move_closer_value > icloser_bucket);
+
+    const std::size_t ireturn_bucket =
+        ito_move_closer_value -
+        std::min(
+            ito_move_closer_value - icloser_bucket,
+            std::size_t(
+                m_buckets[ito_move_closer_value].dist_from_ideal_bucket()));
+
+    while (ito_move_closer_value < m_bucket_count &&
+           m_buckets[ito_move_closer_value].dist_from_ideal_bucket() > 0) {
+      icloser_bucket =
+          ito_move_closer_value -
+          std::min(
+              ito_move_closer_value - icloser_bucket,
+              std::size_t(
+                  m_buckets[ito_move_closer_value].dist_from_ideal_bucket()));
+
+      tsl_rh_assert(m_buckets[icloser_bucket].empty());
+      const distance_type new_distance = distance_type(
+          m_buckets[ito_move_closer_value].dist_from_ideal_bucket() -
+          (ito_move_closer_value - icloser_bucket));
+      m_buckets[icloser_bucket].set_value_of_empty_bucket(
+          new_distance, m_buckets[ito_move_closer_value].truncated_hash(),
+          std::move(m_buckets[ito_move_closer_value].value()));
+      m_buckets[ito_move_closer_value].clear();
+
+      ++icloser_bucket;
+      ++ito_move_closer_value;
+    }
+
+    m_try_shrink_on_next_insert = true;
+
+    return iterator(m_buckets + ireturn_bucket);
+  }
+
+  template <class K>
+  size_type erase(const K& key) {
+    return erase(key, hash_key(key));
+  }
+
+  template <class K>
+  size_type erase(const K& key, std::size_t hash) {
+    auto it = find(key, hash);
+    if (it != end()) {
+      erase_from_bucket(it);
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+
+  void swap(robin_hash& other) {
+    using std::swap;
+
+    swap(static_cast<Hash&>(*this), static_cast<Hash&>(other));
+    swap(static_cast<KeyEqual&>(*this), static_cast<KeyEqual&>(other));
+    swap(static_cast<GrowthPolicy&>(*this), static_cast<GrowthPolicy&>(other));
+    swap(m_buckets_data, other.m_buckets_data);
+    swap(m_buckets, other.m_buckets);
+    swap(m_bucket_count, other.m_bucket_count);
+    swap(m_nb_elements, other.m_nb_elements);
+    swap(m_load_threshold, other.m_load_threshold);
+    swap(m_min_load_factor, other.m_min_load_factor);
+    swap(m_max_load_factor, other.m_max_load_factor);
+    swap(m_grow_on_next_insert, other.m_grow_on_next_insert);
+    swap(m_try_shrink_on_next_insert, other.m_try_shrink_on_next_insert);
+  }
+
+  /*
+   * Lookup
+   */
+  template <class K, class U = ValueSelect,
+            typename std::enable_if<has_mapped_type<U>::value>::type* = nullptr>
+  typename U::value_type& at(const K& key) {
+    return at(key, hash_key(key));
+  }
+
+  template <class K, class U = ValueSelect,
+            typename std::enable_if<has_mapped_type<U>::value>::type* = nullptr>
+  typename U::value_type& at(const K& key, std::size_t hash) {
+    return const_cast<typename U::value_type&>(
+        static_cast<const robin_hash*>(this)->at(key, hash));
+  }
+
+  template <class K, class U = ValueSelect,
+            typename std::enable_if<has_mapped_type<U>::value>::type* = nullptr>
+  const typename U::value_type& at(const K& key) const {
+    return at(key, hash_key(key));
+  }
+
+  template <class K, class U = ValueSelect,
+            typename std::enable_if<has_mapped_type<U>::value>::type* = nullptr>
+  const typename U::value_type& at(const K& key, std::size_t hash) const {
+    auto it = find(key, hash);
+    if (it != cend()) {
+      return it.value();
+    } else {
+      TSL_RH_THROW_OR_TERMINATE(std::out_of_range, "Couldn't find key.");
+    }
+  }
+
+  template <class K, class U = ValueSelect,
+            typename std::enable_if<has_mapped_type<U>::value>::type* = nullptr>
+  typename U::value_type& operator[](K&& key) {
+    return try_emplace(std::forward<K>(key)).first.value();
+  }
+
+  template <class K>
+  size_type count(const K& key) const {
+    return count(key, hash_key(key));
+  }
+
+  template <class K>
+  size_type count(const K& key, std::size_t hash) const {
+    if (find(key, hash) != cend()) {
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+
+  template <class K>
+  iterator find(const K& key) {
+    return find_impl(key, hash_key(key));
+  }
+
+  template <class K>
+  iterator find(const K& key, std::size_t hash) {
+    return find_impl(key, hash);
+  }
+
+  template <class K>
+  const_iterator find(const K& key) const {
+    return find_impl(key, hash_key(key));
+  }
+
+  template <class K>
+  const_iterator find(const K& key, std::size_t hash) const {
+    return find_impl(key, hash);
+  }
+
+  template <class K>
+  bool contains(const K& key) const {
+    return contains(key, hash_key(key));
+  }
+
+  template <class K>
+  bool contains(const K& key, std::size_t hash) const {
+    return count(key, hash) != 0;
+  }
+
+  template <class K>
+  std::pair<iterator, iterator> equal_range(const K& key) {
+    return equal_range(key, hash_key(key));
+  }
+
+  template <class K>
+  std::pair<iterator, iterator> equal_range(const K& key, std::size_t hash) {
+    iterator it = find(key, hash);
+    return std::make_pair(it, (it == end()) ? it : std::next(it));
+  }
+
+  template <class K>
+  std::pair<const_iterator, const_iterator> equal_range(const K& key) const {
+    return equal_range(key, hash_key(key));
+  }
+
+  template <class K>
+  std::pair<const_iterator, const_iterator> equal_range(
+      const K& key, std::size_t hash) const {
+    const_iterator it = find(key, hash);
+    return std::make_pair(it, (it == cend()) ? it : std::next(it));
+  }
+
+  /*
+   * Bucket interface
+   */
+  size_type bucket_count() const { return m_bucket_count; }
+
+  size_type max_bucket_count() const {
+    return std::min(GrowthPolicy::max_bucket_count(),
+                    m_buckets_data.max_size());
+  }
+
+  /*
+   * Hash policy
+   */
+  float load_factor() const {
+    if (bucket_count() == 0) {
+      return 0;
+    }
+
+    return float(m_nb_elements) / float(bucket_count());
+  }
+
+  float min_load_factor() const { return m_min_load_factor; }
+
+  float max_load_factor() const { return m_max_load_factor; }
+
+  void min_load_factor(float ml) {
+    m_min_load_factor = std::clamp(ml, float(MINIMUM_MIN_LOAD_FACTOR),
+                                   float(MAXIMUM_MIN_LOAD_FACTOR));
+  }
+
+  void max_load_factor(float ml) {
+    m_max_load_factor = std::clamp(ml, float(MINIMUM_MAX_LOAD_FACTOR),
+                                   float(MAXIMUM_MAX_LOAD_FACTOR));
+    m_load_threshold = size_type(float(bucket_count()) * m_max_load_factor);
+    tsl_rh_assert(bucket_count() == 0 || m_load_threshold < bucket_count());
+  }
+
+  void rehash(size_type count_) {
+    count_ = std::max(count_,
+                      size_type(std::ceil(float(size()) / max_load_factor())));
+    rehash_impl(count_);
+  }
+
+  void reserve(size_type count_) {
+    rehash(size_type(std::ceil(float(count_) / max_load_factor())));
+  }
+
+  /*
+   * Observers
+   */
+  hasher hash_function() const { return static_cast<const Hash&>(*this); }
+
+  key_equal key_eq() const { return static_cast<const KeyEqual&>(*this); }
+
+  /*
+   * Other
+   */
+  iterator mutable_iterator(const_iterator pos) {
+    return iterator(const_cast<bucket_entry*>(pos.m_bucket));
+  }
+
+  template <class Serializer>
+  void serialize(Serializer& serializer) const {
+    serialize_impl(serializer);
+  }
+
+  template <class Deserializer>
+  void deserialize(Deserializer& deserializer, bool hash_compatible) {
+    deserialize_impl(deserializer, hash_compatible);
+  }
+
+ private:
+  template <class K>
+  std::size_t hash_key(const K& key) const {
+    return Hash::operator()(key);
+  }
+
+  template <class K1, class K2>
+  bool compare_keys(const K1& key1, const K2& key2) const {
+    return KeyEqual::operator()(key1, key2);
+  }
+
+  std::size_t bucket_for_hash(std::size_t hash) const {
+    const std::size_t bucket = GrowthPolicy::bucket_for_hash(hash);
+    tsl_rh_assert(bucket < m_bucket_count ||
+                  (bucket == 0 && m_bucket_count == 0));
+
+    return bucket;
+  }
+
+  template <class U = GrowthPolicy,
+            typename std::enable_if<is_power_of_two_policy<U>::value>::type* =
+                nullptr>
+  std::size_t next_bucket(std::size_t index) const noexcept {
+    tsl_rh_assert(index < bucket_count());
+
+    return (index + 1) & this->m_mask;
+  }
+
+  template <class U = GrowthPolicy,
+            typename std::enable_if<!is_power_of_two_policy<U>::value>::type* =
+                nullptr>
+  std::size_t next_bucket(std::size_t index) const noexcept {
+    tsl_rh_assert(index < bucket_count());
+
+    index++;
+    return (index != bucket_count()) ? index : 0;
+  }
+
+  template <class K>
+  iterator find_impl(const K& key, std::size_t hash) {
+    return mutable_iterator(
+        static_cast<const robin_hash*>(this)->find(key, hash));
+  }
+
+  template <class K>
+  const_iterator find_impl(const K& key, std::size_t hash) const {
+    std::size_t ibucket = bucket_for_hash(hash);
+    distance_type dist_from_ideal_bucket = 0;
+
+    while (dist_from_ideal_bucket <=
+           m_buckets[ibucket].dist_from_ideal_bucket()) {
+      if (TSL_RH_LIKELY(
+              (!USE_STORED_HASH_ON_LOOKUP ||
+               m_buckets[ibucket].bucket_hash_equal(hash)) &&
+              compare_keys(KeySelect()(m_buckets[ibucket].value()), key))) {
+        return const_iterator(m_buckets + ibucket);
+      }
+
+      ibucket = next_bucket(ibucket);
+      dist_from_ideal_bucket++;
+    }
+
+    return cend();
+  }
+
+  void erase_from_bucket(iterator pos) {
+    pos.m_bucket->clear();
+    m_nb_elements--;
+
+    /**
+     * Backward shift, swap the empty bucket, previous_ibucket, with the values
+     * on its right, ibucket, until we cross another empty bucket or if the
+     * other bucket has a distance_from_ideal_bucket == 0.
+     *
+     * We try to move the values closer to their ideal bucket.
+     */
+    std::size_t previous_ibucket =
+        static_cast<std::size_t>(pos.m_bucket - m_buckets);
+    std::size_t ibucket = next_bucket(previous_ibucket);
+
+    while (m_buckets[ibucket].dist_from_ideal_bucket() > 0) {
+      tsl_rh_assert(m_buckets[previous_ibucket].empty());
+
+      const distance_type new_distance =
+          distance_type(m_buckets[ibucket].dist_from_ideal_bucket() - 1);
+      m_buckets[previous_ibucket].set_value_of_empty_bucket(
+          new_distance, m_buckets[ibucket].truncated_hash(),
+          std::move(m_buckets[ibucket].value()));
+      m_buckets[ibucket].clear();
+
+      previous_ibucket = ibucket;
+      ibucket = next_bucket(ibucket);
+    }
+    m_try_shrink_on_next_insert = true;
+  }
+
+  template <class K, class... Args>
+  std::pair<iterator, bool> insert_impl(const K& key,
+                                        Args&&... value_type_args) {
+    const std::size_t hash = hash_key(key);
+
+    std::size_t ibucket = bucket_for_hash(hash);
+    distance_type dist_from_ideal_bucket = 0;
+
+    while (dist_from_ideal_bucket <=
+           m_buckets[ibucket].dist_from_ideal_bucket()) {
+      if ((!USE_STORED_HASH_ON_LOOKUP ||
+           m_buckets[ibucket].bucket_hash_equal(hash)) &&
+          compare_keys(KeySelect()(m_buckets[ibucket].value()), key)) {
+        return std::make_pair(iterator(m_buckets + ibucket), false);
+      }
+
+      ibucket = next_bucket(ibucket);
+      dist_from_ideal_bucket++;
+    }
+
+    while (rehash_on_extreme_load(dist_from_ideal_bucket)) {
+      ibucket = bucket_for_hash(hash);
+      dist_from_ideal_bucket = 0;
+
+      while (dist_from_ideal_bucket <=
+             m_buckets[ibucket].dist_from_ideal_bucket()) {
+        ibucket = next_bucket(ibucket);
+        dist_from_ideal_bucket++;
+      }
+    }
+
+    if (m_buckets[ibucket].empty()) {
+      m_buckets[ibucket].set_value_of_empty_bucket(
+          dist_from_ideal_bucket, bucket_entry::truncate_hash(hash),
+          std::forward<Args>(value_type_args)...);
+    } else {
+      insert_value(ibucket, dist_from_ideal_bucket,
+                   bucket_entry::truncate_hash(hash),
+                   std::forward<Args>(value_type_args)...);
+    }
+
+    m_nb_elements++;
+    /*
+     * The value will be inserted in ibucket in any case, either because it was
+     * empty or by stealing the bucket (robin hood).
+     */
+    return std::make_pair(iterator(m_buckets + ibucket), true);
+  }
+
+  template <class... Args>
+  void insert_value(std::size_t ibucket, distance_type dist_from_ideal_bucket,
+                    truncated_hash_type hash, Args&&... value_type_args) {
+    value_type value(std::forward<Args>(value_type_args)...);
+    insert_value_impl(ibucket, dist_from_ideal_bucket, hash, value);
+  }
+
+  void insert_value(std::size_t ibucket, distance_type dist_from_ideal_bucket,
+                    truncated_hash_type hash, value_type&& value) {
+    insert_value_impl(ibucket, dist_from_ideal_bucket, hash, value);
+  }
+
+  /*
+   * We don't use `value_type&& value` as last argument due to a bug in MSVC
+   * when `value_type` is a pointer, The compiler is not able to see the
+   * difference between `std::string*` and `std::string*&&` resulting in a
+   * compilation error.
+   *
+   * The `value` will be in a moved state at the end of the function.
+   */
+  void insert_value_impl(std::size_t ibucket,
+                         distance_type dist_from_ideal_bucket,
+                         truncated_hash_type hash, value_type& value) {
+    tsl_rh_assert(dist_from_ideal_bucket >
+                  m_buckets[ibucket].dist_from_ideal_bucket());
+    m_buckets[ibucket].swap_with_value_in_bucket(dist_from_ideal_bucket, hash,
+                                                 value);
+    ibucket = next_bucket(ibucket);
+    dist_from_ideal_bucket++;
+
+    while (!m_buckets[ibucket].empty()) {
+      if (dist_from_ideal_bucket >
+          m_buckets[ibucket].dist_from_ideal_bucket()) {
+        if (dist_from_ideal_bucket >
+            bucket_entry::DIST_FROM_IDEAL_BUCKET_LIMIT) {
+          /**
+           * The number of probes is really high, rehash the map on the next
+           * insert. Difficult to do now as rehash may throw an exception.
+           */
+          m_grow_on_next_insert = true;
+        }
+
+        m_buckets[ibucket].swap_with_value_in_bucket(dist_from_ideal_bucket,
+                                                     hash, value);
+      }
+
+      ibucket = next_bucket(ibucket);
+      dist_from_ideal_bucket++;
+    }
+
+    m_buckets[ibucket].set_value_of_empty_bucket(dist_from_ideal_bucket, hash,
+                                                 std::move(value));
+  }
+
+  void rehash_impl(size_type count_) {
+    robin_hash new_table(count_, static_cast<Hash&>(*this),
+                         static_cast<KeyEqual&>(*this), get_allocator(),
+                         m_min_load_factor, m_max_load_factor);
+    tsl_rh_assert(size() <= new_table.m_load_threshold);
+
+    const bool use_stored_hash =
+        USE_STORED_HASH_ON_REHASH(new_table.bucket_count());
+    for (auto& bucket : m_buckets_data) {
+      if (bucket.empty()) {
+        continue;
+      }
+
+      const std::size_t hash =
+          use_stored_hash ? bucket.truncated_hash()
+                          : new_table.hash_key(KeySelect()(bucket.value()));
+
+      new_table.insert_value_on_rehash(new_table.bucket_for_hash(hash), 0,
+                                       bucket_entry::truncate_hash(hash),
+                                       std::move(bucket.value()));
+    }
+
+    new_table.m_nb_elements = m_nb_elements;
+    new_table.swap(*this);
+  }
+
+  void clear_and_shrink() noexcept {
+    GrowthPolicy::clear();
+    m_buckets_data.clear();
+    m_buckets = static_empty_bucket_ptr();
+    m_bucket_count = 0;
+    m_nb_elements = 0;
+    m_load_threshold = 0;
+    m_grow_on_next_insert = false;
+    m_try_shrink_on_next_insert = false;
+  }
+
+  void insert_value_on_rehash(std::size_t ibucket,
+                              distance_type dist_from_ideal_bucket,
+                              truncated_hash_type hash, value_type&& value) {
+    while (true) {
+      if (dist_from_ideal_bucket >
+          m_buckets[ibucket].dist_from_ideal_bucket()) {
+        if (m_buckets[ibucket].empty()) {
+          m_buckets[ibucket].set_value_of_empty_bucket(dist_from_ideal_bucket,
+                                                       hash, std::move(value));
+          return;
+        } else {
+          m_buckets[ibucket].swap_with_value_in_bucket(dist_from_ideal_bucket,
+                                                       hash, value);
+        }
+      }
+
+      dist_from_ideal_bucket++;
+      ibucket = next_bucket(ibucket);
+    }
+  }
+
+  /**
+   * Grow the table if m_grow_on_next_insert is true or we reached the
+   * max_load_factor. Shrink the table if m_try_shrink_on_next_insert is true
+   * (an erase occurred) and we're below the min_load_factor.
+   *
+   * Return true if the table has been rehashed.
+   */
+  bool rehash_on_extreme_load(distance_type curr_dist_from_ideal_bucket) {
+    if (m_grow_on_next_insert ||
+        curr_dist_from_ideal_bucket >
+            bucket_entry::DIST_FROM_IDEAL_BUCKET_LIMIT ||
+        size() >= m_load_threshold) {
+      rehash_impl(GrowthPolicy::next_bucket_count());
+      m_grow_on_next_insert = false;
+
+      return true;
+    }
+
+    if (m_try_shrink_on_next_insert) {
+      m_try_shrink_on_next_insert = false;
+      if (m_min_load_factor != 0.0f && load_factor() < m_min_load_factor) {
+        reserve(size() + 1);
+
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  template <class Serializer>
+  void serialize_impl(Serializer& serializer) const {
+    const slz_size_type version = SERIALIZATION_PROTOCOL_VERSION;
+    serializer(version);
+
+    // Indicate if the truncated hash of each bucket is stored. Use a
+    // std::int16_t instead of a bool to avoid the need for the serializer to
+    // support an extra 'bool' type.
+    const std::int16_t hash_stored_for_bucket =
+        static_cast<std::int16_t>(STORE_HASH);
+    serializer(hash_stored_for_bucket);
+
+    const slz_size_type nb_elements = m_nb_elements;
+    serializer(nb_elements);
+
+    const slz_size_type bucket_count = m_buckets_data.size();
+    serializer(bucket_count);
+
+    const float min_load_factor = m_min_load_factor;
+    serializer(min_load_factor);
+
+    const float max_load_factor = m_max_load_factor;
+    serializer(max_load_factor);
+
+    for (const bucket_entry& bucket : m_buckets_data) {
+      if (bucket.empty()) {
+        const std::int16_t empty_bucket =
+            bucket_entry::EMPTY_MARKER_DIST_FROM_IDEAL_BUCKET;
+        serializer(empty_bucket);
+      } else {
+        const std::int16_t dist_from_ideal_bucket =
+            bucket.dist_from_ideal_bucket();
+        serializer(dist_from_ideal_bucket);
+        if (STORE_HASH) {
+          const std::uint32_t truncated_hash = bucket.truncated_hash();
+          serializer(truncated_hash);
+        }
+        serializer(bucket.value());
+      }
+    }
+  }
+
+  template <class Deserializer>
+  void deserialize_impl(Deserializer& deserializer, bool hash_compatible) {
+    tsl_rh_assert(m_buckets_data.empty());  // Current hash table must be empty
+
+    const slz_size_type version =
+        deserialize_value<slz_size_type>(deserializer);
+    // For now we only have one version of the serialization protocol.
+    // If it doesn't match there is a problem with the file.
+    if (version != SERIALIZATION_PROTOCOL_VERSION) {
+      TSL_RH_THROW_OR_TERMINATE(std::runtime_error,
+                                "Can't deserialize the ordered_map/set. "
+                                "The protocol version header is invalid.");
+    }
+
+    const bool hash_stored_for_bucket =
+        deserialize_value<std::int16_t>(deserializer) ? true : false;
+    if (hash_compatible && STORE_HASH != hash_stored_for_bucket) {
+      TSL_RH_THROW_OR_TERMINATE(
+          std::runtime_error,
+          "Can't deserialize a map with a different StoreHash "
+          "than the one used during the serialization when "
+          "hash compatibility is used");
+    }
+
+    const slz_size_type nb_elements =
+        deserialize_value<slz_size_type>(deserializer);
+    const slz_size_type bucket_count_ds =
+        deserialize_value<slz_size_type>(deserializer);
+    const float min_load_factor = deserialize_value<float>(deserializer);
+    const float max_load_factor = deserialize_value<float>(deserializer);
+
+    if (min_load_factor < MINIMUM_MIN_LOAD_FACTOR ||
+        min_load_factor > MAXIMUM_MIN_LOAD_FACTOR) {
+      TSL_RH_THROW_OR_TERMINATE(
+          std::runtime_error,
+          "Invalid min_load_factor. Check that the serializer "
+          "and deserializer support floats correctly as they "
+          "can be converted implicitly to ints.");
+    }
+
+    if (max_load_factor < MINIMUM_MAX_LOAD_FACTOR ||
+        max_load_factor > MAXIMUM_MAX_LOAD_FACTOR) {
+      TSL_RH_THROW_OR_TERMINATE(
+          std::runtime_error,
+          "Invalid max_load_factor. Check that the serializer "
+          "and deserializer support floats correctly as they "
+          "can be converted implicitly to ints.");
+    }
+
+    this->min_load_factor(min_load_factor);
+    this->max_load_factor(max_load_factor);
+
+    if (bucket_count_ds == 0) {
+      tsl_rh_assert(nb_elements == 0);
+      return;
+    }
+
+    if (!hash_compatible) {
+      reserve(numeric_cast<size_type>(nb_elements,
+                                      "Deserialized nb_elements is too big."));
+      for (slz_size_type ibucket = 0; ibucket < bucket_count_ds; ibucket++) {
+        const distance_type dist_from_ideal_bucket =
+            deserialize_value<std::int16_t>(deserializer);
+        if (dist_from_ideal_bucket !=
+            bucket_entry::EMPTY_MARKER_DIST_FROM_IDEAL_BUCKET) {
+          if (hash_stored_for_bucket) {
+            TSL_RH_UNUSED(deserialize_value<std::uint32_t>(deserializer));
+          }
+
+          insert(deserialize_value<value_type>(deserializer));
+        }
+      }
+
+      tsl_rh_assert(nb_elements == size());
+    } else {
+      m_bucket_count = numeric_cast<size_type>(
+          bucket_count_ds, "Deserialized bucket_count is too big.");
+      // Recompute m_load_threshold, during max_load_factor() the bucket count
+      // was still 0 which would trigger rehash on first insert
+      m_load_threshold = size_type(float(bucket_count()) * m_max_load_factor);
+
+      GrowthPolicy::operator=(GrowthPolicy(m_bucket_count));
+      // GrowthPolicy should not modify the bucket count we got from
+      // deserialization
+      if (m_bucket_count != bucket_count_ds) {
+        TSL_RH_THROW_OR_TERMINATE(std::runtime_error,
+                                  "The GrowthPolicy is not the same even "
+                                  "though hash_compatible is true.");
+      }
+
+      m_nb_elements = numeric_cast<size_type>(
+          nb_elements, "Deserialized nb_elements is too big.");
+      m_buckets_data.resize(m_bucket_count);
+      m_buckets = m_buckets_data.data();
+
+      for (bucket_entry& bucket : m_buckets_data) {
+        const distance_type dist_from_ideal_bucket =
+            deserialize_value<std::int16_t>(deserializer);
+        if (dist_from_ideal_bucket !=
+            bucket_entry::EMPTY_MARKER_DIST_FROM_IDEAL_BUCKET) {
+          truncated_hash_type truncated_hash = 0;
+          if (hash_stored_for_bucket) {
+            tsl_rh_assert(hash_stored_for_bucket);
+            truncated_hash = deserialize_value<std::uint32_t>(deserializer);
+          }
+
+          bucket.set_value_of_empty_bucket(
+              dist_from_ideal_bucket, truncated_hash,
+              deserialize_value<value_type>(deserializer));
+        }
+      }
+
+      if (!m_buckets_data.empty()) {
+        m_buckets_data.back().set_as_last_bucket();
+      }
+    }
+  }
+
+ public:
+  static const size_type DEFAULT_INIT_BUCKETS_SIZE = 0;
+
+  static constexpr float DEFAULT_MAX_LOAD_FACTOR = 0.5f;
+  static constexpr float MINIMUM_MAX_LOAD_FACTOR = 0.2f;
+  static constexpr float MAXIMUM_MAX_LOAD_FACTOR = 0.95f;
+
+  static constexpr float DEFAULT_MIN_LOAD_FACTOR = 0.0f;
+  static constexpr float MINIMUM_MIN_LOAD_FACTOR = 0.0f;
+  static constexpr float MAXIMUM_MIN_LOAD_FACTOR = 0.15f;
+
+  static_assert(MINIMUM_MAX_LOAD_FACTOR < MAXIMUM_MAX_LOAD_FACTOR,
+                "MINIMUM_MAX_LOAD_FACTOR should be < MAXIMUM_MAX_LOAD_FACTOR");
+  static_assert(MINIMUM_MIN_LOAD_FACTOR < MAXIMUM_MIN_LOAD_FACTOR,
+                "MINIMUM_MIN_LOAD_FACTOR should be < MAXIMUM_MIN_LOAD_FACTOR");
+  static_assert(MAXIMUM_MIN_LOAD_FACTOR < MINIMUM_MAX_LOAD_FACTOR,
+                "MAXIMUM_MIN_LOAD_FACTOR should be < MINIMUM_MAX_LOAD_FACTOR");
+
+ private:
+  /**
+   * Protocol version currenlty used for serialization.
+   */
+  static const slz_size_type SERIALIZATION_PROTOCOL_VERSION = 1;
+
+  /**
+   * Return an always valid pointer to an static empty bucket_entry with
+   * last_bucket() == true.
+   */
+  bucket_entry* static_empty_bucket_ptr() noexcept {
+    static bucket_entry empty_bucket(true);
+    tsl_rh_assert(empty_bucket.empty());
+    return &empty_bucket;
+  }
+
+ private:
+  buckets_container_type m_buckets_data;
+
+  /**
+   * Points to m_buckets_data.data() if !m_buckets_data.empty() otherwise points
+   * to static_empty_bucket_ptr. This variable is useful to avoid the cost of
+   * checking if m_buckets_data is empty when trying to find an element.
+   *
+   * TODO Remove m_buckets_data and only use a pointer instead of a
+   * pointer+vector to save some space in the robin_hash object. Manage the
+   * Allocator manually.
+   */
+  bucket_entry* m_buckets;
+
+  /**
+   * Used a lot in find, avoid the call to m_buckets_data.size() which is a bit
+   * slower.
+   */
+  size_type m_bucket_count;
+
+  size_type m_nb_elements;
+
+  size_type m_load_threshold;
+
+  float m_min_load_factor;
+  float m_max_load_factor;
+
+  bool m_grow_on_next_insert;
+
+  /**
+   * We can't shrink down the map on erase operations as the erase methods need
+   * to return the next iterator. Shrinking the map would invalidate all the
+   * iterators and we could not return the next iterator in a meaningful way, On
+   * erase, we thus just indicate on erase that we should try to shrink the hash
+   * table on the next insert if we go below the min_load_factor.
+   */
+  bool m_try_shrink_on_next_insert;
+};
+
+}  // namespace detail_robin_hash
+
+}  // namespace tsl
+
+#endif

--- a/third_party/robin_map.h
+++ b/third_party/robin_map.h
@@ -1,0 +1,815 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017 Thibaut Goetghebuer-Planchon <tessil@gmx.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef TSL_ROBIN_MAP_H
+#define TSL_ROBIN_MAP_H
+
+#include <cstddef>
+#include <functional>
+#include <initializer_list>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+#include "robin_hash.h"
+
+namespace tsl {
+
+/**
+ * Implementation of a hash map using open-addressing and the robin hood hashing
+ * algorithm with backward shift deletion.
+ *
+ * For operations modifying the hash map (insert, erase, rehash, ...), the
+ * strong exception guarantee is only guaranteed when the expression
+ * `std::is_nothrow_swappable<std::pair<Key, T>>::value &&
+ * std::is_nothrow_move_constructible<std::pair<Key, T>>::value` is true,
+ * otherwise if an exception is thrown during the swap or the move, the hash map
+ * may end up in a undefined state. Per the standard a `Key` or `T` with a
+ * noexcept copy constructor and no move constructor also satisfies the
+ * `std::is_nothrow_move_constructible<std::pair<Key, T>>::value` criterion (and
+ * will thus guarantee the strong exception for the map).
+ *
+ * When `StoreHash` is true, 32 bits of the hash are stored alongside the
+ * values. It can improve the performance during lookups if the `KeyEqual`
+ * function takes time (if it engenders a cache-miss for example) as we then
+ * compare the stored hashes before comparing the keys. When
+ * `tsl::rh::power_of_two_growth_policy` is used as `GrowthPolicy`, it may also
+ * speed-up the rehash process as we can avoid to recalculate the hash. When it
+ * is detected that storing the hash will not incur any memory penalty due to
+ * alignment (i.e. `sizeof(tsl::detail_robin_hash::bucket_entry<ValueType,
+ * true>) == sizeof(tsl::detail_robin_hash::bucket_entry<ValueType, false>)`)
+ * and `tsl::rh::power_of_two_growth_policy` is used, the hash will be stored
+ * even if `StoreHash` is false so that we can speed-up the rehash (but it will
+ * not be used on lookups unless `StoreHash` is true).
+ *
+ * `GrowthPolicy` defines how the map grows and consequently how a hash value is
+ * mapped to a bucket. By default the map uses
+ * `tsl::rh::power_of_two_growth_policy`. This policy keeps the number of
+ * buckets to a power of two and uses a mask to map the hash to a bucket instead
+ * of the slow modulo. Other growth policies are available and you may define
+ * your own growth policy, check `tsl::rh::power_of_two_growth_policy` for the
+ * interface.
+ *
+ * `std::pair<Key, T>` must be swappable.
+ *
+ * `Key` and `T` must be copy and/or move constructible.
+ *
+ * If the destructor of `Key` or `T` throws an exception, the behaviour of the
+ * class is undefined.
+ *
+ * Iterators invalidation:
+ *  - clear, operator=, reserve, rehash: always invalidate the iterators.
+ *  - insert, emplace, emplace_hint, operator[]: if there is an effective
+ * insert, invalidate the iterators.
+ *  - erase: always invalidate the iterators.
+ */
+template <class Key, class T, class Hash = std::hash<Key>,
+          class KeyEqual = std::equal_to<Key>,
+          class Allocator = std::allocator<std::pair<Key, T>>,
+          bool StoreHash = false,
+          class GrowthPolicy = tsl::rh::power_of_two_growth_policy<2>>
+class robin_map {
+ private:
+  template <typename U>
+  using has_is_transparent = tsl::detail_robin_hash::has_is_transparent<U>;
+
+  class KeySelect {
+   public:
+    using key_type = Key;
+
+    const key_type& operator()(
+        const std::pair<Key, T>& key_value) const noexcept {
+      return key_value.first;
+    }
+
+    key_type& operator()(std::pair<Key, T>& key_value) noexcept {
+      return key_value.first;
+    }
+  };
+
+  class ValueSelect {
+   public:
+    using value_type = T;
+
+    const value_type& operator()(
+        const std::pair<Key, T>& key_value) const noexcept {
+      return key_value.second;
+    }
+
+    value_type& operator()(std::pair<Key, T>& key_value) noexcept {
+      return key_value.second;
+    }
+  };
+
+  using ht = detail_robin_hash::robin_hash<std::pair<Key, T>, KeySelect,
+                                           ValueSelect, Hash, KeyEqual,
+                                           Allocator, StoreHash, GrowthPolicy>;
+
+ public:
+  using key_type = typename ht::key_type;
+  using mapped_type = T;
+  using value_type = typename ht::value_type;
+  using size_type = typename ht::size_type;
+  using difference_type = typename ht::difference_type;
+  using hasher = typename ht::hasher;
+  using key_equal = typename ht::key_equal;
+  using allocator_type = typename ht::allocator_type;
+  using reference = typename ht::reference;
+  using const_reference = typename ht::const_reference;
+  using pointer = typename ht::pointer;
+  using const_pointer = typename ht::const_pointer;
+  using iterator = typename ht::iterator;
+  using const_iterator = typename ht::const_iterator;
+
+ public:
+  /*
+   * Constructors
+   */
+  robin_map() : robin_map(ht::DEFAULT_INIT_BUCKETS_SIZE) {}
+
+  explicit robin_map(size_type bucket_count, const Hash& hash = Hash(),
+                     const KeyEqual& equal = KeyEqual(),
+                     const Allocator& alloc = Allocator())
+      : m_ht(bucket_count, hash, equal, alloc) {}
+
+  robin_map(size_type bucket_count, const Allocator& alloc)
+      : robin_map(bucket_count, Hash(), KeyEqual(), alloc) {}
+
+  robin_map(size_type bucket_count, const Hash& hash, const Allocator& alloc)
+      : robin_map(bucket_count, hash, KeyEqual(), alloc) {}
+
+  explicit robin_map(const Allocator& alloc)
+      : robin_map(ht::DEFAULT_INIT_BUCKETS_SIZE, alloc) {}
+
+  template <class InputIt>
+  robin_map(InputIt first, InputIt last,
+            size_type bucket_count = ht::DEFAULT_INIT_BUCKETS_SIZE,
+            const Hash& hash = Hash(), const KeyEqual& equal = KeyEqual(),
+            const Allocator& alloc = Allocator())
+      : robin_map(bucket_count, hash, equal, alloc) {
+    insert(first, last);
+  }
+
+  template <class InputIt>
+  robin_map(InputIt first, InputIt last, size_type bucket_count,
+            const Allocator& alloc)
+      : robin_map(first, last, bucket_count, Hash(), KeyEqual(), alloc) {}
+
+  template <class InputIt>
+  robin_map(InputIt first, InputIt last, size_type bucket_count,
+            const Hash& hash, const Allocator& alloc)
+      : robin_map(first, last, bucket_count, hash, KeyEqual(), alloc) {}
+
+  robin_map(std::initializer_list<value_type> init,
+            size_type bucket_count = ht::DEFAULT_INIT_BUCKETS_SIZE,
+            const Hash& hash = Hash(), const KeyEqual& equal = KeyEqual(),
+            const Allocator& alloc = Allocator())
+      : robin_map(init.begin(), init.end(), bucket_count, hash, equal, alloc) {}
+
+  robin_map(std::initializer_list<value_type> init, size_type bucket_count,
+            const Allocator& alloc)
+      : robin_map(init.begin(), init.end(), bucket_count, Hash(), KeyEqual(),
+                  alloc) {}
+
+  robin_map(std::initializer_list<value_type> init, size_type bucket_count,
+            const Hash& hash, const Allocator& alloc)
+      : robin_map(init.begin(), init.end(), bucket_count, hash, KeyEqual(),
+                  alloc) {}
+
+  robin_map& operator=(std::initializer_list<value_type> ilist) {
+    m_ht.clear();
+
+    m_ht.reserve(ilist.size());
+    m_ht.insert(ilist.begin(), ilist.end());
+
+    return *this;
+  }
+
+  allocator_type get_allocator() const { return m_ht.get_allocator(); }
+
+  /*
+   * Iterators
+   */
+  iterator begin() noexcept { return m_ht.begin(); }
+  const_iterator begin() const noexcept { return m_ht.begin(); }
+  const_iterator cbegin() const noexcept { return m_ht.cbegin(); }
+
+  iterator end() noexcept { return m_ht.end(); }
+  const_iterator end() const noexcept { return m_ht.end(); }
+  const_iterator cend() const noexcept { return m_ht.cend(); }
+
+  /*
+   * Capacity
+   */
+  bool empty() const noexcept { return m_ht.empty(); }
+  size_type size() const noexcept { return m_ht.size(); }
+  size_type max_size() const noexcept { return m_ht.max_size(); }
+
+  /*
+   * Modifiers
+   */
+  void clear() noexcept { m_ht.clear(); }
+
+  std::pair<iterator, bool> insert(const value_type& value) {
+    return m_ht.insert(value);
+  }
+
+  template <class P, typename std::enable_if<std::is_constructible<
+                         value_type, P&&>::value>::type* = nullptr>
+  std::pair<iterator, bool> insert(P&& value) {
+    return m_ht.emplace(std::forward<P>(value));
+  }
+
+  std::pair<iterator, bool> insert(value_type&& value) {
+    return m_ht.insert(std::move(value));
+  }
+
+  iterator insert(const_iterator hint, const value_type& value) {
+    return m_ht.insert_hint(hint, value);
+  }
+
+  template <class P, typename std::enable_if<std::is_constructible<
+                         value_type, P&&>::value>::type* = nullptr>
+  iterator insert(const_iterator hint, P&& value) {
+    return m_ht.emplace_hint(hint, std::forward<P>(value));
+  }
+
+  iterator insert(const_iterator hint, value_type&& value) {
+    return m_ht.insert_hint(hint, std::move(value));
+  }
+
+  template <class InputIt>
+  void insert(InputIt first, InputIt last) {
+    m_ht.insert(first, last);
+  }
+
+  void insert(std::initializer_list<value_type> ilist) {
+    m_ht.insert(ilist.begin(), ilist.end());
+  }
+
+  template <class M>
+  std::pair<iterator, bool> insert_or_assign(const key_type& k, M&& obj) {
+    return m_ht.insert_or_assign(k, std::forward<M>(obj));
+  }
+
+  template <class M>
+  std::pair<iterator, bool> insert_or_assign(key_type&& k, M&& obj) {
+    return m_ht.insert_or_assign(std::move(k), std::forward<M>(obj));
+  }
+
+  template <class M>
+  iterator insert_or_assign(const_iterator hint, const key_type& k, M&& obj) {
+    return m_ht.insert_or_assign(hint, k, std::forward<M>(obj));
+  }
+
+  template <class M>
+  iterator insert_or_assign(const_iterator hint, key_type&& k, M&& obj) {
+    return m_ht.insert_or_assign(hint, std::move(k), std::forward<M>(obj));
+  }
+
+  /**
+   * Due to the way elements are stored, emplace will need to move or copy the
+   * key-value once. The method is equivalent to
+   * insert(value_type(std::forward<Args>(args)...));
+   *
+   * Mainly here for compatibility with the std::unordered_map interface.
+   */
+  template <class... Args>
+  std::pair<iterator, bool> emplace(Args&&... args) {
+    return m_ht.emplace(std::forward<Args>(args)...);
+  }
+
+  /**
+   * Due to the way elements are stored, emplace_hint will need to move or copy
+   * the key-value once. The method is equivalent to insert(hint,
+   * value_type(std::forward<Args>(args)...));
+   *
+   * Mainly here for compatibility with the std::unordered_map interface.
+   */
+  template <class... Args>
+  iterator emplace_hint(const_iterator hint, Args&&... args) {
+    return m_ht.emplace_hint(hint, std::forward<Args>(args)...);
+  }
+
+  template <class... Args>
+  std::pair<iterator, bool> try_emplace(const key_type& k, Args&&... args) {
+    return m_ht.try_emplace(k, std::forward<Args>(args)...);
+  }
+
+  template <class... Args>
+  std::pair<iterator, bool> try_emplace(key_type&& k, Args&&... args) {
+    return m_ht.try_emplace(std::move(k), std::forward<Args>(args)...);
+  }
+
+  template <class... Args>
+  iterator try_emplace(const_iterator hint, const key_type& k, Args&&... args) {
+    return m_ht.try_emplace_hint(hint, k, std::forward<Args>(args)...);
+  }
+
+  template <class... Args>
+  iterator try_emplace(const_iterator hint, key_type&& k, Args&&... args) {
+    return m_ht.try_emplace_hint(hint, std::move(k),
+                                 std::forward<Args>(args)...);
+  }
+
+  iterator erase(iterator pos) { return m_ht.erase(pos); }
+  iterator erase(const_iterator pos) { return m_ht.erase(pos); }
+  iterator erase(const_iterator first, const_iterator last) {
+    return m_ht.erase(first, last);
+  }
+  size_type erase(const key_type& key) { return m_ht.erase(key); }
+
+  /**
+   * Erase the element at position 'pos'. In contrast to the regular erase()
+   * function, erase_fast() does not return an iterator. This allows it to be
+   * faster especially in hash tables with a low load factor, where finding the
+   * next nonempty bucket would be costly.
+   */
+  void erase_fast(iterator pos) { return m_ht.erase_fast(pos); }
+
+  /**
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup to the value if you already have the hash.
+   */
+  size_type erase(const key_type& key, std::size_t precalculated_hash) {
+    return m_ht.erase(key, precalculated_hash);
+  }
+
+  /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent exists. If so, K must be hashable and comparable
+   * to Key.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  size_type erase(const K& key) {
+    return m_ht.erase(key);
+  }
+
+  /**
+   * @copydoc erase(const K& key)
+   *
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup to the value if you already have the hash.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  size_type erase(const K& key, std::size_t precalculated_hash) {
+    return m_ht.erase(key, precalculated_hash);
+  }
+
+  void swap(robin_map& other) { other.m_ht.swap(m_ht); }
+
+  /*
+   * Lookup
+   */
+  T& at(const Key& key) { return m_ht.at(key); }
+
+  /**
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+  T& at(const Key& key, std::size_t precalculated_hash) {
+    return m_ht.at(key, precalculated_hash);
+  }
+
+  const T& at(const Key& key) const { return m_ht.at(key); }
+
+  /**
+   * @copydoc at(const Key& key, std::size_t precalculated_hash)
+   */
+  const T& at(const Key& key, std::size_t precalculated_hash) const {
+    return m_ht.at(key, precalculated_hash);
+  }
+
+  /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent exists. If so, K must be hashable and comparable
+   * to Key.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  T& at(const K& key) {
+    return m_ht.at(key);
+  }
+
+  /**
+   * @copydoc at(const K& key)
+   *
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  T& at(const K& key, std::size_t precalculated_hash) {
+    return m_ht.at(key, precalculated_hash);
+  }
+
+  /**
+   * @copydoc at(const K& key)
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  const T& at(const K& key) const {
+    return m_ht.at(key);
+  }
+
+  /**
+   * @copydoc at(const K& key, std::size_t precalculated_hash)
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  const T& at(const K& key, std::size_t precalculated_hash) const {
+    return m_ht.at(key, precalculated_hash);
+  }
+
+  T& operator[](const Key& key) { return m_ht[key]; }
+  T& operator[](Key&& key) { return m_ht[std::move(key)]; }
+
+  size_type count(const Key& key) const { return m_ht.count(key); }
+
+  /**
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+  size_type count(const Key& key, std::size_t precalculated_hash) const {
+    return m_ht.count(key, precalculated_hash);
+  }
+
+  /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent exists. If so, K must be hashable and comparable
+   * to Key.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  size_type count(const K& key) const {
+    return m_ht.count(key);
+  }
+
+  /**
+   * @copydoc count(const K& key) const
+   *
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  size_type count(const K& key, std::size_t precalculated_hash) const {
+    return m_ht.count(key, precalculated_hash);
+  }
+
+  iterator find(const Key& key) { return m_ht.find(key); }
+
+  /**
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+  iterator find(const Key& key, std::size_t precalculated_hash) {
+    return m_ht.find(key, precalculated_hash);
+  }
+
+  const_iterator find(const Key& key) const { return m_ht.find(key); }
+
+  /**
+   * @copydoc find(const Key& key, std::size_t precalculated_hash)
+   */
+  const_iterator find(const Key& key, std::size_t precalculated_hash) const {
+    return m_ht.find(key, precalculated_hash);
+  }
+
+  /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent exists. If so, K must be hashable and comparable
+   * to Key.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  iterator find(const K& key) {
+    return m_ht.find(key);
+  }
+
+  /**
+   * @copydoc find(const K& key)
+   *
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  iterator find(const K& key, std::size_t precalculated_hash) {
+    return m_ht.find(key, precalculated_hash);
+  }
+
+  /**
+   * @copydoc find(const K& key)
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  const_iterator find(const K& key) const {
+    return m_ht.find(key);
+  }
+
+  /**
+   * @copydoc find(const K& key)
+   *
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  const_iterator find(const K& key, std::size_t precalculated_hash) const {
+    return m_ht.find(key, precalculated_hash);
+  }
+
+  bool contains(const Key& key) const { return m_ht.contains(key); }
+
+  /**
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+  bool contains(const Key& key, std::size_t precalculated_hash) const {
+    return m_ht.contains(key, precalculated_hash);
+  }
+
+  /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent exists. If so, K must be hashable and comparable
+   * to Key.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  bool contains(const K& key) const {
+    return m_ht.contains(key);
+  }
+
+  /**
+   * @copydoc contains(const K& key) const
+   *
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  bool contains(const K& key, std::size_t precalculated_hash) const {
+    return m_ht.contains(key, precalculated_hash);
+  }
+
+  std::pair<iterator, iterator> equal_range(const Key& key) {
+    return m_ht.equal_range(key);
+  }
+
+  /**
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+  std::pair<iterator, iterator> equal_range(const Key& key,
+                                            std::size_t precalculated_hash) {
+    return m_ht.equal_range(key, precalculated_hash);
+  }
+
+  std::pair<const_iterator, const_iterator> equal_range(const Key& key) const {
+    return m_ht.equal_range(key);
+  }
+
+  /**
+   * @copydoc equal_range(const Key& key, std::size_t precalculated_hash)
+   */
+  std::pair<const_iterator, const_iterator> equal_range(
+      const Key& key, std::size_t precalculated_hash) const {
+    return m_ht.equal_range(key, precalculated_hash);
+  }
+
+  /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent exists. If so, K must be hashable and comparable
+   * to Key.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  std::pair<iterator, iterator> equal_range(const K& key) {
+    return m_ht.equal_range(key);
+  }
+
+  /**
+   * @copydoc equal_range(const K& key)
+   *
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  std::pair<iterator, iterator> equal_range(const K& key,
+                                            std::size_t precalculated_hash) {
+    return m_ht.equal_range(key, precalculated_hash);
+  }
+
+  /**
+   * @copydoc equal_range(const K& key)
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  std::pair<const_iterator, const_iterator> equal_range(const K& key) const {
+    return m_ht.equal_range(key);
+  }
+
+  /**
+   * @copydoc equal_range(const K& key, std::size_t precalculated_hash)
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  std::pair<const_iterator, const_iterator> equal_range(
+      const K& key, std::size_t precalculated_hash) const {
+    return m_ht.equal_range(key, precalculated_hash);
+  }
+
+  /*
+   * Bucket interface
+   */
+  size_type bucket_count() const { return m_ht.bucket_count(); }
+  size_type max_bucket_count() const { return m_ht.max_bucket_count(); }
+
+  /*
+   *  Hash policy
+   */
+  float load_factor() const { return m_ht.load_factor(); }
+
+  float min_load_factor() const { return m_ht.min_load_factor(); }
+  float max_load_factor() const { return m_ht.max_load_factor(); }
+
+  /**
+   * Set the `min_load_factor` to `ml`. When the `load_factor` of the map goes
+   * below `min_load_factor` after some erase operations, the map will be
+   * shrunk when an insertion occurs. The erase method itself never shrinks
+   * the map.
+   *
+   * The default value of `min_load_factor` is 0.0f, the map never shrinks by
+   * default.
+   */
+  void min_load_factor(float ml) { m_ht.min_load_factor(ml); }
+  void max_load_factor(float ml) { m_ht.max_load_factor(ml); }
+
+  void rehash(size_type count_) { m_ht.rehash(count_); }
+  void reserve(size_type count_) { m_ht.reserve(count_); }
+
+  /*
+   * Observers
+   */
+  hasher hash_function() const { return m_ht.hash_function(); }
+  key_equal key_eq() const { return m_ht.key_eq(); }
+
+  /*
+   * Other
+   */
+
+  /**
+   * Convert a const_iterator to an iterator.
+   */
+  iterator mutable_iterator(const_iterator pos) {
+    return m_ht.mutable_iterator(pos);
+  }
+
+  /**
+   * Serialize the map through the `serializer` parameter.
+   *
+   * The `serializer` parameter must be a function object that supports the
+   * following call:
+   *  - `template<typename U> void operator()(const U& value);` where the types
+   * `std::int16_t`, `std::uint32_t`, `std::uint64_t`, `float` and
+   * `std::pair<Key, T>` must be supported for U.
+   *
+   * The implementation leaves binary compatibility (endianness, IEEE 754 for
+   * floats, ...) of the types it serializes in the hands of the `Serializer`
+   * function object if compatibility is required.
+   */
+  template <class Serializer>
+  void serialize(Serializer& serializer) const {
+    m_ht.serialize(serializer);
+  }
+
+  /**
+   * Deserialize a previously serialized map through the `deserializer`
+   * parameter.
+   *
+   * The `deserializer` parameter must be a function object that supports the
+   * following call:
+   *  - `template<typename U> U operator()();` where the types `std::int16_t`,
+   * `std::uint32_t`, `std::uint64_t`, `float` and `std::pair<Key, T>` must be
+   * supported for U.
+   *
+   * If the deserialized hash map type is hash compatible with the serialized
+   * map, the deserialization process can be sped up by setting
+   * `hash_compatible` to true. To be hash compatible, the Hash, KeyEqual and
+   * GrowthPolicy must behave the same way than the ones used on the serialized
+   * map and the StoreHash must have the same value. The `std::size_t` must also
+   * be of the same size as the one on the platform used to serialize the map.
+   * If these criteria are not met, the behaviour is undefined with
+   * `hash_compatible` sets to true.
+   *
+   * The behaviour is undefined if the type `Key` and `T` of the `robin_map` are
+   * not the same as the types used during serialization.
+   *
+   * The implementation leaves binary compatibility (endianness, IEEE 754 for
+   * floats, size of int, ...) of the types it deserializes in the hands of the
+   * `Deserializer` function object if compatibility is required.
+   */
+  template <class Deserializer>
+  static robin_map deserialize(Deserializer& deserializer,
+                               bool hash_compatible = false) {
+    robin_map map(0);
+    map.m_ht.deserialize(deserializer, hash_compatible);
+
+    return map;
+  }
+
+  friend bool operator==(const robin_map& lhs, const robin_map& rhs) {
+    if (lhs.size() != rhs.size()) {
+      return false;
+    }
+
+    for (const auto& element_lhs : lhs) {
+      const auto it_element_rhs = rhs.find(element_lhs.first);
+      if (it_element_rhs == rhs.cend() ||
+          element_lhs.second != it_element_rhs->second) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  friend bool operator!=(const robin_map& lhs, const robin_map& rhs) {
+    return !operator==(lhs, rhs);
+  }
+
+  friend void swap(robin_map& lhs, robin_map& rhs) { lhs.swap(rhs); }
+
+ private:
+  ht m_ht;
+};
+
+/**
+ * Same as `tsl::robin_map<Key, T, Hash, KeyEqual, Allocator, StoreHash,
+ * tsl::rh::prime_growth_policy>`.
+ */
+template <class Key, class T, class Hash = std::hash<Key>,
+          class KeyEqual = std::equal_to<Key>,
+          class Allocator = std::allocator<std::pair<Key, T>>,
+          bool StoreHash = false>
+using robin_pg_map = robin_map<Key, T, Hash, KeyEqual, Allocator, StoreHash,
+                               tsl::rh::prime_growth_policy>;
+
+}  // end namespace tsl
+
+#endif

--- a/third_party/stl.h
+++ b/third_party/stl.h
@@ -1,0 +1,83 @@
+///////////////////////// ankerl::unordered_dense::{map, set} /////////////////////////
+
+// A fast & densely stored hashmap and hashset based on robin-hood backward shift deletion.
+// Version 4.8.1
+// https://github.com/martinus/unordered_dense
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2022 Martin Leitner-Ankerl <martin.ankerl@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef ANKERL_STL_H
+#define ANKERL_STL_H
+
+#include <array>            // for array
+#include <cstdint>          // for uint64_t, uint32_t, std::uint8_t, UINT64_C
+#include <cstring>          // for size_t, memcpy, memset
+#include <functional>       // for equal_to, hash
+#include <initializer_list> // for initializer_list
+#include <iterator>         // for pair, distance
+#include <limits>           // for numeric_limits
+#include <memory>           // for allocator, allocator_traits, shared_ptr
+#include <optional>         // for optional
+#include <stdexcept>        // for out_of_range
+#include <string>           // for basic_string
+#include <string_view>      // for basic_string_view, hash
+#include <tuple>            // for forward_as_tuple
+#include <type_traits>      // for enable_if_t, declval, conditional_t, ena...
+#include <utility>          // for forward, exchange, pair, as_const, piece...
+#include <vector>           // for vector
+
+// <memory_resource> includes <mutex>, which fails to compile if
+// targeting GCC >= 13 with the (rewritten) win32 thread model, and
+// targeting Windows earlier than Vista (0x600).  GCC predefines
+// _REENTRANT when using the 'posix' model, and doesn't when using the
+// 'win32' model.
+#if defined __MINGW64__ && defined __GNUC__ && __GNUC__ >= 13 && !defined _REENTRANT
+// _WIN32_WINNT is guaranteed to be defined here because of the
+// <cstdint> inclusion above.
+#    ifndef _WIN32_WINNT
+#        error "_WIN32_WINNT not defined"
+#    endif
+#    if _WIN32_WINNT < 0x600
+#        define ANKERL_MEMORY_RESOURCE_IS_BAD() 1 // NOLINT(cppcoreguidelines-macro-usage)
+#    endif
+#endif
+#ifndef ANKERL_MEMORY_RESOURCE_IS_BAD
+#    define ANKERL_MEMORY_RESOURCE_IS_BAD() 0 // NOLINT(cppcoreguidelines-macro-usage)
+#endif
+
+#if defined(__has_include) && !defined(ANKERL_UNORDERED_DENSE_DISABLE_PMR)
+#    if __has_include(<memory_resource>) && !ANKERL_MEMORY_RESOURCE_IS_BAD()
+#        define ANKERL_UNORDERED_DENSE_PMR std::pmr // NOLINT(cppcoreguidelines-macro-usage)
+#        include <memory_resource>                  // for polymorphic_allocator
+#    elif __has_include(<experimental/memory_resource>)
+#        define ANKERL_UNORDERED_DENSE_PMR std::experimental::pmr // NOLINT(cppcoreguidelines-macro-usage)
+#        include <experimental/memory_resource>                   // for polymorphic_allocator
+#    endif
+#endif
+
+#if defined(_MSC_VER) && defined(_M_X64)
+#    include <intrin.h>
+#    pragma intrinsic(_umul128)
+#endif
+
+#endif

--- a/third_party/unordered_dense.h
+++ b/third_party/unordered_dense.h
@@ -1,0 +1,2239 @@
+///////////////////////// ankerl::unordered_dense::{map, set} /////////////////////////
+
+// A fast & densely stored hashmap and hashset based on robin-hood backward shift deletion.
+// Version 4.8.1
+// https://github.com/martinus/unordered_dense
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2022 Martin Leitner-Ankerl <martin.ankerl@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef ANKERL_UNORDERED_DENSE_H
+#define ANKERL_UNORDERED_DENSE_H
+
+// see https://semver.org/spec/v2.0.0.html
+#define ANKERL_UNORDERED_DENSE_VERSION_MAJOR 4 // NOLINT(cppcoreguidelines-macro-usage) incompatible API changes
+#define ANKERL_UNORDERED_DENSE_VERSION_MINOR 8 // NOLINT(cppcoreguidelines-macro-usage) backwards compatible functionality
+#define ANKERL_UNORDERED_DENSE_VERSION_PATCH 1 // NOLINT(cppcoreguidelines-macro-usage) backwards compatible bug fixes
+
+// API versioning with inline namespace, see https://www.foonathan.net/2018/11/inline-namespaces/
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define ANKERL_UNORDERED_DENSE_VERSION_CONCAT1(major, minor, patch) v##major##_##minor##_##patch
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define ANKERL_UNORDERED_DENSE_VERSION_CONCAT(major, minor, patch) ANKERL_UNORDERED_DENSE_VERSION_CONCAT1(major, minor, patch)
+#define ANKERL_UNORDERED_DENSE_NAMESPACE   \
+    ANKERL_UNORDERED_DENSE_VERSION_CONCAT( \
+        ANKERL_UNORDERED_DENSE_VERSION_MAJOR, ANKERL_UNORDERED_DENSE_VERSION_MINOR, ANKERL_UNORDERED_DENSE_VERSION_PATCH)
+
+#if defined(_MSVC_LANG)
+#    define ANKERL_UNORDERED_DENSE_CPP_VERSION _MSVC_LANG
+#else
+#    define ANKERL_UNORDERED_DENSE_CPP_VERSION __cplusplus
+#endif
+
+#if defined(__GNUC__)
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#    define ANKERL_UNORDERED_DENSE_PACK(decl) decl __attribute__((__packed__))
+#elif defined(_MSC_VER)
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#    define ANKERL_UNORDERED_DENSE_PACK(decl) __pragma(pack(push, 1)) decl __pragma(pack(pop))
+#endif
+
+// exceptions
+#if defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND)
+#    define ANKERL_UNORDERED_DENSE_HAS_EXCEPTIONS() 1 // NOLINT(cppcoreguidelines-macro-usage)
+#else
+#    define ANKERL_UNORDERED_DENSE_HAS_EXCEPTIONS() 0 // NOLINT(cppcoreguidelines-macro-usage)
+#endif
+#ifdef _MSC_VER
+#    define ANKERL_UNORDERED_DENSE_NOINLINE __declspec(noinline)
+#else
+#    define ANKERL_UNORDERED_DENSE_NOINLINE __attribute__((noinline))
+#endif
+
+#if defined(__clang__) && defined(__has_attribute)
+#    if __has_attribute(__no_sanitize__)
+#        define ANKERL_UNORDERED_DENSE_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK \
+            __attribute__((__no_sanitize__("unsigned-integer-overflow")))
+#    endif
+#endif
+
+#if !defined(ANKERL_UNORDERED_DENSE_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK)
+#    define ANKERL_UNORDERED_DENSE_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK
+#endif
+
+#if ANKERL_UNORDERED_DENSE_CPP_VERSION < 201703L
+#    error ankerl::unordered_dense requires C++17 or higher
+#else
+
+#    if !defined(ANKERL_UNORDERED_DENSE_STD_MODULE)
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#        define ANKERL_UNORDERED_DENSE_STD_MODULE 0
+#    endif
+
+#    if !ANKERL_UNORDERED_DENSE_STD_MODULE
+#        include "stl.h"
+#    endif
+
+#    if __has_cpp_attribute(likely) && __has_cpp_attribute(unlikely) && ANKERL_UNORDERED_DENSE_CPP_VERSION >= 202002L
+#        define ANKERL_UNORDERED_DENSE_LIKELY_ATTR [[likely]]     // NOLINT(cppcoreguidelines-macro-usage)
+#        define ANKERL_UNORDERED_DENSE_UNLIKELY_ATTR [[unlikely]] // NOLINT(cppcoreguidelines-macro-usage)
+#        define ANKERL_UNORDERED_DENSE_LIKELY(x) (x)              // NOLINT(cppcoreguidelines-macro-usage)
+#        define ANKERL_UNORDERED_DENSE_UNLIKELY(x) (x)            // NOLINT(cppcoreguidelines-macro-usage)
+#    else
+#        define ANKERL_UNORDERED_DENSE_LIKELY_ATTR   // NOLINT(cppcoreguidelines-macro-usage)
+#        define ANKERL_UNORDERED_DENSE_UNLIKELY_ATTR // NOLINT(cppcoreguidelines-macro-usage)
+
+#        if defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__)
+#            define ANKERL_UNORDERED_DENSE_LIKELY(x) __builtin_expect(x, 1)   // NOLINT(cppcoreguidelines-macro-usage)
+#            define ANKERL_UNORDERED_DENSE_UNLIKELY(x) __builtin_expect(x, 0) // NOLINT(cppcoreguidelines-macro-usage)
+#        else
+#            define ANKERL_UNORDERED_DENSE_LIKELY(x) (x)   // NOLINT(cppcoreguidelines-macro-usage)
+#            define ANKERL_UNORDERED_DENSE_UNLIKELY(x) (x) // NOLINT(cppcoreguidelines-macro-usage)
+#        endif
+
+#    endif
+
+namespace ankerl::unordered_dense {
+inline namespace ANKERL_UNORDERED_DENSE_NAMESPACE {
+
+namespace detail {
+
+#    if ANKERL_UNORDERED_DENSE_HAS_EXCEPTIONS()
+
+// make sure this is not inlined as it is slow and dramatically enlarges code, thus making other
+// inlinings more difficult. Throws are also generally the slow path.
+[[noreturn]] inline ANKERL_UNORDERED_DENSE_NOINLINE void on_error_key_not_found() {
+    throw std::out_of_range("ankerl::unordered_dense::map::at(): key not found");
+}
+[[noreturn]] inline ANKERL_UNORDERED_DENSE_NOINLINE void on_error_bucket_overflow() {
+    throw std::overflow_error("ankerl::unordered_dense: reached max bucket size, cannot increase size");
+}
+[[noreturn]] inline ANKERL_UNORDERED_DENSE_NOINLINE void on_error_too_many_elements() {
+    throw std::out_of_range("ankerl::unordered_dense::map::replace(): too many elements");
+}
+
+#    else
+
+[[noreturn]] inline void on_error_key_not_found() {
+    abort();
+}
+[[noreturn]] inline void on_error_bucket_overflow() {
+    abort();
+}
+[[noreturn]] inline void on_error_too_many_elements() {
+    abort();
+}
+
+#    endif
+
+} // namespace detail
+
+// hash ///////////////////////////////////////////////////////////////////////
+
+// This is a stripped-down implementation of wyhash: https://github.com/wangyi-fudan/wyhash
+// No big-endian support (because different values on different machines don't matter),
+// hardcodes seed and the secret, reformats the code, and clang-tidy fixes.
+namespace detail::wyhash {
+
+inline void mum(std::uint64_t* a, std::uint64_t* b) {
+#    if defined(__SIZEOF_INT128__)
+    __uint128_t r = *a;
+    r *= *b;
+    *a = static_cast<std::uint64_t>(r);
+    *b = static_cast<std::uint64_t>(r >> 64U);
+#    elif defined(_MSC_VER) && defined(_M_X64)
+    *a = _umul128(*a, *b, b);
+#    else
+    std::uint64_t ha = *a >> 32U;
+    std::uint64_t hb = *b >> 32U;
+    std::uint64_t la = static_cast<std::uint32_t>(*a);
+    std::uint64_t lb = static_cast<std::uint32_t>(*b);
+    std::uint64_t hi{};
+    std::uint64_t lo{};
+    std::uint64_t rh = ha * hb;
+    std::uint64_t rm0 = ha * lb;
+    std::uint64_t rm1 = hb * la;
+    std::uint64_t rl = la * lb;
+    std::uint64_t t = rl + (rm0 << 32U);
+    auto c = static_cast<std::uint64_t>(t < rl);
+    lo = t + (rm1 << 32U);
+    c += static_cast<std::uint64_t>(lo < t);
+    hi = rh + (rm0 >> 32U) + (rm1 >> 32U) + c;
+    *a = lo;
+    *b = hi;
+#    endif
+}
+
+// multiply and xor mix function, aka MUM
+[[nodiscard]] inline auto mix(std::uint64_t a, std::uint64_t b) -> std::uint64_t {
+    mum(&a, &b);
+    return a ^ b;
+}
+
+// read functions. WARNING: we don't care about endianness, so results are different on big endian!
+[[nodiscard]] inline auto r8(const std::uint8_t* p) -> std::uint64_t {
+    std::uint64_t v{};
+    std::memcpy(&v, p, 8U);
+    return v;
+}
+
+[[nodiscard]] inline auto r4(const std::uint8_t* p) -> std::uint64_t {
+    std::uint32_t v{};
+    std::memcpy(&v, p, 4);
+    return v;
+}
+
+// reads 1, 2, or 3 bytes
+[[nodiscard]] inline auto r3(const std::uint8_t* p, std::size_t k) -> std::uint64_t {
+    return (static_cast<std::uint64_t>(p[0]) << 16U) | (static_cast<std::uint64_t>(p[k >> 1U]) << 8U) | p[k - 1];
+}
+
+[[maybe_unused]] [[nodiscard]] inline auto hash(void const* key, std::size_t len) -> std::uint64_t {
+    static constexpr auto secret = std::array{UINT64_C(0xa0761d6478bd642f),
+                                              UINT64_C(0xe7037ed1a0b428db),
+                                              UINT64_C(0x8ebc6af09c88c6e3),
+                                              UINT64_C(0x589965cc75374cc3)};
+
+    auto const* p = static_cast<std::uint8_t const*>(key);
+    std::uint64_t seed = secret[0];
+    std::uint64_t a{};
+    std::uint64_t b{};
+    if (ANKERL_UNORDERED_DENSE_LIKELY(len <= 16))
+        ANKERL_UNORDERED_DENSE_LIKELY_ATTR {
+            if (ANKERL_UNORDERED_DENSE_LIKELY(len >= 4))
+                ANKERL_UNORDERED_DENSE_LIKELY_ATTR {
+                    a = (r4(p) << 32U) | r4(p + ((len >> 3U) << 2U));
+                    b = (r4(p + len - 4) << 32U) | r4(p + len - 4 - ((len >> 3U) << 2U));
+                }
+            else if (ANKERL_UNORDERED_DENSE_LIKELY(len > 0))
+                ANKERL_UNORDERED_DENSE_LIKELY_ATTR {
+                    a = r3(p, len);
+                    b = 0;
+                }
+            else {
+                a = 0;
+                b = 0;
+            }
+        }
+    else {
+        std::size_t i = len;
+        if (ANKERL_UNORDERED_DENSE_UNLIKELY(i > 48))
+            ANKERL_UNORDERED_DENSE_UNLIKELY_ATTR {
+                std::uint64_t see1 = seed;
+                std::uint64_t see2 = seed;
+                do {
+                    seed = mix(r8(p) ^ secret[1], r8(p + 8) ^ seed);
+                    see1 = mix(r8(p + 16) ^ secret[2], r8(p + 24) ^ see1);
+                    see2 = mix(r8(p + 32) ^ secret[3], r8(p + 40) ^ see2);
+                    p += 48;
+                    i -= 48;
+                } while (ANKERL_UNORDERED_DENSE_LIKELY(i > 48));
+                seed ^= see1 ^ see2;
+            }
+        while (ANKERL_UNORDERED_DENSE_UNLIKELY(i > 16))
+            ANKERL_UNORDERED_DENSE_UNLIKELY_ATTR {
+                seed = mix(r8(p) ^ secret[1], r8(p + 8) ^ seed);
+                i -= 16;
+                p += 16;
+            }
+        a = r8(p + i - 16);
+        b = r8(p + i - 8);
+    }
+
+    return mix(secret[1] ^ len, mix(a ^ secret[1], b ^ seed));
+}
+
+[[nodiscard]] inline auto hash(std::uint64_t x) -> std::uint64_t {
+    return detail::wyhash::mix(x, UINT64_C(0x9E3779B97F4A7C15));
+}
+
+} // namespace detail::wyhash
+
+template <typename T, typename Enable = void>
+struct hash {
+    auto operator()(T const& obj) const noexcept(noexcept(std::declval<std::hash<T>>().operator()(std::declval<T const&>())))
+        -> std::uint64_t {
+        return std::hash<T>{}(obj);
+    }
+};
+
+template <typename T>
+struct hash<T, typename std::hash<T>::is_avalanching> {
+    using is_avalanching = void;
+    auto operator()(T const& obj) const noexcept(noexcept(std::declval<std::hash<T>>().operator()(std::declval<T const&>())))
+        -> std::uint64_t {
+        return std::hash<T>{}(obj);
+    }
+};
+
+template <typename CharT>
+struct hash<std::basic_string<CharT>> {
+    using is_avalanching = void;
+    auto operator()(std::basic_string<CharT> const& str) const noexcept -> std::uint64_t {
+        return detail::wyhash::hash(str.data(), sizeof(CharT) * str.size());
+    }
+};
+
+template <typename CharT>
+struct hash<std::basic_string_view<CharT>> {
+    using is_avalanching = void;
+    auto operator()(std::basic_string_view<CharT> const& sv) const noexcept -> std::uint64_t {
+        return detail::wyhash::hash(sv.data(), sizeof(CharT) * sv.size());
+    }
+};
+
+template <class T>
+struct hash<T*> {
+    using is_avalanching = void;
+    auto operator()(T* ptr) const noexcept -> std::uint64_t {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        return detail::wyhash::hash(reinterpret_cast<std::uintptr_t>(ptr));
+    }
+};
+
+template <class T>
+struct hash<std::unique_ptr<T>> {
+    using is_avalanching = void;
+    auto operator()(std::unique_ptr<T> const& ptr) const noexcept -> std::uint64_t {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        return detail::wyhash::hash(reinterpret_cast<std::uintptr_t>(ptr.get()));
+    }
+};
+
+template <class T>
+struct hash<std::shared_ptr<T>> {
+    using is_avalanching = void;
+    auto operator()(std::shared_ptr<T> const& ptr) const noexcept -> std::uint64_t {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        return detail::wyhash::hash(reinterpret_cast<std::uintptr_t>(ptr.get()));
+    }
+};
+
+template <typename Enum>
+struct hash<Enum, typename std::enable_if_t<std::is_enum_v<Enum>>> {
+    using is_avalanching = void;
+    auto operator()(Enum e) const noexcept -> std::uint64_t {
+        using underlying = std::underlying_type_t<Enum>;
+        return detail::wyhash::hash(static_cast<underlying>(e));
+    }
+};
+
+template <typename... Args>
+struct tuple_hash_helper {
+    // Converts the value into 64bit. If it is an integral type, just cast it. Mixing is doing the rest.
+    // If it isn't an integral we need to hash it.
+    template <typename Arg>
+    [[nodiscard]] constexpr static auto to64(Arg const& arg) -> std::uint64_t {
+        if constexpr (std::is_integral_v<Arg> || std::is_enum_v<Arg>) {
+            return static_cast<std::uint64_t>(arg);
+        } else {
+            return hash<Arg>{}(arg);
+        }
+    }
+
+    [[nodiscard]] ANKERL_UNORDERED_DENSE_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK static auto mix64(std::uint64_t state,
+                                                                                                std::uint64_t v)
+        -> std::uint64_t {
+        return detail::wyhash::mix(state + v, std::uint64_t{0x9ddfea08eb382d69});
+    }
+
+    // Creates a buffer that holds all the data from each element of the tuple. If possible we memcpy the data directly. If
+    // not, we hash the object and use this for the array. Size of the array is known at compile time, and memcpy is optimized
+    // away, so filling the buffer is highly efficient. Finally, call wyhash with this buffer.
+    template <typename T, std::size_t... Idx>
+    [[nodiscard]] static auto calc_hash(T const& t, std::index_sequence<Idx...> /*unused*/) noexcept -> std::uint64_t {
+        auto h = std::uint64_t{};
+        ((h = mix64(h, to64(std::get<Idx>(t)))), ...);
+        return h;
+    }
+};
+
+template <typename... Args>
+struct hash<std::tuple<Args...>> : tuple_hash_helper<Args...> {
+    using is_avalanching = void;
+    auto operator()(std::tuple<Args...> const& t) const noexcept -> std::uint64_t {
+        return tuple_hash_helper<Args...>::calc_hash(t, std::index_sequence_for<Args...>{});
+    }
+};
+
+template <typename A, typename B>
+struct hash<std::pair<A, B>> : tuple_hash_helper<A, B> {
+    using is_avalanching = void;
+    auto operator()(std::pair<A, B> const& t) const noexcept -> std::uint64_t {
+        return tuple_hash_helper<A, B>::calc_hash(t, std::index_sequence_for<A, B>{});
+    }
+};
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#    define ANKERL_UNORDERED_DENSE_HASH_STATICCAST(T)                         \
+        template <>                                                           \
+        struct hash<T> {                                                      \
+            using is_avalanching = void;                                      \
+            auto operator()(T const& obj) const noexcept -> std::uint64_t {   \
+                return detail::wyhash::hash(static_cast<std::uint64_t>(obj)); \
+            }                                                                 \
+        }
+
+#    if defined(__GNUC__) && !defined(__clang__)
+#        pragma GCC diagnostic push
+#        pragma GCC diagnostic ignored "-Wuseless-cast"
+#    endif
+// see https://en.cppreference.com/w/cpp/utility/hash
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(bool);
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(char);
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(signed char);
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(unsigned char);
+#    if ANKERL_UNORDERED_DENSE_CPP_VERSION >= 202002L && defined(__cpp_char8_t)
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(char8_t);
+#    endif
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(char16_t);
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(char32_t);
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(wchar_t);
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(short);
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(unsigned short);
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(int);
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(unsigned int);
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(long);
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(long long);
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(unsigned long);
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(unsigned long long);
+
+#    if defined(__GNUC__) && !defined(__clang__)
+#        pragma GCC diagnostic pop
+#    endif
+
+// bucket_type //////////////////////////////////////////////////////////
+
+namespace bucket_type {
+
+struct standard {
+    static constexpr std::uint32_t dist_inc = 1U << 8U;             // skip 1 byte fingerprint
+    static constexpr std::uint32_t fingerprint_mask = dist_inc - 1; // mask for 1 byte of fingerprint
+
+    std::uint32_t m_dist_and_fingerprint; // upper 3 byte: distance to original bucket. lower byte: fingerprint from hash
+    std::uint32_t m_value_idx;            // index into the m_values vector.
+};
+
+ANKERL_UNORDERED_DENSE_PACK(struct big {
+    static constexpr std::uint32_t dist_inc = 1U << 8U;             // skip 1 byte fingerprint
+    static constexpr std::uint32_t fingerprint_mask = dist_inc - 1; // mask for 1 byte of fingerprint
+
+    std::uint32_t m_dist_and_fingerprint; // upper 3 byte: distance to original bucket. lower byte: fingerprint from hash
+    std::size_t m_value_idx;              // index into the m_values vector.
+});
+
+} // namespace bucket_type
+
+namespace detail {
+
+struct nonesuch {};
+struct default_container_t {};
+
+template <class Default, class AlwaysVoid, template <class...> class Op, class... Args>
+struct detector {
+    using value_t = std::false_type;
+    using type = Default;
+};
+
+template <class Default, template <class...> class Op, class... Args>
+struct detector<Default, std::void_t<Op<Args...>>, Op, Args...> {
+    using value_t = std::true_type;
+    using type = Op<Args...>;
+};
+
+template <template <class...> class Op, class... Args>
+using is_detected = typename detail::detector<detail::nonesuch, void, Op, Args...>::value_t;
+
+template <template <class...> class Op, class... Args>
+constexpr bool is_detected_v = is_detected<Op, Args...>::value;
+
+template <typename T>
+using detect_avalanching = typename T::is_avalanching;
+
+template <typename T>
+using detect_is_transparent = typename T::is_transparent;
+
+template <typename T>
+using detect_iterator = typename T::iterator;
+
+template <typename T>
+using detect_reserve = decltype(std::declval<T&>().reserve(std::size_t{}));
+
+// enable_if helpers
+
+template <typename Mapped>
+constexpr bool is_map_v = !std::is_void_v<Mapped>;
+
+// clang-format off
+template <typename Hash, typename KeyEqual>
+constexpr bool is_transparent_v = is_detected_v<detect_is_transparent, Hash> && is_detected_v<detect_is_transparent, KeyEqual>;
+// clang-format on
+
+template <typename From, typename To1, typename To2>
+constexpr bool is_neither_convertible_v = !std::is_convertible_v<From, To1> && !std::is_convertible_v<From, To2>;
+
+template <typename T>
+constexpr bool has_reserve = is_detected_v<detect_reserve, T>;
+
+// base type for map has mapped_type
+template <class T>
+struct base_table_type_map {
+    using mapped_type = T;
+};
+
+// base type for set doesn't have mapped_type
+struct base_table_type_set {};
+
+} // namespace detail
+
+// Very much like std::deque, but faster for indexing (in most cases). As of now this doesn't implement the full std::vector
+// API, but merely what's necessary to work as an underlying container for ankerl::unordered_dense::{map, set}.
+// It allocates blocks of equal size and puts them into the m_blocks vector. That means it can grow simply by adding a new
+// block to the back of m_blocks, and doesn't double its size like an std::vector. The disadvantage is that memory is not
+// linear and thus there is one more indirection necessary for indexing.
+template <typename T, typename Allocator = std::allocator<T>, std::size_t MaxSegmentSizeBytes = 4096>
+class segmented_vector {
+    template <bool IsConst>
+    class iter_t;
+
+public:
+    using allocator_type = Allocator;
+    using pointer = typename std::allocator_traits<allocator_type>::pointer;
+    using const_pointer = typename std::allocator_traits<allocator_type>::const_pointer;
+    using difference_type = typename std::allocator_traits<allocator_type>::difference_type;
+    using value_type = T;
+    using size_type = std::size_t;
+    using reference = T&;
+    using const_reference = T const&;
+    using iterator = iter_t<false>;
+    using const_iterator = iter_t<true>;
+
+private:
+    using vec_alloc = typename std::allocator_traits<Allocator>::template rebind_alloc<pointer>;
+    std::vector<pointer, vec_alloc> m_blocks{};
+    std::size_t m_size{};
+
+    // Calculates the maximum number for x in  (s << x) <= max_val
+    static constexpr auto num_bits_closest(std::size_t max_val, std::size_t s) -> std::size_t {
+        auto f = std::size_t{0};
+        while (s << (f + 1) <= max_val) {
+            ++f;
+        }
+        return f;
+    }
+
+    using self_t = segmented_vector<T, Allocator, MaxSegmentSizeBytes>;
+    static constexpr auto num_bits = num_bits_closest(MaxSegmentSizeBytes, sizeof(T));
+    static constexpr auto num_elements_in_block = 1U << num_bits;
+    static constexpr auto mask = num_elements_in_block - 1U;
+
+    /**
+     * Iterator class doubles as const_iterator and iterator
+     */
+    template <bool IsConst>
+    class iter_t {
+        using ptr_t = std::conditional_t<IsConst, segmented_vector::const_pointer const*, segmented_vector::pointer*>;
+        ptr_t m_data{};
+        std::size_t m_idx{};
+
+        template <bool B>
+        friend class iter_t;
+
+    public:
+        using difference_type = segmented_vector::difference_type;
+        using value_type = segmented_vector::value_type;
+        using reference = std::conditional_t<IsConst, value_type const&, value_type&>;
+        using pointer = std::conditional_t<IsConst, segmented_vector::const_pointer, segmented_vector::pointer>;
+        using iterator_category = std::forward_iterator_tag;
+
+        iter_t() noexcept = default;
+
+        template <bool OtherIsConst, typename = std::enable_if_t<IsConst && !OtherIsConst>>
+        // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
+        constexpr iter_t(iter_t<OtherIsConst> const& other) noexcept
+            : m_data(other.m_data)
+            , m_idx(other.m_idx) {}
+
+        constexpr iter_t(ptr_t data, std::size_t idx) noexcept
+            : m_data(data)
+            , m_idx(idx) {}
+
+        template <bool OtherIsConst, typename = std::enable_if_t<IsConst && !OtherIsConst>>
+        constexpr auto operator=(iter_t<OtherIsConst> const& other) noexcept -> iter_t& {
+            m_data = other.m_data;
+            m_idx = other.m_idx;
+            return *this;
+        }
+
+        constexpr auto operator++() noexcept -> iter_t& {
+            ++m_idx;
+            return *this;
+        }
+
+        constexpr auto operator++(int) noexcept -> iter_t {
+            iter_t prev(*this);
+            this->operator++();
+            return prev;
+        }
+
+        constexpr auto operator--() noexcept -> iter_t& {
+            --m_idx;
+            return *this;
+        }
+
+        constexpr auto operator--(int) noexcept -> iter_t {
+            iter_t prev(*this);
+            this->operator--();
+            return prev;
+        }
+
+        [[nodiscard]] constexpr auto operator+(difference_type diff) const noexcept -> iter_t {
+            return {m_data, static_cast<std::size_t>(static_cast<difference_type>(m_idx) + diff)};
+        }
+
+        constexpr auto operator+=(difference_type diff) noexcept -> iter_t& {
+            m_idx += diff;
+            return *this;
+        }
+
+        [[nodiscard]] constexpr auto operator-(difference_type diff) const noexcept -> iter_t {
+            return {m_data, static_cast<std::size_t>(static_cast<difference_type>(m_idx) - diff)};
+        }
+
+        constexpr auto operator-=(difference_type diff) noexcept -> iter_t& {
+            m_idx -= diff;
+            return *this;
+        }
+
+        template <bool OtherIsConst>
+        [[nodiscard]] constexpr auto operator-(iter_t<OtherIsConst> const& other) const noexcept -> difference_type {
+            return static_cast<difference_type>(m_idx) - static_cast<difference_type>(other.m_idx);
+        }
+
+        constexpr auto operator*() const noexcept -> reference {
+            return m_data[m_idx >> num_bits][m_idx & mask];
+        }
+
+        constexpr auto operator->() const noexcept -> pointer {
+            return &m_data[m_idx >> num_bits][m_idx & mask];
+        }
+
+        template <bool O>
+        [[nodiscard]] constexpr auto operator==(iter_t<O> const& o) const noexcept -> bool {
+            return m_idx == o.m_idx;
+        }
+
+        template <bool O>
+        [[nodiscard]] constexpr auto operator!=(iter_t<O> const& o) const noexcept -> bool {
+            return !(*this == o);
+        }
+
+        template <bool O>
+        [[nodiscard]] constexpr auto operator<(iter_t<O> const& o) const noexcept -> bool {
+            return m_idx < o.m_idx;
+        }
+
+        template <bool O>
+        [[nodiscard]] constexpr auto operator>(iter_t<O> const& o) const noexcept -> bool {
+            return o < *this;
+        }
+
+        template <bool O>
+        [[nodiscard]] constexpr auto operator<=(iter_t<O> const& o) const noexcept -> bool {
+            return !(o < *this);
+        }
+
+        template <bool O>
+        [[nodiscard]] constexpr auto operator>=(iter_t<O> const& o) const noexcept -> bool {
+            return !(*this < o);
+        }
+    };
+
+    // slow path: need to allocate a new segment every once in a while
+    void increase_capacity() {
+        auto ba = Allocator(m_blocks.get_allocator());
+        pointer block = std::allocator_traits<Allocator>::allocate(ba, num_elements_in_block);
+        m_blocks.push_back(block);
+    }
+
+    // Moves everything from other
+    void append_everything_from(segmented_vector&& other) { // NOLINT(cppcoreguidelines-rvalue-reference-param-not-moved)
+        reserve(size() + other.size());
+        for (auto&& o : other) {
+            emplace_back(std::move(o));
+        }
+    }
+
+    // Copies everything from other
+    void append_everything_from(segmented_vector const& other) {
+        reserve(size() + other.size());
+        for (auto const& o : other) {
+            emplace_back(o);
+        }
+    }
+
+    void dealloc() {
+        auto ba = Allocator(m_blocks.get_allocator());
+        for (auto ptr : m_blocks) {
+            std::allocator_traits<Allocator>::deallocate(ba, ptr, num_elements_in_block);
+        }
+    }
+
+    [[nodiscard]] static constexpr auto calc_num_blocks_for_capacity(std::size_t capacity) {
+        return (capacity + num_elements_in_block - 1U) / num_elements_in_block;
+    }
+
+    void resize_shrink(std::size_t new_size) {
+        if constexpr (!std::is_trivially_destructible_v<T>) {
+            for (std::size_t ix = new_size; ix < m_size; ++ix) {
+                operator[](ix).~T();
+            }
+        }
+        m_size = new_size;
+    }
+
+public:
+    segmented_vector() = default;
+
+    // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
+    segmented_vector(Allocator alloc)
+        : m_blocks(vec_alloc(alloc)) {}
+
+    segmented_vector(segmented_vector&& other, Allocator alloc)
+        : segmented_vector(alloc) {
+        *this = std::move(other);
+    }
+
+    segmented_vector(segmented_vector const& other, Allocator alloc)
+        : m_blocks(vec_alloc(alloc)) {
+        append_everything_from(other);
+    }
+
+    segmented_vector(segmented_vector&& other) noexcept
+        : segmented_vector(std::move(other), other.get_allocator()) {}
+
+    segmented_vector(segmented_vector const& other) {
+        append_everything_from(other);
+    }
+
+    auto operator=(segmented_vector const& other) -> segmented_vector& {
+        if (this == &other) {
+            return *this;
+        }
+        clear();
+        append_everything_from(other);
+        return *this;
+    }
+
+    auto operator=(segmented_vector&& other) noexcept -> segmented_vector& {
+        clear();
+        dealloc();
+        if (other.get_allocator() == get_allocator()) {
+            m_blocks = std::move(other.m_blocks);
+            m_size = std::exchange(other.m_size, {});
+        } else {
+            // make sure to construct with other's allocator!
+            m_blocks = std::vector<pointer, vec_alloc>(vec_alloc(other.get_allocator()));
+            append_everything_from(std::move(other));
+        }
+        return *this;
+    }
+
+    ~segmented_vector() {
+        clear();
+        dealloc();
+    }
+
+    [[nodiscard]] constexpr auto size() const -> std::size_t {
+        return m_size;
+    }
+
+    [[nodiscard]] constexpr auto capacity() const -> std::size_t {
+        return m_blocks.size() * num_elements_in_block;
+    }
+
+    // Indexing is highly performance critical
+    [[nodiscard]] constexpr auto operator[](std::size_t i) const noexcept -> T const& {
+        return m_blocks[i >> num_bits][i & mask];
+    }
+
+    [[nodiscard]] constexpr auto operator[](std::size_t i) noexcept -> T& {
+        return m_blocks[i >> num_bits][i & mask];
+    }
+
+    [[nodiscard]] constexpr auto begin() -> iterator {
+        return {m_blocks.data(), 0U};
+    }
+    [[nodiscard]] constexpr auto begin() const -> const_iterator {
+        return {m_blocks.data(), 0U};
+    }
+    [[nodiscard]] constexpr auto cbegin() const -> const_iterator {
+        return {m_blocks.data(), 0U};
+    }
+
+    [[nodiscard]] constexpr auto end() -> iterator {
+        return {m_blocks.data(), m_size};
+    }
+    [[nodiscard]] constexpr auto end() const -> const_iterator {
+        return {m_blocks.data(), m_size};
+    }
+    [[nodiscard]] constexpr auto cend() const -> const_iterator {
+        return {m_blocks.data(), m_size};
+    }
+
+    [[nodiscard]] constexpr auto back() -> reference {
+        return operator[](m_size - 1);
+    }
+    [[nodiscard]] constexpr auto back() const -> const_reference {
+        return operator[](m_size - 1);
+    }
+
+    void pop_back() {
+        back().~T();
+        --m_size;
+    }
+
+    [[nodiscard]] auto empty() const {
+        return 0 == m_size;
+    }
+
+    void reserve(std::size_t new_capacity) {
+        m_blocks.reserve(calc_num_blocks_for_capacity(new_capacity));
+        while (new_capacity > capacity()) {
+            increase_capacity();
+        }
+    }
+
+    void resize(std::size_t const count) {
+        if (count < m_size) {
+            resize_shrink(count);
+        } else if (count > m_size) {
+            std::size_t const new_elems = count - m_size;
+            reserve(count);
+            for (std::size_t ix = 0; ix < new_elems; ++ix) {
+                emplace_back();
+            }
+        }
+    }
+
+    void resize(std::size_t const count, value_type const& value) {
+        if (count < m_size) {
+            resize_shrink(count);
+        } else if (count > m_size) {
+            std::size_t const new_elems = count - m_size;
+            reserve(count);
+            for (std::size_t ix = 0; ix < new_elems; ++ix) {
+                emplace_back(value);
+            }
+        }
+    }
+
+    [[nodiscard]] auto get_allocator() const -> allocator_type {
+        return allocator_type{m_blocks.get_allocator()};
+    }
+
+    template <class... Args>
+    auto emplace_back(Args&&... args) -> reference {
+        if (m_size == capacity()) {
+            increase_capacity();
+        }
+        auto* ptr = static_cast<void*>(&operator[](m_size));
+        auto& ref = *new (ptr) T(std::forward<Args>(args)...);
+        ++m_size;
+        return ref;
+    }
+
+    void clear() {
+        if constexpr (!std::is_trivially_destructible_v<T>) {
+            for (std::size_t i = 0, s = size(); i < s; ++i) {
+                operator[](i).~T();
+            }
+        }
+        m_size = 0;
+    }
+
+    void shrink_to_fit() {
+        auto ba = Allocator(m_blocks.get_allocator());
+        auto num_blocks_required = calc_num_blocks_for_capacity(m_size);
+        while (m_blocks.size() > num_blocks_required) {
+            std::allocator_traits<Allocator>::deallocate(ba, m_blocks.back(), num_elements_in_block);
+            m_blocks.pop_back();
+        }
+        m_blocks.shrink_to_fit();
+    }
+};
+
+namespace detail {
+
+// This is it, the table. Doubles as map and set, and uses `void` for T when its used as a set.
+template <class Key,
+          class T, // when void, treat it as a set.
+          class Hash,
+          class KeyEqual,
+          class AllocatorOrContainer,
+          class Bucket,
+          class BucketContainer,
+          bool IsSegmented>
+class table : public std::conditional_t<is_map_v<T>, base_table_type_map<T>, base_table_type_set> {
+    using underlying_value_type = std::conditional_t<is_map_v<T>, std::pair<Key, T>, Key>;
+    using underlying_container_type = std::conditional_t<IsSegmented,
+                                                         segmented_vector<underlying_value_type, AllocatorOrContainer>,
+                                                         std::vector<underlying_value_type, AllocatorOrContainer>>;
+
+public:
+    using value_container_type = std::
+        conditional_t<is_detected_v<detect_iterator, AllocatorOrContainer>, AllocatorOrContainer, underlying_container_type>;
+
+private:
+    using bucket_alloc =
+        typename std::allocator_traits<typename value_container_type::allocator_type>::template rebind_alloc<Bucket>;
+    using default_bucket_container_type =
+        std::conditional_t<IsSegmented, segmented_vector<Bucket, bucket_alloc>, std::vector<Bucket, bucket_alloc>>;
+
+    using bucket_container_type = std::conditional_t<std::is_same_v<BucketContainer, detail::default_container_t>,
+                                                     default_bucket_container_type,
+                                                     BucketContainer>;
+
+    static constexpr std::uint8_t initial_shifts = 64 - 2; // 2^(64-m_shift) number of buckets
+    static constexpr float default_max_load_factor = 0.8F;
+
+public:
+    using key_type = Key;
+    using value_type = typename value_container_type::value_type;
+    using size_type = typename value_container_type::size_type;
+    using difference_type = typename value_container_type::difference_type;
+    using hasher = Hash;
+    using key_equal = KeyEqual;
+    using allocator_type = typename value_container_type::allocator_type;
+    using reference = typename value_container_type::reference;
+    using const_reference = typename value_container_type::const_reference;
+    using pointer = typename value_container_type::pointer;
+    using const_pointer = typename value_container_type::const_pointer;
+    using const_iterator = typename value_container_type::const_iterator;
+    using iterator = std::conditional_t<is_map_v<T>, typename value_container_type::iterator, const_iterator>;
+    using bucket_type = Bucket;
+
+private:
+    using value_idx_type = decltype(Bucket::m_value_idx);
+    using dist_and_fingerprint_type = decltype(Bucket::m_dist_and_fingerprint);
+
+    static_assert(std::is_trivially_destructible_v<Bucket>, "assert there's no need to call destructor / std::destroy");
+    static_assert(std::is_trivially_copyable_v<Bucket>, "assert we can just memset / memcpy");
+
+    value_container_type m_values{}; // Contains all the key-value pairs in one densely stored container. No holes.
+    bucket_container_type m_buckets{};
+    std::size_t m_max_bucket_capacity = 0;
+    float m_max_load_factor = default_max_load_factor;
+    Hash m_hash{};
+    KeyEqual m_equal{};
+    std::uint8_t m_shifts = initial_shifts;
+
+    [[nodiscard]] auto next(value_idx_type bucket_idx) const -> value_idx_type {
+        if (ANKERL_UNORDERED_DENSE_UNLIKELY(bucket_idx + 1U == bucket_count()))
+            ANKERL_UNORDERED_DENSE_UNLIKELY_ATTR {
+                return 0;
+            }
+
+        return static_cast<value_idx_type>(bucket_idx + 1U);
+    }
+
+    // Helper to access bucket through pointer types
+    [[nodiscard]] static constexpr auto at(bucket_container_type& bucket, std::size_t offset) -> Bucket& {
+        return bucket[offset];
+    }
+
+    [[nodiscard]] static constexpr auto at(const bucket_container_type& bucket, std::size_t offset) -> const Bucket& {
+        return bucket[offset];
+    }
+
+    // use the dist_inc and dist_dec functions so that std::uint16_t types work without warning
+    [[nodiscard]] static constexpr auto dist_inc(dist_and_fingerprint_type x) -> dist_and_fingerprint_type {
+        return static_cast<dist_and_fingerprint_type>(x + Bucket::dist_inc);
+    }
+
+    [[nodiscard]] static constexpr auto dist_dec(dist_and_fingerprint_type x) -> dist_and_fingerprint_type {
+        return static_cast<dist_and_fingerprint_type>(x - Bucket::dist_inc);
+    }
+
+    // The goal of mixed_hash is to always produce a high quality 64bit hash.
+    template <typename K>
+    [[nodiscard]] constexpr auto mixed_hash(K const& key) const -> std::uint64_t {
+        if constexpr (is_detected_v<detect_avalanching, Hash>) {
+            // we know that the hash is good because is_avalanching.
+            if constexpr (sizeof(decltype(m_hash(key))) < sizeof(std::uint64_t)) {
+                // 32bit hash and is_avalanching => multiply with a constant to avalanche bits upwards
+                return m_hash(key) * UINT64_C(0x9ddfea08eb382d69);
+            } else {
+                // 64bit and is_avalanching => only use the hash itself.
+                return m_hash(key);
+            }
+        } else {
+            // not is_avalanching => apply wyhash
+            return wyhash::hash(m_hash(key));
+        }
+    }
+
+    [[nodiscard]] constexpr auto dist_and_fingerprint_from_hash(std::uint64_t hash) const -> dist_and_fingerprint_type {
+        return Bucket::dist_inc | (static_cast<dist_and_fingerprint_type>(hash) & Bucket::fingerprint_mask);
+    }
+
+    [[nodiscard]] constexpr auto bucket_idx_from_hash(std::uint64_t hash) const -> value_idx_type {
+        return static_cast<value_idx_type>(hash >> m_shifts);
+    }
+
+    [[nodiscard]] static constexpr auto get_key(value_type const& vt) -> key_type const& {
+        if constexpr (is_map_v<T>) {
+            return vt.first;
+        } else {
+            return vt;
+        }
+    }
+
+    template <typename K>
+    [[nodiscard]] auto next_while_less(K const& key) const -> Bucket {
+        auto hash = mixed_hash(key);
+        auto dist_and_fingerprint = dist_and_fingerprint_from_hash(hash);
+        auto bucket_idx = bucket_idx_from_hash(hash);
+
+        while (dist_and_fingerprint < at(m_buckets, bucket_idx).m_dist_and_fingerprint) {
+            dist_and_fingerprint = dist_inc(dist_and_fingerprint);
+            bucket_idx = next(bucket_idx);
+        }
+        return {dist_and_fingerprint, bucket_idx};
+    }
+
+    void place_and_shift_up(Bucket bucket, value_idx_type place) {
+        while (0 != at(m_buckets, place).m_dist_and_fingerprint) {
+            bucket = std::exchange(at(m_buckets, place), bucket);
+            bucket.m_dist_and_fingerprint = dist_inc(bucket.m_dist_and_fingerprint);
+            place = next(place);
+        }
+        at(m_buckets, place) = bucket;
+    }
+
+    void erase_and_shift_down(value_idx_type bucket_idx) {
+        // shift down until either empty or an element with correct spot is found
+        auto next_bucket_idx = next(bucket_idx);
+        while (at(m_buckets, next_bucket_idx).m_dist_and_fingerprint >= Bucket::dist_inc * 2) {
+            auto& next_bucket = at(m_buckets, next_bucket_idx);
+            at(m_buckets, bucket_idx) = {dist_dec(next_bucket.m_dist_and_fingerprint), next_bucket.m_value_idx};
+            bucket_idx = std::exchange(next_bucket_idx, next(next_bucket_idx));
+        }
+        at(m_buckets, bucket_idx) = {};
+    }
+
+    [[nodiscard]] static constexpr auto calc_num_buckets(std::uint8_t shifts) -> std::size_t {
+        return (std::min)(max_bucket_count(), std::size_t{1} << (64U - shifts));
+    }
+
+    [[nodiscard]] constexpr auto calc_shifts_for_size(std::size_t s) const -> std::uint8_t {
+        auto shifts = initial_shifts;
+        while (shifts > 0 && static_cast<std::size_t>(static_cast<float>(calc_num_buckets(shifts)) * max_load_factor()) < s) {
+            --shifts;
+        }
+        return shifts;
+    }
+
+    // assumes m_values has data, m_buckets=m_buckets_end=nullptr, m_shifts is INITIAL_SHIFTS
+    void copy_buckets(table const& other) {
+        // assumes m_values has already the correct data copied over.
+        if (empty()) {
+            // when empty, at least allocate an initial buckets and clear them.
+            allocate_buckets_from_shift();
+            clear_buckets();
+        } else {
+            m_shifts = other.m_shifts;
+            allocate_buckets_from_shift();
+            if constexpr (IsSegmented || !std::is_same_v<BucketContainer, default_container_t>) {
+                for (auto i = 0UL; i < bucket_count(); ++i) {
+                    at(m_buckets, i) = at(other.m_buckets, i);
+                }
+            } else {
+                std::memcpy(m_buckets.data(), other.m_buckets.data(), sizeof(Bucket) * bucket_count());
+            }
+        }
+    }
+
+    /**
+     * True when no element can be added any more without increasing the size
+     */
+    [[nodiscard]] auto is_full() const -> bool {
+        return size() > m_max_bucket_capacity;
+    }
+
+    void deallocate_buckets() {
+        m_buckets.clear();
+        m_buckets.shrink_to_fit();
+        m_max_bucket_capacity = 0;
+    }
+
+    void allocate_buckets_from_shift() {
+        auto num_buckets = calc_num_buckets(m_shifts);
+        if constexpr (IsSegmented || !std::is_same_v<BucketContainer, default_container_t>) {
+            if constexpr (has_reserve<bucket_container_type>) {
+                m_buckets.reserve(num_buckets);
+            }
+            for (std::size_t i = m_buckets.size(); i < num_buckets; ++i) {
+                m_buckets.emplace_back();
+            }
+        } else {
+            m_buckets.resize(num_buckets);
+        }
+        if (num_buckets == max_bucket_count()) {
+            // reached the maximum, make sure we can use each bucket
+            m_max_bucket_capacity = max_bucket_count();
+        } else {
+            m_max_bucket_capacity = static_cast<value_idx_type>(static_cast<float>(num_buckets) * max_load_factor());
+        }
+    }
+
+    void clear_buckets() {
+        if constexpr (IsSegmented || !std::is_same_v<BucketContainer, default_container_t>) {
+            for (auto&& e : m_buckets) {
+                std::memset(&e, 0, sizeof(e));
+            }
+        } else {
+            std::memset(m_buckets.data(), 0, sizeof(Bucket) * bucket_count());
+        }
+    }
+
+    void clear_and_fill_buckets_from_values() {
+        clear_buckets();
+        for (value_idx_type value_idx = 0, end_idx = static_cast<value_idx_type>(m_values.size()); value_idx < end_idx;
+             ++value_idx) {
+            auto const& key = get_key(m_values[value_idx]);
+            auto [dist_and_fingerprint, bucket] = next_while_less(key);
+
+            // we know for certain that key has not yet been inserted, so no need to check it.
+            place_and_shift_up({dist_and_fingerprint, value_idx}, bucket);
+        }
+    }
+
+    void increase_size() {
+        if (m_max_bucket_capacity == max_bucket_count()) {
+            // remove the value again, we can't add it!
+            m_values.pop_back();
+            on_error_bucket_overflow();
+        }
+        --m_shifts;
+        if constexpr (!IsSegmented || std::is_same_v<BucketContainer, default_container_t>) {
+            deallocate_buckets();
+        }
+        allocate_buckets_from_shift();
+        clear_and_fill_buckets_from_values();
+    }
+
+    template <typename Op>
+    void do_erase(value_idx_type bucket_idx, Op handle_erased_value) {
+        auto const value_idx_to_remove = at(m_buckets, bucket_idx).m_value_idx;
+        erase_and_shift_down(bucket_idx);
+        handle_erased_value(std::move(m_values[value_idx_to_remove]));
+
+        // update m_values
+        if (value_idx_to_remove != m_values.size() - 1) {
+            // no luck, we'll have to replace the value with the last one and update the index accordingly
+            auto& val = m_values[value_idx_to_remove];
+            val = std::move(m_values.back());
+
+            // update the values_idx of the moved entry. No need to play the info game, just look until we find the values_idx
+            bucket_idx = bucket_idx_from_hash(mixed_hash(get_key(val)));
+            auto const values_idx_back = static_cast<value_idx_type>(m_values.size() - 1);
+            while (values_idx_back != at(m_buckets, bucket_idx).m_value_idx) {
+                bucket_idx = next(bucket_idx);
+            }
+            at(m_buckets, bucket_idx).m_value_idx = value_idx_to_remove;
+        }
+        m_values.pop_back();
+    }
+
+    template <typename K, typename Op>
+    auto do_erase_key(K&& key, Op handle_erased_value) -> std::size_t { // NOLINT(cppcoreguidelines-missing-std-forward)
+        if (empty()) {
+            return 0;
+        }
+
+        auto [dist_and_fingerprint, bucket_idx] = next_while_less(key);
+
+        while (dist_and_fingerprint == at(m_buckets, bucket_idx).m_dist_and_fingerprint &&
+               !m_equal(key, get_key(m_values[at(m_buckets, bucket_idx).m_value_idx]))) {
+            dist_and_fingerprint = dist_inc(dist_and_fingerprint);
+            bucket_idx = next(bucket_idx);
+        }
+
+        if (dist_and_fingerprint != at(m_buckets, bucket_idx).m_dist_and_fingerprint) {
+            return 0;
+        }
+        do_erase(bucket_idx, handle_erased_value);
+        return 1;
+    }
+
+    template <class K, class M>
+    auto do_insert_or_assign(K&& key, M&& mapped) -> std::pair<iterator, bool> {
+        auto it_isinserted = try_emplace(std::forward<K>(key), std::forward<M>(mapped));
+        if (!it_isinserted.second) {
+            it_isinserted.first->second = std::forward<M>(mapped);
+        }
+        return it_isinserted;
+    }
+
+    template <typename... Args>
+    auto do_place_element(dist_and_fingerprint_type dist_and_fingerprint, value_idx_type bucket_idx, Args&&... args)
+        -> std::pair<iterator, bool> {
+
+        // emplace the new value. If that throws an exception, no harm done; index is still in a valid state
+        m_values.emplace_back(std::forward<Args>(args)...);
+
+        auto value_idx = static_cast<value_idx_type>(m_values.size() - 1);
+        if (ANKERL_UNORDERED_DENSE_UNLIKELY(is_full()))
+            ANKERL_UNORDERED_DENSE_UNLIKELY_ATTR {
+                increase_size();
+            }
+        else {
+            place_and_shift_up({dist_and_fingerprint, value_idx}, bucket_idx);
+        }
+
+        // place element and shift up until we find an empty spot
+        return {begin() + static_cast<difference_type>(value_idx), true};
+    }
+
+    template <typename K, typename... Args>
+    auto do_try_emplace(K&& key, Args&&... args) -> std::pair<iterator, bool> {
+        auto hash = mixed_hash(key);
+        auto dist_and_fingerprint = dist_and_fingerprint_from_hash(hash);
+        auto bucket_idx = bucket_idx_from_hash(hash);
+
+        while (true) {
+            auto* bucket = &at(m_buckets, bucket_idx);
+            if (dist_and_fingerprint == bucket->m_dist_and_fingerprint) {
+                if (m_equal(key, get_key(m_values[bucket->m_value_idx]))) {
+                    return {begin() + static_cast<difference_type>(bucket->m_value_idx), false};
+                }
+            } else if (dist_and_fingerprint > bucket->m_dist_and_fingerprint) {
+                return do_place_element(dist_and_fingerprint,
+                                        bucket_idx,
+                                        std::piecewise_construct,
+                                        std::forward_as_tuple(std::forward<K>(key)),
+                                        std::forward_as_tuple(std::forward<Args>(args)...));
+            }
+            dist_and_fingerprint = dist_inc(dist_and_fingerprint);
+            bucket_idx = next(bucket_idx);
+        }
+    }
+
+    template <typename K>
+    auto do_find(K const& key) -> iterator {
+        if (ANKERL_UNORDERED_DENSE_UNLIKELY(empty()))
+            ANKERL_UNORDERED_DENSE_UNLIKELY_ATTR {
+                return end();
+            }
+
+        auto mh = mixed_hash(key);
+        auto dist_and_fingerprint = dist_and_fingerprint_from_hash(mh);
+        auto bucket_idx = bucket_idx_from_hash(mh);
+        auto* bucket = &at(m_buckets, bucket_idx);
+
+        // unrolled loop. *Always* check a few directly, then enter the loop. This is faster.
+        if (dist_and_fingerprint == bucket->m_dist_and_fingerprint && m_equal(key, get_key(m_values[bucket->m_value_idx]))) {
+            return begin() + static_cast<difference_type>(bucket->m_value_idx);
+        }
+        dist_and_fingerprint = dist_inc(dist_and_fingerprint);
+        bucket_idx = next(bucket_idx);
+        bucket = &at(m_buckets, bucket_idx);
+
+        if (dist_and_fingerprint == bucket->m_dist_and_fingerprint && m_equal(key, get_key(m_values[bucket->m_value_idx]))) {
+            return begin() + static_cast<difference_type>(bucket->m_value_idx);
+        }
+        dist_and_fingerprint = dist_inc(dist_and_fingerprint);
+        bucket_idx = next(bucket_idx);
+        bucket = &at(m_buckets, bucket_idx);
+
+        while (true) {
+            if (dist_and_fingerprint == bucket->m_dist_and_fingerprint) {
+                if (m_equal(key, get_key(m_values[bucket->m_value_idx]))) {
+                    return begin() + static_cast<difference_type>(bucket->m_value_idx);
+                }
+            } else if (dist_and_fingerprint > bucket->m_dist_and_fingerprint) {
+                return end();
+            }
+            dist_and_fingerprint = dist_inc(dist_and_fingerprint);
+            bucket_idx = next(bucket_idx);
+            bucket = &at(m_buckets, bucket_idx);
+        }
+    }
+
+    template <typename K>
+    auto do_find(K const& key) const -> const_iterator {
+        return const_cast<table*>(this)->do_find(key); // NOLINT(cppcoreguidelines-pro-type-const-cast)
+    }
+
+    template <typename K, typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto do_at(K const& key) -> Q& {
+        if (auto it = find(key); ANKERL_UNORDERED_DENSE_LIKELY(end() != it))
+            ANKERL_UNORDERED_DENSE_LIKELY_ATTR {
+                return it->second;
+            }
+        on_error_key_not_found();
+    }
+
+    template <typename K, typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto do_at(K const& key) const -> Q const& {
+        return const_cast<table*>(this)->at(key); // NOLINT(cppcoreguidelines-pro-type-const-cast)
+    }
+
+public:
+    explicit table(std::size_t bucket_count,
+                   Hash const& hash = Hash(),
+                   KeyEqual const& equal = KeyEqual(),
+                   allocator_type const& alloc_or_container = allocator_type())
+        : m_values(alloc_or_container)
+        , m_buckets(alloc_or_container)
+        , m_hash(hash)
+        , m_equal(equal) {
+        if (0 != bucket_count) {
+            reserve(bucket_count);
+        } else {
+            allocate_buckets_from_shift();
+            clear_buckets();
+        }
+    }
+
+    table()
+        : table(0) {}
+
+    table(std::size_t bucket_count, allocator_type const& alloc)
+        : table(bucket_count, Hash(), KeyEqual(), alloc) {}
+
+    table(std::size_t bucket_count, Hash const& hash, allocator_type const& alloc)
+        : table(bucket_count, hash, KeyEqual(), alloc) {}
+
+    explicit table(allocator_type const& alloc)
+        : table(0, Hash(), KeyEqual(), alloc) {}
+
+    template <class InputIt>
+    table(InputIt first,
+          InputIt last,
+          size_type bucket_count = 0,
+          Hash const& hash = Hash(),
+          KeyEqual const& equal = KeyEqual(),
+          allocator_type const& alloc = allocator_type())
+        : table(bucket_count, hash, equal, alloc) {
+        insert(first, last);
+    }
+
+    template <class InputIt>
+    table(InputIt first, InputIt last, size_type bucket_count, allocator_type const& alloc)
+        : table(first, last, bucket_count, Hash(), KeyEqual(), alloc) {}
+
+    template <class InputIt>
+    table(InputIt first, InputIt last, size_type bucket_count, Hash const& hash, allocator_type const& alloc)
+        : table(first, last, bucket_count, hash, KeyEqual(), alloc) {}
+
+    table(table const& other)
+        : table(other, other.m_values.get_allocator()) {}
+
+    table(table const& other, allocator_type const& alloc)
+        : m_values(other.m_values, alloc)
+        , m_max_load_factor(other.m_max_load_factor)
+        , m_hash(other.m_hash)
+        , m_equal(other.m_equal) {
+        copy_buckets(other);
+    }
+
+    table(table&& other) noexcept
+        : table(std::move(other), other.m_values.get_allocator()) {}
+
+    table(table&& other, allocator_type const& alloc) noexcept
+        : m_values(alloc) {
+        *this = std::move(other);
+    }
+
+    table(std::initializer_list<value_type> ilist,
+          std::size_t bucket_count = 0,
+          Hash const& hash = Hash(),
+          KeyEqual const& equal = KeyEqual(),
+          allocator_type const& alloc = allocator_type())
+        : table(bucket_count, hash, equal, alloc) {
+        insert(ilist);
+    }
+
+    table(std::initializer_list<value_type> ilist, size_type bucket_count, allocator_type const& alloc)
+        : table(ilist, bucket_count, Hash(), KeyEqual(), alloc) {}
+
+    table(std::initializer_list<value_type> init, size_type bucket_count, Hash const& hash, allocator_type const& alloc)
+        : table(init, bucket_count, hash, KeyEqual(), alloc) {}
+
+    ~table() = default;
+
+    auto operator=(table const& other) -> table& {
+        if (&other != this) {
+            deallocate_buckets(); // deallocate before m_values is set (might have another allocator)
+            m_values = other.m_values;
+            m_max_load_factor = other.m_max_load_factor;
+            m_hash = other.m_hash;
+            m_equal = other.m_equal;
+            m_shifts = initial_shifts;
+            copy_buckets(other);
+        }
+        return *this;
+    }
+
+    auto operator=(table&& other) noexcept(noexcept(std::is_nothrow_move_assignable_v<value_container_type> &&
+                                                    std::is_nothrow_move_assignable_v<Hash> &&
+                                                    std::is_nothrow_move_assignable_v<KeyEqual>)) -> table& {
+        if (&other != this) {
+            deallocate_buckets(); // deallocate before m_values is set (might have another allocator)
+            m_values = std::move(other.m_values);
+            other.m_values.clear();
+
+            // we can only reuse m_buckets when both maps have the same allocator!
+            if (get_allocator() == other.get_allocator()) {
+                m_buckets = std::move(other.m_buckets);
+                other.m_buckets.clear();
+                m_max_bucket_capacity = std::exchange(other.m_max_bucket_capacity, 0);
+                m_shifts = std::exchange(other.m_shifts, initial_shifts);
+                m_max_load_factor = std::exchange(other.m_max_load_factor, default_max_load_factor);
+                m_hash = std::exchange(other.m_hash, {});
+                m_equal = std::exchange(other.m_equal, {});
+                other.allocate_buckets_from_shift();
+                other.clear_buckets();
+            } else {
+                // set max_load_factor *before* copying the other's buckets, so we have the same
+                // behavior
+                m_max_load_factor = other.m_max_load_factor;
+
+                // copy_buckets sets m_buckets, m_num_buckets, m_max_bucket_capacity, m_shifts
+                copy_buckets(other);
+                // clear's the other's buckets so other is now already usable.
+                other.clear_buckets();
+                m_hash = other.m_hash;
+                m_equal = other.m_equal;
+            }
+            // map "other" is now already usable, it's empty.
+        }
+        return *this;
+    }
+
+    auto operator=(std::initializer_list<value_type> ilist) -> table& {
+        clear();
+        insert(ilist);
+        return *this;
+    }
+
+    auto get_allocator() const noexcept -> allocator_type {
+        return m_values.get_allocator();
+    }
+
+    // iterators //////////////////////////////////////////////////////////////
+
+    auto begin() noexcept -> iterator {
+        return m_values.begin();
+    }
+
+    auto begin() const noexcept -> const_iterator {
+        return m_values.begin();
+    }
+
+    auto cbegin() const noexcept -> const_iterator {
+        return m_values.cbegin();
+    }
+
+    auto end() noexcept -> iterator {
+        return m_values.end();
+    }
+
+    auto cend() const noexcept -> const_iterator {
+        return m_values.cend();
+    }
+
+    auto end() const noexcept -> const_iterator {
+        return m_values.end();
+    }
+
+    // capacity ///////////////////////////////////////////////////////////////
+
+    [[nodiscard]] auto empty() const noexcept -> bool {
+        return m_values.empty();
+    }
+
+    [[nodiscard]] auto size() const noexcept -> std::size_t {
+        return m_values.size();
+    }
+
+    [[nodiscard]] static constexpr auto max_size() noexcept -> std::size_t {
+        if constexpr ((std::numeric_limits<value_idx_type>::max)() == (std::numeric_limits<std::size_t>::max)()) {
+            return std::size_t{1} << (sizeof(value_idx_type) * 8 - 1);
+        } else {
+            return std::size_t{1} << (sizeof(value_idx_type) * 8);
+        }
+    }
+
+    // modifiers //////////////////////////////////////////////////////////////
+
+    void clear() {
+        m_values.clear();
+        clear_buckets();
+    }
+
+    auto insert(value_type const& value) -> std::pair<iterator, bool> {
+        return emplace(value);
+    }
+
+    auto insert(value_type&& value) -> std::pair<iterator, bool> {
+        return emplace(std::move(value));
+    }
+
+    template <class P, std::enable_if_t<std::is_constructible_v<value_type, P&&>, bool> = true>
+    auto insert(P&& value) -> std::pair<iterator, bool> {
+        return emplace(std::forward<P>(value));
+    }
+
+    auto insert(const_iterator /*hint*/, value_type const& value) -> iterator {
+        return insert(value).first;
+    }
+
+    auto insert(const_iterator /*hint*/, value_type&& value) -> iterator {
+        return insert(std::move(value)).first;
+    }
+
+    template <class P, std::enable_if_t<std::is_constructible_v<value_type, P&&>, bool> = true>
+    auto insert(const_iterator /*hint*/, P&& value) -> iterator {
+        return insert(std::forward<P>(value)).first;
+    }
+
+    template <class InputIt>
+    void insert(InputIt first, InputIt last) {
+        while (first != last) {
+            insert(*first);
+            ++first;
+        }
+    }
+
+    void insert(std::initializer_list<value_type> ilist) {
+        insert(ilist.begin(), ilist.end());
+    }
+
+    // nonstandard API: *this is emptied.
+    // Also see "A Standard flat_map" https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p0429r9.pdf
+    auto extract() && -> value_container_type {
+        return std::move(m_values);
+    }
+
+    // nonstandard API:
+    // Discards the internally held container and replaces it with the one passed. Erases non-unique elements.
+    auto replace(value_container_type&& container) {
+        if (ANKERL_UNORDERED_DENSE_UNLIKELY(container.size() > max_size()))
+            ANKERL_UNORDERED_DENSE_UNLIKELY_ATTR {
+                on_error_too_many_elements();
+            }
+        auto shifts = calc_shifts_for_size(container.size());
+        if (0 == bucket_count() || shifts < m_shifts || container.get_allocator() != m_values.get_allocator()) {
+            m_shifts = shifts;
+            deallocate_buckets();
+            allocate_buckets_from_shift();
+        }
+        clear_buckets();
+
+        m_values = std::move(container);
+
+        // can't use clear_and_fill_buckets_from_values() because container elements might not be unique
+        auto value_idx = value_idx_type{};
+
+        // loop until we reach the end of the container. duplicated entries will be replaced with back().
+        while (value_idx != static_cast<value_idx_type>(m_values.size())) {
+            auto const& key = get_key(m_values[value_idx]);
+
+            auto hash = mixed_hash(key);
+            auto dist_and_fingerprint = dist_and_fingerprint_from_hash(hash);
+            auto bucket_idx = bucket_idx_from_hash(hash);
+
+            bool key_found = false;
+            while (true) {
+                auto const& bucket = at(m_buckets, bucket_idx);
+                if (dist_and_fingerprint > bucket.m_dist_and_fingerprint) {
+                    break;
+                }
+                if (dist_and_fingerprint == bucket.m_dist_and_fingerprint &&
+                    m_equal(key, get_key(m_values[bucket.m_value_idx]))) {
+                    key_found = true;
+                    break;
+                }
+                dist_and_fingerprint = dist_inc(dist_and_fingerprint);
+                bucket_idx = next(bucket_idx);
+            }
+
+            if (key_found) {
+                if (value_idx != static_cast<value_idx_type>(m_values.size() - 1)) {
+                    m_values[value_idx] = std::move(m_values.back());
+                }
+                m_values.pop_back();
+            } else {
+                place_and_shift_up({dist_and_fingerprint, value_idx}, bucket_idx);
+                ++value_idx;
+            }
+        }
+    }
+
+    template <class M, typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto insert_or_assign(Key const& key, M&& mapped) -> std::pair<iterator, bool> {
+        return do_insert_or_assign(key, std::forward<M>(mapped));
+    }
+
+    template <class M, typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto insert_or_assign(Key&& key, M&& mapped) -> std::pair<iterator, bool> {
+        return do_insert_or_assign(std::move(key), std::forward<M>(mapped));
+    }
+
+    template <typename K,
+              typename M,
+              typename Q = T,
+              typename H = Hash,
+              typename KE = KeyEqual,
+              std::enable_if_t<is_map_v<Q> && is_transparent_v<H, KE>, bool> = true>
+    auto insert_or_assign(K&& key, M&& mapped) -> std::pair<iterator, bool> {
+        return do_insert_or_assign(std::forward<K>(key), std::forward<M>(mapped));
+    }
+
+    template <class M, typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto insert_or_assign(const_iterator /*hint*/, Key const& key, M&& mapped) -> iterator {
+        return do_insert_or_assign(key, std::forward<M>(mapped)).first;
+    }
+
+    template <class M, typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto insert_or_assign(const_iterator /*hint*/, Key&& key, M&& mapped) -> iterator {
+        return do_insert_or_assign(std::move(key), std::forward<M>(mapped)).first;
+    }
+
+    template <typename K,
+              typename M,
+              typename Q = T,
+              typename H = Hash,
+              typename KE = KeyEqual,
+              std::enable_if_t<is_map_v<Q> && is_transparent_v<H, KE>, bool> = true>
+    auto insert_or_assign(const_iterator /*hint*/, K&& key, M&& mapped) -> iterator {
+        return do_insert_or_assign(std::forward<K>(key), std::forward<M>(mapped)).first;
+    }
+
+    // Single arguments for unordered_set can be used without having to construct the value_type
+    template <class K,
+              typename Q = T,
+              typename H = Hash,
+              typename KE = KeyEqual,
+              std::enable_if_t<!is_map_v<Q> && is_transparent_v<H, KE>, bool> = true>
+    auto emplace(K&& key) -> std::pair<iterator, bool> {
+        auto hash = mixed_hash(key);
+        auto dist_and_fingerprint = dist_and_fingerprint_from_hash(hash);
+        auto bucket_idx = bucket_idx_from_hash(hash);
+
+        while (dist_and_fingerprint <= at(m_buckets, bucket_idx).m_dist_and_fingerprint) {
+            if (dist_and_fingerprint == at(m_buckets, bucket_idx).m_dist_and_fingerprint &&
+                m_equal(key, m_values[at(m_buckets, bucket_idx).m_value_idx])) {
+                // found it, return without ever actually creating anything
+                return {begin() + static_cast<difference_type>(at(m_buckets, bucket_idx).m_value_idx), false};
+            }
+            dist_and_fingerprint = dist_inc(dist_and_fingerprint);
+            bucket_idx = next(bucket_idx);
+        }
+
+        // value is new, insert element first, so when exception happens we are in a valid state
+        return do_place_element(dist_and_fingerprint, bucket_idx, std::forward<K>(key));
+    }
+
+    template <class... Args>
+    auto emplace(Args&&... args) -> std::pair<iterator, bool> {
+        // we have to instantiate the value_type to be able to access the key.
+        // 1. emplace_back the object so it is constructed. 2. If the key is already there, pop it later in the loop.
+        auto& key = get_key(m_values.emplace_back(std::forward<Args>(args)...));
+        auto hash = mixed_hash(key);
+        auto dist_and_fingerprint = dist_and_fingerprint_from_hash(hash);
+        auto bucket_idx = bucket_idx_from_hash(hash);
+
+        while (dist_and_fingerprint <= at(m_buckets, bucket_idx).m_dist_and_fingerprint) {
+            if (dist_and_fingerprint == at(m_buckets, bucket_idx).m_dist_and_fingerprint &&
+                m_equal(key, get_key(m_values[at(m_buckets, bucket_idx).m_value_idx]))) {
+                m_values.pop_back(); // value was already there, so get rid of it
+                return {begin() + static_cast<difference_type>(at(m_buckets, bucket_idx).m_value_idx), false};
+            }
+            dist_and_fingerprint = dist_inc(dist_and_fingerprint);
+            bucket_idx = next(bucket_idx);
+        }
+
+        // value is new, place the bucket and shift up until we find an empty spot
+        auto value_idx = static_cast<value_idx_type>(m_values.size() - 1);
+        if (ANKERL_UNORDERED_DENSE_UNLIKELY(is_full()))
+            ANKERL_UNORDERED_DENSE_UNLIKELY_ATTR {
+                // increase_size just rehashes all the data we have in m_values
+                increase_size();
+            }
+        else {
+            // place element and shift up until we find an empty spot
+            place_and_shift_up({dist_and_fingerprint, value_idx}, bucket_idx);
+        }
+        return {begin() + static_cast<difference_type>(value_idx), true};
+    }
+
+    template <class... Args>
+    auto emplace_hint(const_iterator /*hint*/, Args&&... args) -> iterator {
+        return emplace(std::forward<Args>(args)...).first;
+    }
+
+    template <class... Args, typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto try_emplace(Key const& key, Args&&... args) -> std::pair<iterator, bool> {
+        return do_try_emplace(key, std::forward<Args>(args)...);
+    }
+
+    template <class... Args, typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto try_emplace(Key&& key, Args&&... args) -> std::pair<iterator, bool> {
+        return do_try_emplace(std::move(key), std::forward<Args>(args)...);
+    }
+
+    template <class... Args, typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto try_emplace(const_iterator /*hint*/, Key const& key, Args&&... args) -> iterator {
+        return do_try_emplace(key, std::forward<Args>(args)...).first;
+    }
+
+    template <class... Args, typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto try_emplace(const_iterator /*hint*/, Key&& key, Args&&... args) -> iterator {
+        return do_try_emplace(std::move(key), std::forward<Args>(args)...).first;
+    }
+
+    template <
+        typename K,
+        typename... Args,
+        typename Q = T,
+        typename H = Hash,
+        typename KE = KeyEqual,
+        std::enable_if_t<is_map_v<Q> && is_transparent_v<H, KE> && is_neither_convertible_v<K&&, iterator, const_iterator>,
+                         bool> = true>
+    auto try_emplace(K&& key, Args&&... args) -> std::pair<iterator, bool> {
+        return do_try_emplace(std::forward<K>(key), std::forward<Args>(args)...);
+    }
+
+    template <
+        typename K,
+        typename... Args,
+        typename Q = T,
+        typename H = Hash,
+        typename KE = KeyEqual,
+        std::enable_if_t<is_map_v<Q> && is_transparent_v<H, KE> && is_neither_convertible_v<K&&, iterator, const_iterator>,
+                         bool> = true>
+    auto try_emplace(const_iterator /*hint*/, K&& key, Args&&... args) -> iterator {
+        return do_try_emplace(std::forward<K>(key), std::forward<Args>(args)...).first;
+    }
+
+    // Replaces the key at the given iterator with new_key. This does not change any other data in the underlying table, so
+    // all iterators and references remain valid. However, this operation can fail if new_key already exists in the table.
+    // In that case, returns {iterator to the already existing new_key, false} and no change is made.
+    //
+    // In the case of a set, this effectively removes the old key and inserts the new key at the same spot, which is more
+    // efficient than removing the old key and inserting the new key because it avoids repositioning the last element.
+    template <typename K>
+    auto replace_key(iterator it, K&& new_key) -> std::pair<iterator, bool> {
+        auto const new_key_hash = mixed_hash(new_key);
+
+        // first, check if new_key already exists and return if so
+        auto dist_and_fingerprint = dist_and_fingerprint_from_hash(new_key_hash);
+        auto bucket_idx = bucket_idx_from_hash(new_key_hash);
+        while (dist_and_fingerprint <= at(m_buckets, bucket_idx).m_dist_and_fingerprint) {
+            auto const& bucket = at(m_buckets, bucket_idx);
+            if (dist_and_fingerprint == bucket.m_dist_and_fingerprint &&
+                m_equal(new_key, get_key(m_values[bucket.m_value_idx]))) {
+                return {begin() + static_cast<difference_type>(bucket.m_value_idx), false};
+            }
+            dist_and_fingerprint = dist_inc(dist_and_fingerprint);
+            bucket_idx = next(bucket_idx);
+        }
+
+        // const_cast is needed because iterator for the set is always const, so adding another get_key overload is not
+        // feasible.
+        auto& target_key = const_cast<key_type&>(get_key(*it));
+        auto const old_key_bucket_idx = bucket_idx_from_hash(mixed_hash(target_key));
+
+        // Replace the key before doing any bucket changes. If it throws, no harm done, we are still in a valid state as we
+        // have not modified any buckets yet.
+        target_key = std::forward<K>(new_key);
+
+        auto const value_idx = static_cast<value_idx_type>(it - begin());
+
+        // Find the bucket containing our value_idx. It's guaranteed we find it, so no other stopping condition needed.
+        bucket_idx = old_key_bucket_idx;
+        while (value_idx != at(m_buckets, bucket_idx).m_value_idx) {
+            bucket_idx = next(bucket_idx);
+        }
+        erase_and_shift_down(bucket_idx);
+
+        // place the new bucket
+        dist_and_fingerprint = dist_and_fingerprint_from_hash(new_key_hash);
+        bucket_idx = bucket_idx_from_hash(new_key_hash);
+        while (dist_and_fingerprint < at(m_buckets, bucket_idx).m_dist_and_fingerprint) {
+            dist_and_fingerprint = dist_inc(dist_and_fingerprint);
+            bucket_idx = next(bucket_idx);
+        }
+        place_and_shift_up({dist_and_fingerprint, value_idx}, bucket_idx);
+
+        return {it, true};
+    }
+
+    auto erase(iterator it) -> iterator {
+        auto hash = mixed_hash(get_key(*it));
+        auto bucket_idx = bucket_idx_from_hash(hash);
+
+        auto const value_idx_to_remove = static_cast<value_idx_type>(it - cbegin());
+        while (at(m_buckets, bucket_idx).m_value_idx != value_idx_to_remove) {
+            bucket_idx = next(bucket_idx);
+        }
+
+        do_erase(bucket_idx, [](value_type const& /*unused*/) -> void {
+        });
+        return begin() + static_cast<difference_type>(value_idx_to_remove);
+    }
+
+    auto extract(iterator it) -> value_type {
+        auto hash = mixed_hash(get_key(*it));
+        auto bucket_idx = bucket_idx_from_hash(hash);
+
+        auto const value_idx_to_remove = static_cast<value_idx_type>(it - cbegin());
+        while (at(m_buckets, bucket_idx).m_value_idx != value_idx_to_remove) {
+            bucket_idx = next(bucket_idx);
+        }
+
+        auto tmp = std::optional<value_type>{};
+        do_erase(bucket_idx, [&tmp](value_type&& val) -> void {
+            tmp = std::move(val);
+        });
+        return std::move(tmp).value();
+    }
+
+    template <typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto erase(const_iterator it) -> iterator {
+        return erase(begin() + (it - cbegin()));
+    }
+
+    template <typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto extract(const_iterator it) -> value_type {
+        return extract(begin() + (it - cbegin()));
+    }
+
+    auto erase(const_iterator first, const_iterator last) -> iterator {
+        auto const idx_first = first - cbegin();
+        auto const idx_last = last - cbegin();
+        auto const first_to_last = std::distance(first, last);
+        auto const last_to_end = std::distance(last, cend());
+
+        // remove elements from left to right which moves elements from the end back
+        auto const mid = idx_first + (std::min)(first_to_last, last_to_end);
+        auto idx = idx_first;
+        while (idx != mid) {
+            erase(begin() + idx);
+            ++idx;
+        }
+
+        // all elements from the right are moved, now remove the last element until all done
+        idx = idx_last;
+        while (idx != mid) {
+            --idx;
+            erase(begin() + idx);
+        }
+
+        return begin() + idx_first;
+    }
+
+    auto erase(Key const& key) -> std::size_t {
+        return do_erase_key(key, [](value_type const& /*unused*/) -> void {
+        });
+    }
+
+    auto extract(Key const& key) -> std::optional<value_type> {
+        auto tmp = std::optional<value_type>{};
+        do_erase_key(key, [&tmp](value_type&& val) -> void {
+            tmp = std::move(val);
+        });
+        return tmp;
+    }
+
+    template <class K, class H = Hash, class KE = KeyEqual, std::enable_if_t<is_transparent_v<H, KE>, bool> = true>
+    auto erase(K&& key) -> std::size_t {
+        return do_erase_key(std::forward<K>(key), [](value_type const& /*unused*/) -> void {
+        });
+    }
+
+    template <class K, class H = Hash, class KE = KeyEqual, std::enable_if_t<is_transparent_v<H, KE>, bool> = true>
+    auto extract(K&& key) -> std::optional<value_type> {
+        auto tmp = std::optional<value_type>{};
+        do_erase_key(std::forward<K>(key), [&tmp](value_type&& val) -> void {
+            tmp = std::move(val);
+        });
+        return tmp;
+    }
+
+    void swap(table& other) noexcept(noexcept(std::is_nothrow_swappable_v<value_container_type> &&
+                                              std::is_nothrow_swappable_v<Hash> && std::is_nothrow_swappable_v<KeyEqual>)) {
+        using std::swap;
+        swap(other, *this);
+    }
+
+    // lookup /////////////////////////////////////////////////////////////////
+
+    template <typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto at(key_type const& key) -> Q& {
+        return do_at(key);
+    }
+
+    template <typename K,
+              typename Q = T,
+              typename H = Hash,
+              typename KE = KeyEqual,
+              std::enable_if_t<is_map_v<Q> && is_transparent_v<H, KE>, bool> = true>
+    auto at(K const& key) -> Q& {
+        return do_at(key);
+    }
+
+    template <typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto at(key_type const& key) const -> Q const& {
+        return do_at(key);
+    }
+
+    template <typename K,
+              typename Q = T,
+              typename H = Hash,
+              typename KE = KeyEqual,
+              std::enable_if_t<is_map_v<Q> && is_transparent_v<H, KE>, bool> = true>
+    auto at(K const& key) const -> Q const& {
+        return do_at(key);
+    }
+
+    template <typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto operator[](Key const& key) -> Q& {
+        return try_emplace(key).first->second;
+    }
+
+    template <typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto operator[](Key&& key) -> Q& {
+        return try_emplace(std::move(key)).first->second;
+    }
+
+    template <typename K,
+              typename Q = T,
+              typename H = Hash,
+              typename KE = KeyEqual,
+              std::enable_if_t<is_map_v<Q> && is_transparent_v<H, KE>, bool> = true>
+    auto operator[](K&& key) -> Q& {
+        return try_emplace(std::forward<K>(key)).first->second;
+    }
+
+    auto count(Key const& key) const -> std::size_t {
+        return find(key) == end() ? 0 : 1;
+    }
+
+    template <class K, class H = Hash, class KE = KeyEqual, std::enable_if_t<is_transparent_v<H, KE>, bool> = true>
+    auto count(K const& key) const -> std::size_t {
+        return find(key) == end() ? 0 : 1;
+    }
+
+    auto find(Key const& key) -> iterator {
+        return do_find(key);
+    }
+
+    auto find(Key const& key) const -> const_iterator {
+        return do_find(key);
+    }
+
+    template <class K, class H = Hash, class KE = KeyEqual, std::enable_if_t<is_transparent_v<H, KE>, bool> = true>
+    auto find(K const& key) -> iterator {
+        return do_find(key);
+    }
+
+    template <class K, class H = Hash, class KE = KeyEqual, std::enable_if_t<is_transparent_v<H, KE>, bool> = true>
+    auto find(K const& key) const -> const_iterator {
+        return do_find(key);
+    }
+
+    auto contains(Key const& key) const -> bool {
+        return find(key) != end();
+    }
+
+    template <class K, class H = Hash, class KE = KeyEqual, std::enable_if_t<is_transparent_v<H, KE>, bool> = true>
+    auto contains(K const& key) const -> bool {
+        return find(key) != end();
+    }
+
+    auto equal_range(Key const& key) -> std::pair<iterator, iterator> {
+        auto it = do_find(key);
+        return {it, it == end() ? end() : it + 1};
+    }
+
+    auto equal_range(const Key& key) const -> std::pair<const_iterator, const_iterator> {
+        auto it = do_find(key);
+        return {it, it == end() ? end() : it + 1};
+    }
+
+    template <class K, class H = Hash, class KE = KeyEqual, std::enable_if_t<is_transparent_v<H, KE>, bool> = true>
+    auto equal_range(K const& key) -> std::pair<iterator, iterator> {
+        auto it = do_find(key);
+        return {it, it == end() ? end() : it + 1};
+    }
+
+    template <class K, class H = Hash, class KE = KeyEqual, std::enable_if_t<is_transparent_v<H, KE>, bool> = true>
+    auto equal_range(K const& key) const -> std::pair<const_iterator, const_iterator> {
+        auto it = do_find(key);
+        return {it, it == end() ? end() : it + 1};
+    }
+
+    // bucket interface ///////////////////////////////////////////////////////
+
+    auto bucket_count() const noexcept -> std::size_t { // NOLINT(modernize-use-nodiscard)
+        return m_buckets.size();
+    }
+
+    static constexpr auto max_bucket_count() noexcept -> std::size_t { // NOLINT(modernize-use-nodiscard)
+        return max_size();
+    }
+
+    // hash policy ////////////////////////////////////////////////////////////
+
+    [[nodiscard]] auto load_factor() const -> float {
+        return bucket_count() ? static_cast<float>(size()) / static_cast<float>(bucket_count()) : 0.0F;
+    }
+
+    [[nodiscard]] auto max_load_factor() const -> float {
+        return m_max_load_factor;
+    }
+
+    void max_load_factor(float ml) {
+        m_max_load_factor = ml;
+        if (bucket_count() != max_bucket_count()) {
+            m_max_bucket_capacity = static_cast<value_idx_type>(static_cast<float>(bucket_count()) * max_load_factor());
+        }
+    }
+
+    void rehash(std::size_t count) {
+        count = (std::min)(count, max_size());
+        auto shifts = calc_shifts_for_size((std::max)(count, size()));
+        if (shifts != m_shifts) {
+            m_shifts = shifts;
+            deallocate_buckets();
+            m_values.shrink_to_fit();
+            allocate_buckets_from_shift();
+            clear_and_fill_buckets_from_values();
+        }
+    }
+
+    void reserve(std::size_t capa) {
+        capa = (std::min)(capa, max_size());
+        if constexpr (has_reserve<value_container_type>) {
+            // std::deque doesn't have reserve(). Make sure we only call when available
+            m_values.reserve(capa);
+        }
+        auto shifts = calc_shifts_for_size((std::max)(capa, size()));
+        if (0 == bucket_count() || shifts < m_shifts) {
+            m_shifts = shifts;
+            deallocate_buckets();
+            allocate_buckets_from_shift();
+            clear_and_fill_buckets_from_values();
+        }
+    }
+
+    // observers //////////////////////////////////////////////////////////////
+
+    auto hash_function() const -> hasher {
+        return m_hash;
+    }
+
+    auto key_eq() const -> key_equal {
+        return m_equal;
+    }
+
+    // nonstandard API: expose the underlying values container
+    [[nodiscard]] auto values() const noexcept -> value_container_type const& {
+        return m_values;
+    }
+
+    // non-member functions ///////////////////////////////////////////////////
+
+    friend auto operator==(table const& a, table const& b) -> bool {
+        if (&a == &b) {
+            return true;
+        }
+        if (a.size() != b.size()) {
+            return false;
+        }
+        for (auto const& b_entry : b) {
+            auto it = a.find(get_key(b_entry));
+            if constexpr (is_map_v<T>) {
+                // map: check that key is here, then also check that value is the same
+                if (a.end() == it || !(b_entry.second == it->second)) {
+                    return false;
+                }
+            } else {
+                // set: only check that the key is here
+                if (a.end() == it) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    friend auto operator!=(table const& a, table const& b) -> bool {
+        return !(a == b);
+    }
+};
+
+} // namespace detail
+
+template <class Key,
+          class T,
+          class Hash = hash<Key>,
+          class KeyEqual = std::equal_to<Key>,
+          class AllocatorOrContainer = std::allocator<std::pair<Key, T>>,
+          class Bucket = bucket_type::standard,
+          class BucketContainer = detail::default_container_t>
+using map = detail::table<Key, T, Hash, KeyEqual, AllocatorOrContainer, Bucket, BucketContainer, false>;
+
+template <class Key,
+          class T,
+          class Hash = hash<Key>,
+          class KeyEqual = std::equal_to<Key>,
+          class AllocatorOrContainer = std::allocator<std::pair<Key, T>>,
+          class Bucket = bucket_type::standard,
+          class BucketContainer = detail::default_container_t>
+using segmented_map = detail::table<Key, T, Hash, KeyEqual, AllocatorOrContainer, Bucket, BucketContainer, true>;
+
+template <class Key,
+          class Hash = hash<Key>,
+          class KeyEqual = std::equal_to<Key>,
+          class AllocatorOrContainer = std::allocator<Key>,
+          class Bucket = bucket_type::standard,
+          class BucketContainer = detail::default_container_t>
+using set = detail::table<Key, void, Hash, KeyEqual, AllocatorOrContainer, Bucket, BucketContainer, false>;
+
+template <class Key,
+          class Hash = hash<Key>,
+          class KeyEqual = std::equal_to<Key>,
+          class AllocatorOrContainer = std::allocator<Key>,
+          class Bucket = bucket_type::standard,
+          class BucketContainer = detail::default_container_t>
+using segmented_set = detail::table<Key, void, Hash, KeyEqual, AllocatorOrContainer, Bucket, BucketContainer, true>;
+
+#    if defined(ANKERL_UNORDERED_DENSE_PMR)
+
+namespace pmr {
+
+template <class Key,
+          class T,
+          class Hash = hash<Key>,
+          class KeyEqual = std::equal_to<Key>,
+          class Bucket = bucket_type::standard>
+using map = detail::table<Key,
+                          T,
+                          Hash,
+                          KeyEqual,
+                          ANKERL_UNORDERED_DENSE_PMR::polymorphic_allocator<std::pair<Key, T>>,
+                          Bucket,
+                          detail::default_container_t,
+                          false>;
+
+template <class Key,
+          class T,
+          class Hash = hash<Key>,
+          class KeyEqual = std::equal_to<Key>,
+          class Bucket = bucket_type::standard>
+using segmented_map = detail::table<Key,
+                                    T,
+                                    Hash,
+                                    KeyEqual,
+                                    ANKERL_UNORDERED_DENSE_PMR::polymorphic_allocator<std::pair<Key, T>>,
+                                    Bucket,
+                                    detail::default_container_t,
+                                    true>;
+
+template <class Key, class Hash = hash<Key>, class KeyEqual = std::equal_to<Key>, class Bucket = bucket_type::standard>
+using set = detail::table<Key,
+                          void,
+                          Hash,
+                          KeyEqual,
+                          ANKERL_UNORDERED_DENSE_PMR::polymorphic_allocator<Key>,
+                          Bucket,
+                          detail::default_container_t,
+                          false>;
+
+template <class Key, class Hash = hash<Key>, class KeyEqual = std::equal_to<Key>, class Bucket = bucket_type::standard>
+using segmented_set = detail::table<Key,
+                                    void,
+                                    Hash,
+                                    KeyEqual,
+                                    ANKERL_UNORDERED_DENSE_PMR::polymorphic_allocator<Key>,
+                                    Bucket,
+                                    detail::default_container_t,
+                                    true>;
+
+} // namespace pmr
+
+#    endif
+
+// deduction guides ///////////////////////////////////////////////////////////
+
+// deduction guides for alias templates are only possible since C++20
+// see https://en.cppreference.com/w/cpp/language/class_template_argument_deduction
+
+} // namespace ANKERL_UNORDERED_DENSE_NAMESPACE
+} // namespace ankerl::unordered_dense
+
+// std extensions /////////////////////////////////////////////////////////////
+
+namespace std { // NOLINT(cert-dcl58-cpp)
+
+template <class Key,
+          class T,
+          class Hash,
+          class KeyEqual,
+          class AllocatorOrContainer,
+          class Bucket,
+          class Pred,
+          class BucketContainer,
+          bool IsSegmented>
+// NOLINTNEXTLINE(cert-dcl58-cpp)
+auto erase_if(
+    ankerl::unordered_dense::detail::table<Key, T, Hash, KeyEqual, AllocatorOrContainer, Bucket, BucketContainer, IsSegmented>&
+        map,
+    Pred pred) -> std::size_t {
+    using map_t = ankerl::unordered_dense::detail::
+        table<Key, T, Hash, KeyEqual, AllocatorOrContainer, Bucket, BucketContainer, IsSegmented>;
+
+    // going back to front because erase() invalidates the end iterator
+    auto const old_size = map.size();
+    auto idx = old_size;
+    while (idx) {
+        --idx;
+        auto it = map.begin() + static_cast<typename map_t::difference_type>(idx);
+        if (pred(*it)) {
+            map.erase(it);
+        }
+    }
+
+    return old_size - map.size();
+}
+
+} // namespace std
+
+#endif
+#endif


### PR DESCRIPTION
## Summary

Add high-performance `dense_map` hash map with type-specialized storage:

- **Flat storage** (Robin Hood + contiguous values) for small trivially copyable keys (≤8 bytes)
- **Indirect storage** (Swiss Table SIMD + contiguous values) for string/complex keys

### Performance vs competitors (100K int64 keys)

| Operation | dense_map | vs ankerl | vs tsl::robin |
|-----------|-----------|-----------|---------------|
| `operator[]` | 427μs | **3.0x faster** | **2.7x faster** |
| `try_emplace` | 401μs | **1.8x faster** | **1.4x faster** |
| `find (100% hit)` | 293μs | ~same | 0.7x |
| `iterate` | 26μs | ~same | **7.3x faster** |

### Storage policy selection

```cpp
// Auto-selected based on key type (recommended)
dense_map<int, Value> map1;      // uses flat storage
dense_map<string, Value> map2;   // uses indirect storage

// Manual selection
dense_map<K, V, Hash, Eq, Alloc, inline_storage_policy> map3;  // like tsl
dense_map<K, V, Hash, Eq, Alloc, flat_storage_policy> map4;    // like ankerl
```

### Key optimizations

- Hash high bits for bucket index, low 8 bits for fingerprint (no collision)
- Bucket layout `[distance:24][fingerprint:8]` for single integer comparison
- Robin Hood probing with backward shift deletion
- SIMD h2 matching for string keys (reduces expensive comparisons)

## Test plan

- [x] All 25 dense_map unit tests pass
- [x] Benchmarks vs ankerl::unordered_dense, tsl::robin_map
- [ ] Test on different machine for benchmark validation

🤖 Generated with [Claude Code](https://claude.ai/code)