### PR TITLE
perf: SIMD lower_bound optimizations with direct vector loads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,9 @@ endif()
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG -march=native")
 set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -DDEBUG")
 
-# Use libc++ with Clang for std::flat_map support
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+# Use libc++ with Clang for std::flat_map support (requires libc++ installed)
+option(USE_LIBCXX_DEFAULT "Use libc++ by default with Clang" ON)
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND USE_LIBCXX_DEFAULT)
     add_compile_options(-stdlib=libc++)
     add_link_options(-stdlib=libc++)
 endif()

--- a/benchmark_result.md
+++ b/benchmark_result.md
@@ -148,6 +148,56 @@
 
 ---
 
+## btree_set vs absl::btree_set
+
+### Test Environment (ARM64)
+
+- **Platform**: AWS Graviton (ARM64)
+- **Compiler**: GCC with `-O3 -DNDEBUG`
+- **C++ Standard**: C++20
+
+### Summary
+
+| Operation | Speedup vs absl |
+|-----------|-----------------|
+| **Sorted Insert** | 10-12x faster |
+| **Random Insert** | 2-3x faster |
+| **Find** | 1.0-1.8x faster |
+| **Lower_bound** | 0.9-1.7x faster |
+| **Iterate** | 5-7x faster |
+| **Erase** | 1.3-2.6x faster |
+
+### Detailed Results (ns/op, lower is better)
+
+#### 10K elements
+
+| Container | SortIns | RandIns | Find | LowerBnd | Iterate | Erase |
+|-----------|---------|---------|------|----------|---------|-------|
+| stdb::btree_set | 12 | 80 | 54 | 55 | 2 | 80 |
+| absl::btree_set | 149 | 228 | 97 | 92 | 15 | 212 |
+
+#### 100K elements
+
+| Container | SortIns | RandIns | Find | LowerBnd | Iterate | Erase |
+|-----------|---------|---------|------|----------|---------|-------|
+| stdb::btree_set | 14 | 104 | 80 | 77 | 2 | 109 |
+| absl::btree_set | 158 | 253 | 120 | 113 | 15 | 238 |
+
+#### 1000K elements
+
+| Container | SortIns | RandIns | Find | LowerBnd | Iterate | Erase |
+|-----------|---------|---------|------|----------|---------|-------|
+| stdb::btree_set | 16 | 174 | 215 | 209 | 3 | 247 |
+| absl::btree_set | 179 | 334 | 196 | 188 | 17 | 322 |
+
+### btree_set Optimizations
+
+- **Direct SIMD vector loads**: For btree_set (stride=1), uses `vld1q_*` (NEON), `_mm_loadu_si128` (SSE2), `_mm256_loadu_si256` (AVX2) instead of element-by-element construction
+- **[[no_unique_address]]**: Empty value type uses zero storage, making key access contiguous
+- **~33% lower_bound improvement**: Direct load optimization specifically benefits btree_set
+
+---
+
 ## Notes
 
 - Benchmarks were run with CPU frequency scaling enabled (powersave governor), which may introduce some variance

--- a/benchmark_result.md
+++ b/benchmark_result.md
@@ -198,6 +198,47 @@
 
 ---
 
+## NEON vld2q Stride==2 Optimization (btree_map)
+
+For `btree_map<K, V>` where `sizeof(K) == sizeof(V)`, keys are stored at stride==2 (interleaved with values). The `vld2q` instruction efficiently loads interleaved data, extracting keys in a single instruction.
+
+### Performance Improvements
+
+| Key Type | Elements | Before | After | Improvement |
+|----------|----------|--------|-------|-------------|
+| int32_t | 10K | 72 ns | 64 ns | **+11%** |
+| int32_t | 100K | 113 ns | 100 ns | **+12%** |
+| int32_t | 1000K | 274 ns | 263 ns | **+4%** |
+| int16_t | 10K | 66 ns | 47 ns | **+29%** |
+| int16_t | 100K | 88 ns | 68 ns | **+23%** |
+| int8_t | 100 | 41 ns | 18 ns | **+56%** |
+| int8_t | 200 | 45 ns | 28 ns | **+38%** |
+
+### Implementation
+
+```cpp
+// Before: scalar element-by-element construction
+key_vec = int32x4_t{keys[i*2], keys[(i+1)*2], keys[(i+2)*2], keys[(i+3)*2]};
+
+// After: single vld2q instruction for stride==2
+if constexpr (stride == 2) {
+    int32x4x2_t interleaved = vld2q_s32(&keys[i * 2]);
+    key_vec = interleaved.val[0];  // Keys at even indices
+}
+```
+
+### Applicable Types
+
+| Type | vld2 Instruction | Elements/Vector |
+|------|------------------|-----------------|
+| int8_t/uint8_t | vld2q_s8/u8 | 16 |
+| int16_t/uint16_t | vld2q_s16/u16 | 8 |
+| int32_t/uint32_t | vld2q_s32/u32 | 4 |
+
+Note: int64_t/uint64_t tested but showed no improvement (only 2 elements per vector).
+
+---
+
 ## Notes
 
 - Benchmarks were run with CPU frequency scaling enabled (powersave governor), which may introduce some variance

--- a/container/btree_map.hpp
+++ b/container/btree_map.hpp
@@ -1158,6 +1158,7 @@ class btree_map
     }
 
     // NEON lower_bound for int16_t keys (signed) - processes 8 keys at a time
+    // Optimized: use bitmask to find first match without inner loop
     template <typename T>
     static auto neon_lower_bound_s16(const T* slots, size_type count, int16_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(int16_t))
@@ -1172,13 +1173,15 @@ class btree_map
             int16x8_t key_vec = {keys[i * stride],       keys[(i + 1) * stride], keys[(i + 2) * stride],
                                  keys[(i + 3) * stride], keys[(i + 4) * stride], keys[(i + 5) * stride],
                                  keys[(i + 6) * stride], keys[(i + 7) * stride]};
-            uint16x8_t lt = vcltq_s16(key_vec, target_vec);
+            uint16x8_t ge = vcgeq_s16(key_vec, target_vec);  // >= comparison directly
 
-            // Use vminvq_u16 to detect if any lane is 0 (key >= target)
-            if (vminvq_u16(lt) == 0) {
-                for (size_type j = 0; j < 8; ++j) {
-                    if (keys[(i + j) * stride] >= target) return i + j;
-                }
+            // Narrow to 8-bit and extract as 64-bit value for bitmask
+            uint8x8_t narrow = vmovn_u16(ge);
+            uint64_t mask = vget_lane_u64(vreinterpret_u64_u8(narrow), 0);
+
+            if (mask != 0) {
+                // Find first set 8-bit lane
+                return i + static_cast<size_type>(__builtin_ctzll(mask) / 8);
             }
             i += 8;
         }
@@ -1190,6 +1193,7 @@ class btree_map
     }
 
     // NEON lower_bound for uint16_t keys (unsigned) - processes 8 keys at a time
+    // Optimized: use bitmask to find first match without inner loop
     template <typename T>
     static auto neon_lower_bound_u16(const T* slots, size_type count, uint16_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(uint16_t))
@@ -1204,13 +1208,15 @@ class btree_map
             uint16x8_t key_vec = {keys[i * stride],       keys[(i + 1) * stride], keys[(i + 2) * stride],
                                   keys[(i + 3) * stride], keys[(i + 4) * stride], keys[(i + 5) * stride],
                                   keys[(i + 6) * stride], keys[(i + 7) * stride]};
-            uint16x8_t lt = vcltq_u16(key_vec, target_vec);
+            uint16x8_t ge = vcgeq_u16(key_vec, target_vec);  // >= comparison directly
 
-            // Use vminvq_u16 to detect if any lane is 0 (key >= target)
-            if (vminvq_u16(lt) == 0) {
-                for (size_type j = 0; j < 8; ++j) {
-                    if (keys[(i + j) * stride] >= target) return i + j;
-                }
+            // Narrow to 8-bit and extract as 64-bit value for bitmask
+            uint8x8_t narrow = vmovn_u16(ge);
+            uint64_t mask = vget_lane_u64(vreinterpret_u64_u8(narrow), 0);
+
+            if (mask != 0) {
+                // Find first set 8-bit lane
+                return i + static_cast<size_type>(__builtin_ctzll(mask) / 8);
             }
             i += 8;
         }
@@ -1222,6 +1228,7 @@ class btree_map
     }
 
     // NEON lower_bound for int8_t keys (signed) - processes 16 keys at a time
+    // Optimized: use bitmask to find first match without inner loop
     template <typename T>
     static auto neon_lower_bound_s8(const T* slots, size_type count, int8_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(int8_t))
@@ -1238,13 +1245,16 @@ class btree_map
               keys[(i + 4) * stride],  keys[(i + 5) * stride],  keys[(i + 6) * stride],  keys[(i + 7) * stride],
               keys[(i + 8) * stride],  keys[(i + 9) * stride],  keys[(i + 10) * stride], keys[(i + 11) * stride],
               keys[(i + 12) * stride], keys[(i + 13) * stride], keys[(i + 14) * stride], keys[(i + 15) * stride]};
-            uint8x16_t lt = vcltq_s8(key_vec, target_vec);
+            uint8x16_t ge = vcgeq_s8(key_vec, target_vec);  // >= comparison directly
 
-            // Use vminvq_u8 to detect if any lane is 0 (key >= target)
-            if (vminvq_u8(lt) == 0) {
-                for (size_type j = 0; j < 16; ++j) {
-                    if (keys[(i + j) * stride] >= target) return i + j;
-                }
+            // Extract low and high 64-bit halves as bitmask
+            uint64_t mask_lo = vgetq_lane_u64(vreinterpretq_u64_u8(ge), 0);
+            if (mask_lo != 0) {
+                return i + static_cast<size_type>(__builtin_ctzll(mask_lo) / 8);
+            }
+            uint64_t mask_hi = vgetq_lane_u64(vreinterpretq_u64_u8(ge), 1);
+            if (mask_hi != 0) {
+                return i + 8 + static_cast<size_type>(__builtin_ctzll(mask_hi) / 8);
             }
             i += 16;
         }
@@ -1256,6 +1266,7 @@ class btree_map
     }
 
     // NEON lower_bound for uint8_t keys (unsigned) - processes 16 keys at a time
+    // Optimized: use bitmask to find first match without inner loop
     template <typename T>
     static auto neon_lower_bound_u8(const T* slots, size_type count, uint8_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(uint8_t))
@@ -1272,13 +1283,16 @@ class btree_map
               keys[(i + 4) * stride],  keys[(i + 5) * stride],  keys[(i + 6) * stride],  keys[(i + 7) * stride],
               keys[(i + 8) * stride],  keys[(i + 9) * stride],  keys[(i + 10) * stride], keys[(i + 11) * stride],
               keys[(i + 12) * stride], keys[(i + 13) * stride], keys[(i + 14) * stride], keys[(i + 15) * stride]};
-            uint8x16_t lt = vcltq_u8(key_vec, target_vec);
+            uint8x16_t ge = vcgeq_u8(key_vec, target_vec);  // >= comparison directly
 
-            // Use vminvq_u8 to detect if any lane is 0 (key >= target)
-            if (vminvq_u8(lt) == 0) {
-                for (size_type j = 0; j < 16; ++j) {
-                    if (keys[(i + j) * stride] >= target) return i + j;
-                }
+            // Extract low and high 64-bit halves as bitmask
+            uint64_t mask_lo = vgetq_lane_u64(vreinterpretq_u64_u8(ge), 0);
+            if (mask_lo != 0) {
+                return i + static_cast<size_type>(__builtin_ctzll(mask_lo) / 8);
+            }
+            uint64_t mask_hi = vgetq_lane_u64(vreinterpretq_u64_u8(ge), 1);
+            if (mask_hi != 0) {
+                return i + 8 + static_cast<size_type>(__builtin_ctzll(mask_hi) / 8);
             }
             i += 16;
         }
@@ -1290,6 +1304,7 @@ class btree_map
     }
 
     // NEON lower_bound for float keys - processes 4 keys at a time
+    // Optimized: use bitmask to find first match without inner loop
     template <typename T>
     static auto neon_lower_bound_float(const T* slots, size_type count, float target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(float))
@@ -1303,13 +1318,15 @@ class btree_map
         while (i + 4 <= count) {
             float32x4_t key_vec = {keys[i * stride], keys[(i + 1) * stride], keys[(i + 2) * stride],
                                    keys[(i + 3) * stride]};
-            uint32x4_t lt = vcltq_f32(key_vec, target_vec);
+            uint32x4_t ge = vcgeq_f32(key_vec, target_vec);  // >= comparison directly
 
-            // Use vminvq_u32 to detect if any lane is 0 (key >= target)
-            if (vminvq_u32(lt) == 0) {
-                for (size_type j = 0; j < 4; ++j) {
-                    if (keys[(i + j) * stride] >= target) return i + j;
-                }
+            // Narrow to 16-bit and extract as 64-bit value for bitmask
+            uint16x4_t narrow = vmovn_u32(ge);
+            uint64_t mask = vget_lane_u64(vreinterpret_u64_u16(narrow), 0);
+
+            if (mask != 0) {
+                // Find first set 16-bit lane
+                return i + static_cast<size_type>(__builtin_ctzll(mask) / 16);
             }
             i += 4;
         }
@@ -1321,6 +1338,7 @@ class btree_map
     }
 
     // NEON lower_bound for double keys - processes 2 keys at a time
+    // Optimized: use bitmask to find first match without inner loop
     template <typename T>
     static auto neon_lower_bound_double(const T* slots, size_type count, double target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(double))
@@ -1333,13 +1351,15 @@ class btree_map
 
         while (i + 2 <= count) {
             float64x2_t key_vec = {keys[i * stride], keys[(i + 1) * stride]};
-            uint64x2_t lt = vcltq_f64(key_vec, target_vec);
+            uint64x2_t ge = vcgeq_f64(key_vec, target_vec);  // >= comparison directly
 
-            // Check if any key >= target (any lane is 0)
-            // AND lanes: result == 0 means at least one lane was 0
-            if ((vgetq_lane_u64(lt, 0) & vgetq_lane_u64(lt, 1)) == 0) {
-                if (keys[i * stride] >= target) return i;
-                if (keys[(i + 1) * stride] >= target) return i + 1;
+            // Narrow to 32-bit and extract for bitmask
+            uint32x2_t narrow = vmovn_u64(ge);
+            uint64_t mask = vget_lane_u64(vreinterpret_u64_u32(narrow), 0);
+
+            if (mask != 0) {
+                // Find first set 32-bit lane
+                return i + static_cast<size_type>(__builtin_ctzll(mask) / 32);
             }
             i += 2;
         }

--- a/container/btree_map.hpp
+++ b/container/btree_map.hpp
@@ -1043,7 +1043,8 @@ class btree_map
                                  keys[(i + 3) * stride]};
             uint32x4_t lt = vcltq_s32(key_vec, target_vec);
 
-            if (vmaxvq_u32(lt) != 0xFFFFFFFF) {
+            // Use vminvq_u32 to detect if any lane is 0 (key >= target)
+            if (vminvq_u32(lt) == 0) {
                 for (size_type j = 0; j < 4; ++j) {
                     if (keys[(i + j) * stride] >= target) return i + j;
                 }
@@ -1073,7 +1074,8 @@ class btree_map
                                   keys[(i + 3) * stride]};
             uint32x4_t lt = vcltq_u32(key_vec, target_vec);
 
-            if (vmaxvq_u32(lt) != 0xFFFFFFFF) {
+            // Use vminvq_u32 to detect if any lane is 0 (key >= target)
+            if (vminvq_u32(lt) == 0) {
                 for (size_type j = 0; j < 4; ++j) {
                     if (keys[(i + j) * stride] >= target) return i + j;
                 }
@@ -1102,7 +1104,9 @@ class btree_map
             int64x2_t key_vec = {keys[i * stride], keys[(i + 1) * stride]};
             uint64x2_t lt = vcltq_s64(key_vec, target_vec);
 
-            if (vmaxvq_u64(lt) != 0xFFFFFFFFFFFFFFFFULL) {
+            // Check if any key >= target (any lane is 0)
+            // AND lanes: result == 0 means at least one lane was 0
+            if ((vgetq_lane_u64(lt, 0) & vgetq_lane_u64(lt, 1)) == 0) {
                 if (keys[i * stride] >= target) return i;
                 if (keys[(i + 1) * stride] >= target) return i + 1;
             }
@@ -1128,7 +1132,9 @@ class btree_map
             uint64x2_t key_vec = {keys[i * stride], keys[(i + 1) * stride]};
             uint64x2_t lt = vcltq_u64(key_vec, target_vec);
 
-            if (vmaxvq_u64(lt) != 0xFFFFFFFFFFFFFFFFULL) {
+            // Check if any key >= target (any lane is 0)
+            // AND lanes: result == 0 means at least one lane was 0
+            if ((vgetq_lane_u64(lt, 0) & vgetq_lane_u64(lt, 1)) == 0) {
                 if (keys[i * stride] >= target) return i;
                 if (keys[(i + 1) * stride] >= target) return i + 1;
             }
@@ -1156,7 +1162,8 @@ class btree_map
                                  keys[(i + 6) * stride], keys[(i + 7) * stride]};
             uint16x8_t lt = vcltq_s16(key_vec, target_vec);
 
-            if (vmaxvq_u16(lt) != 0xFFFF) {
+            // Use vminvq_u16 to detect if any lane is 0 (key >= target)
+            if (vminvq_u16(lt) == 0) {
                 for (size_type j = 0; j < 8; ++j) {
                     if (keys[(i + j) * stride] >= target) return i + j;
                 }
@@ -1187,7 +1194,8 @@ class btree_map
                                   keys[(i + 6) * stride], keys[(i + 7) * stride]};
             uint16x8_t lt = vcltq_u16(key_vec, target_vec);
 
-            if (vmaxvq_u16(lt) != 0xFFFF) {
+            // Use vminvq_u16 to detect if any lane is 0 (key >= target)
+            if (vminvq_u16(lt) == 0) {
                 for (size_type j = 0; j < 8; ++j) {
                     if (keys[(i + j) * stride] >= target) return i + j;
                 }
@@ -1220,7 +1228,8 @@ class btree_map
               keys[(i + 12) * stride], keys[(i + 13) * stride], keys[(i + 14) * stride], keys[(i + 15) * stride]};
             uint8x16_t lt = vcltq_s8(key_vec, target_vec);
 
-            if (vmaxvq_u8(lt) != 0xFF) {
+            // Use vminvq_u8 to detect if any lane is 0 (key >= target)
+            if (vminvq_u8(lt) == 0) {
                 for (size_type j = 0; j < 16; ++j) {
                     if (keys[(i + j) * stride] >= target) return i + j;
                 }
@@ -1253,7 +1262,8 @@ class btree_map
               keys[(i + 12) * stride], keys[(i + 13) * stride], keys[(i + 14) * stride], keys[(i + 15) * stride]};
             uint8x16_t lt = vcltq_u8(key_vec, target_vec);
 
-            if (vmaxvq_u8(lt) != 0xFF) {
+            // Use vminvq_u8 to detect if any lane is 0 (key >= target)
+            if (vminvq_u8(lt) == 0) {
                 for (size_type j = 0; j < 16; ++j) {
                     if (keys[(i + j) * stride] >= target) return i + j;
                 }
@@ -1283,7 +1293,8 @@ class btree_map
                                    keys[(i + 3) * stride]};
             uint32x4_t lt = vcltq_f32(key_vec, target_vec);
 
-            if (vmaxvq_u32(lt) != 0xFFFFFFFF) {
+            // Use vminvq_u32 to detect if any lane is 0 (key >= target)
+            if (vminvq_u32(lt) == 0) {
                 for (size_type j = 0; j < 4; ++j) {
                     if (keys[(i + j) * stride] >= target) return i + j;
                 }
@@ -1312,7 +1323,9 @@ class btree_map
             float64x2_t key_vec = {keys[i * stride], keys[(i + 1) * stride]};
             uint64x2_t lt = vcltq_f64(key_vec, target_vec);
 
-            if (vmaxvq_u64(lt) != 0xFFFFFFFFFFFFFFFFULL) {
+            // Check if any key >= target (any lane is 0)
+            // AND lanes: result == 0 means at least one lane was 0
+            if ((vgetq_lane_u64(lt, 0) & vgetq_lane_u64(lt, 1)) == 0) {
                 if (keys[i * stride] >= target) return i;
                 if (keys[(i + 1) * stride] >= target) return i + 1;
             }

--- a/container/btree_map.hpp
+++ b/container/btree_map.hpp
@@ -420,6 +420,7 @@ class btree_map
     // SIMD search helpers
 #ifdef BTREE_HAS_SSE2
     // SSE2 lower_bound for int32_t keys (signed)
+    // Optimized: use direct _mm_loadu_si128 load for contiguous keys
     template <typename T>
     static auto simd_lower_bound_s32(const T* slots, size_type count, int32_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(int32_t))
@@ -431,8 +432,13 @@ class btree_map
         size_type i = 0;
 
         while (i + 4 <= count) {
-            __m128i key_vec =
-              _mm_set_epi32(keys[(i + 3) * stride], keys[(i + 2) * stride], keys[(i + 1) * stride], keys[i * stride]);
+            __m128i key_vec;
+            if constexpr (stride == 1) {
+                key_vec = _mm_loadu_si128(reinterpret_cast<const __m128i*>(&keys[i]));
+            } else {
+                key_vec = _mm_set_epi32(keys[(i + 3) * stride], keys[(i + 2) * stride],
+                                        keys[(i + 1) * stride], keys[i * stride]);
+            }
             __m128i lt = _mm_cmplt_epi32(key_vec, target_vec);
             int mask = _mm_movemask_ps(_mm_castsi128_ps(lt));
 
@@ -449,6 +455,7 @@ class btree_map
     }
 
     // SSE2 lower_bound for uint32_t keys (unsigned)
+    // Optimized: use direct _mm_loadu_si128 load for contiguous keys
     template <typename T>
     static auto simd_lower_bound_u32(const T* slots, size_type count, uint32_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(uint32_t))
@@ -462,9 +469,15 @@ class btree_map
         size_type i = 0;
 
         while (i + 4 <= count) {
-            __m128i key_vec =
-              _mm_set_epi32(static_cast<int32_t>(keys[(i + 3) * stride]), static_cast<int32_t>(keys[(i + 2) * stride]),
-                            static_cast<int32_t>(keys[(i + 1) * stride]), static_cast<int32_t>(keys[i * stride]));
+            __m128i key_vec;
+            if constexpr (stride == 1) {
+                key_vec = _mm_loadu_si128(reinterpret_cast<const __m128i*>(&keys[i]));
+            } else {
+                key_vec = _mm_set_epi32(static_cast<int32_t>(keys[(i + 3) * stride]),
+                                        static_cast<int32_t>(keys[(i + 2) * stride]),
+                                        static_cast<int32_t>(keys[(i + 1) * stride]),
+                                        static_cast<int32_t>(keys[i * stride]));
+            }
             key_vec = _mm_xor_si128(key_vec, sign_bit);
             __m128i lt = _mm_cmplt_epi32(key_vec, target_vec);
             int mask = _mm_movemask_ps(_mm_castsi128_ps(lt));
@@ -482,6 +495,7 @@ class btree_map
     }
 
     // SSE2 lower_bound for int16_t keys (signed) - processes 8 keys at a time
+    // Optimized: use direct _mm_loadu_si128 load for contiguous keys
     template <typename T>
     static auto simd_lower_bound_s16(const T* slots, size_type count, int16_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(int16_t))
@@ -493,13 +507,17 @@ class btree_map
         size_type i = 0;
 
         while (i + 8 <= count) {
-            __m128i key_vec = _mm_set_epi16(keys[(i + 7) * stride], keys[(i + 6) * stride], keys[(i + 5) * stride],
-                                            keys[(i + 4) * stride], keys[(i + 3) * stride], keys[(i + 2) * stride],
-                                            keys[(i + 1) * stride], keys[i * stride]);
+            __m128i key_vec;
+            if constexpr (stride == 1) {
+                key_vec = _mm_loadu_si128(reinterpret_cast<const __m128i*>(&keys[i]));
+            } else {
+                key_vec = _mm_set_epi16(keys[(i + 7) * stride], keys[(i + 6) * stride], keys[(i + 5) * stride],
+                                        keys[(i + 4) * stride], keys[(i + 3) * stride], keys[(i + 2) * stride],
+                                        keys[(i + 1) * stride], keys[i * stride]);
+            }
             __m128i lt = _mm_cmplt_epi16(key_vec, target_vec);
             int mask = _mm_movemask_epi8(lt);
 
-            // Each 16-bit element produces 2 bits in mask (both 1 if <, both 0 if >=)
             if (mask != 0xFFFF) {
                 return i + (__builtin_ctz(~mask) >> 1);
             }
@@ -513,6 +531,7 @@ class btree_map
     }
 
     // SSE2 lower_bound for uint16_t keys (unsigned) - processes 8 keys at a time
+    // Optimized: use direct _mm_loadu_si128 load for contiguous keys
     template <typename T>
     static auto simd_lower_bound_u16(const T* slots, size_type count, uint16_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(uint16_t))
@@ -526,11 +545,19 @@ class btree_map
         size_type i = 0;
 
         while (i + 8 <= count) {
-            __m128i key_vec =
-              _mm_set_epi16(static_cast<int16_t>(keys[(i + 7) * stride]), static_cast<int16_t>(keys[(i + 6) * stride]),
-                            static_cast<int16_t>(keys[(i + 5) * stride]), static_cast<int16_t>(keys[(i + 4) * stride]),
-                            static_cast<int16_t>(keys[(i + 3) * stride]), static_cast<int16_t>(keys[(i + 2) * stride]),
-                            static_cast<int16_t>(keys[(i + 1) * stride]), static_cast<int16_t>(keys[i * stride]));
+            __m128i key_vec;
+            if constexpr (stride == 1) {
+                key_vec = _mm_loadu_si128(reinterpret_cast<const __m128i*>(&keys[i]));
+            } else {
+                key_vec = _mm_set_epi16(static_cast<int16_t>(keys[(i + 7) * stride]),
+                                        static_cast<int16_t>(keys[(i + 6) * stride]),
+                                        static_cast<int16_t>(keys[(i + 5) * stride]),
+                                        static_cast<int16_t>(keys[(i + 4) * stride]),
+                                        static_cast<int16_t>(keys[(i + 3) * stride]),
+                                        static_cast<int16_t>(keys[(i + 2) * stride]),
+                                        static_cast<int16_t>(keys[(i + 1) * stride]),
+                                        static_cast<int16_t>(keys[i * stride]));
+            }
             key_vec = _mm_xor_si128(key_vec, sign_bit);
             __m128i lt = _mm_cmplt_epi16(key_vec, target_vec);
             int mask = _mm_movemask_epi8(lt);
@@ -548,6 +575,7 @@ class btree_map
     }
 
     // SSE2 lower_bound for int8_t keys (signed) - processes 16 keys at a time
+    // Optimized: use direct _mm_loadu_si128 load for contiguous keys
     template <typename T>
     static auto simd_lower_bound_s8(const T* slots, size_type count, int8_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(int8_t))
@@ -559,11 +587,16 @@ class btree_map
         size_type i = 0;
 
         while (i + 16 <= count) {
-            __m128i key_vec = _mm_set_epi8(
-              keys[(i + 15) * stride], keys[(i + 14) * stride], keys[(i + 13) * stride], keys[(i + 12) * stride],
-              keys[(i + 11) * stride], keys[(i + 10) * stride], keys[(i + 9) * stride], keys[(i + 8) * stride],
-              keys[(i + 7) * stride], keys[(i + 6) * stride], keys[(i + 5) * stride], keys[(i + 4) * stride],
-              keys[(i + 3) * stride], keys[(i + 2) * stride], keys[(i + 1) * stride], keys[i * stride]);
+            __m128i key_vec;
+            if constexpr (stride == 1) {
+                key_vec = _mm_loadu_si128(reinterpret_cast<const __m128i*>(&keys[i]));
+            } else {
+                key_vec = _mm_set_epi8(
+                  keys[(i + 15) * stride], keys[(i + 14) * stride], keys[(i + 13) * stride], keys[(i + 12) * stride],
+                  keys[(i + 11) * stride], keys[(i + 10) * stride], keys[(i + 9) * stride], keys[(i + 8) * stride],
+                  keys[(i + 7) * stride], keys[(i + 6) * stride], keys[(i + 5) * stride], keys[(i + 4) * stride],
+                  keys[(i + 3) * stride], keys[(i + 2) * stride], keys[(i + 1) * stride], keys[i * stride]);
+            }
             __m128i lt = _mm_cmplt_epi8(key_vec, target_vec);
             int mask = _mm_movemask_epi8(lt);
 
@@ -580,6 +613,7 @@ class btree_map
     }
 
     // SSE2 lower_bound for uint8_t keys (unsigned) - processes 16 keys at a time
+    // Optimized: use direct _mm_loadu_si128 load for contiguous keys
     template <typename T>
     static auto simd_lower_bound_u8(const T* slots, size_type count, uint8_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(uint8_t))
@@ -593,15 +627,20 @@ class btree_map
         size_type i = 0;
 
         while (i + 16 <= count) {
-            __m128i key_vec =
-              _mm_set_epi8(static_cast<int8_t>(keys[(i + 15) * stride]), static_cast<int8_t>(keys[(i + 14) * stride]),
-                           static_cast<int8_t>(keys[(i + 13) * stride]), static_cast<int8_t>(keys[(i + 12) * stride]),
-                           static_cast<int8_t>(keys[(i + 11) * stride]), static_cast<int8_t>(keys[(i + 10) * stride]),
-                           static_cast<int8_t>(keys[(i + 9) * stride]), static_cast<int8_t>(keys[(i + 8) * stride]),
-                           static_cast<int8_t>(keys[(i + 7) * stride]), static_cast<int8_t>(keys[(i + 6) * stride]),
-                           static_cast<int8_t>(keys[(i + 5) * stride]), static_cast<int8_t>(keys[(i + 4) * stride]),
-                           static_cast<int8_t>(keys[(i + 3) * stride]), static_cast<int8_t>(keys[(i + 2) * stride]),
-                           static_cast<int8_t>(keys[(i + 1) * stride]), static_cast<int8_t>(keys[i * stride]));
+            __m128i key_vec;
+            if constexpr (stride == 1) {
+                key_vec = _mm_loadu_si128(reinterpret_cast<const __m128i*>(&keys[i]));
+            } else {
+                key_vec = _mm_set_epi8(
+                  static_cast<int8_t>(keys[(i + 15) * stride]), static_cast<int8_t>(keys[(i + 14) * stride]),
+                  static_cast<int8_t>(keys[(i + 13) * stride]), static_cast<int8_t>(keys[(i + 12) * stride]),
+                  static_cast<int8_t>(keys[(i + 11) * stride]), static_cast<int8_t>(keys[(i + 10) * stride]),
+                  static_cast<int8_t>(keys[(i + 9) * stride]), static_cast<int8_t>(keys[(i + 8) * stride]),
+                  static_cast<int8_t>(keys[(i + 7) * stride]), static_cast<int8_t>(keys[(i + 6) * stride]),
+                  static_cast<int8_t>(keys[(i + 5) * stride]), static_cast<int8_t>(keys[(i + 4) * stride]),
+                  static_cast<int8_t>(keys[(i + 3) * stride]), static_cast<int8_t>(keys[(i + 2) * stride]),
+                  static_cast<int8_t>(keys[(i + 1) * stride]), static_cast<int8_t>(keys[i * stride]));
+            }
             key_vec = _mm_xor_si128(key_vec, sign_bit);
             __m128i lt = _mm_cmplt_epi8(key_vec, target_vec);
             int mask = _mm_movemask_epi8(lt);
@@ -619,6 +658,7 @@ class btree_map
     }
 
     // SSE lower_bound for float keys - processes 4 keys at a time
+    // Optimized: use direct _mm_loadu_ps load for contiguous keys
     template <typename T>
     static auto simd_lower_bound_float(const T* slots, size_type count, float target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(float))
@@ -630,8 +670,13 @@ class btree_map
         size_type i = 0;
 
         while (i + 4 <= count) {
-            __m128 key_vec =
-              _mm_set_ps(keys[(i + 3) * stride], keys[(i + 2) * stride], keys[(i + 1) * stride], keys[i * stride]);
+            __m128 key_vec;
+            if constexpr (stride == 1) {
+                key_vec = _mm_loadu_ps(&keys[i]);
+            } else {
+                key_vec = _mm_set_ps(keys[(i + 3) * stride], keys[(i + 2) * stride],
+                                     keys[(i + 1) * stride], keys[i * stride]);
+            }
             __m128 lt = _mm_cmplt_ps(key_vec, target_vec);
             int mask = _mm_movemask_ps(lt);
 
@@ -648,6 +693,7 @@ class btree_map
     }
 
     // SSE2 lower_bound for double keys - processes 2 keys at a time
+    // Optimized: use direct _mm_loadu_pd load for contiguous keys
     template <typename T>
     static auto simd_lower_bound_double(const T* slots, size_type count, double target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(double))
@@ -659,7 +705,12 @@ class btree_map
         size_type i = 0;
 
         while (i + 2 <= count) {
-            __m128d key_vec = _mm_set_pd(keys[(i + 1) * stride], keys[i * stride]);
+            __m128d key_vec;
+            if constexpr (stride == 1) {
+                key_vec = _mm_loadu_pd(&keys[i]);
+            } else {
+                key_vec = _mm_set_pd(keys[(i + 1) * stride], keys[i * stride]);
+            }
             __m128d lt = _mm_cmplt_pd(key_vec, target_vec);
             int mask = _mm_movemask_pd(lt);
 
@@ -676,6 +727,7 @@ class btree_map
 
 #ifdef BTREE_HAS_AVX2
     // AVX2 lower_bound for int64_t keys (signed)
+    // Optimized: use direct _mm256_loadu_si256 load for contiguous keys
     template <typename T>
     static auto simd_lower_bound_s64(const T* slots, size_type count, int64_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(int64_t))
@@ -687,8 +739,13 @@ class btree_map
         size_type i = 0;
 
         while (i + 4 <= count) {
-            __m256i key_vec = _mm256_set_epi64x(keys[(i + 3) * stride], keys[(i + 2) * stride], keys[(i + 1) * stride],
-                                                keys[i * stride]);
+            __m256i key_vec;
+            if constexpr (stride == 1) {
+                key_vec = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(&keys[i]));
+            } else {
+                key_vec = _mm256_set_epi64x(keys[(i + 3) * stride], keys[(i + 2) * stride],
+                                            keys[(i + 1) * stride], keys[i * stride]);
+            }
             __m256i lt = _mm256_cmpgt_epi64(target_vec, key_vec);
             int mask = _mm256_movemask_pd(_mm256_castsi256_pd(lt));
 
@@ -705,6 +762,7 @@ class btree_map
     }
 
     // AVX2 lower_bound for uint64_t keys (unsigned)
+    // Optimized: use direct _mm256_loadu_si256 load for contiguous keys
     template <typename T>
     static auto simd_lower_bound_u64(const T* slots, size_type count, uint64_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(uint64_t))
@@ -718,9 +776,15 @@ class btree_map
         size_type i = 0;
 
         while (i + 4 <= count) {
-            __m256i key_vec = _mm256_set_epi64x(
-              static_cast<int64_t>(keys[(i + 3) * stride]), static_cast<int64_t>(keys[(i + 2) * stride]),
-              static_cast<int64_t>(keys[(i + 1) * stride]), static_cast<int64_t>(keys[i * stride]));
+            __m256i key_vec;
+            if constexpr (stride == 1) {
+                key_vec = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(&keys[i]));
+            } else {
+                key_vec = _mm256_set_epi64x(static_cast<int64_t>(keys[(i + 3) * stride]),
+                                            static_cast<int64_t>(keys[(i + 2) * stride]),
+                                            static_cast<int64_t>(keys[(i + 1) * stride]),
+                                            static_cast<int64_t>(keys[i * stride]));
+            }
             key_vec = _mm256_xor_si256(key_vec, sign_bit);
             __m256i lt = _mm256_cmpgt_epi64(target_vec, key_vec);
             int mask = _mm256_movemask_pd(_mm256_castsi256_pd(lt));
@@ -738,6 +802,7 @@ class btree_map
     }
 
     // AVX lower_bound for double keys - processes 4 keys at a time
+    // Optimized: use direct _mm256_loadu_pd load for contiguous keys
     template <typename T>
     static auto simd_lower_bound_double_avx(const T* slots, size_type count, double target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(double))
@@ -749,8 +814,13 @@ class btree_map
         size_type i = 0;
 
         while (i + 4 <= count) {
-            __m256d key_vec =
-              _mm256_set_pd(keys[(i + 3) * stride], keys[(i + 2) * stride], keys[(i + 1) * stride], keys[i * stride]);
+            __m256d key_vec;
+            if constexpr (stride == 1) {
+                key_vec = _mm256_loadu_pd(&keys[i]);
+            } else {
+                key_vec = _mm256_set_pd(keys[(i + 3) * stride], keys[(i + 2) * stride],
+                                        keys[(i + 1) * stride], keys[i * stride]);
+            }
             __m256d lt = _mm256_cmp_pd(key_vec, target_vec, _CMP_LT_OQ);
             int mask = _mm256_movemask_pd(lt);
 
@@ -766,7 +836,8 @@ class btree_map
         return count;
     }
 
-    // AVX2 lower_bound for int32_t - processes 8 keys at a time with manual loads
+    // AVX2 lower_bound for int32_t - processes 8 keys at a time
+    // Optimized: use direct _mm256_loadu_si256 load for contiguous keys
     template <typename T>
     static auto simd_lower_bound_s32_avx2(const T* slots, size_type count, int32_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(int32_t))
@@ -777,13 +848,17 @@ class btree_map
         __m256i target_vec = _mm256_set1_epi32(target);
         size_type i = 0;
 
-        // Process 8 elements at a time
         while (i + 8 <= count) {
-            __m256i key_vec = _mm256_set_epi32(
-                keys[(i + 7) * stride], keys[(i + 6) * stride],
-                keys[(i + 5) * stride], keys[(i + 4) * stride],
-                keys[(i + 3) * stride], keys[(i + 2) * stride],
-                keys[(i + 1) * stride], keys[i * stride]);
+            __m256i key_vec;
+            if constexpr (stride == 1) {
+                key_vec = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(&keys[i]));
+            } else {
+                key_vec = _mm256_set_epi32(
+                    keys[(i + 7) * stride], keys[(i + 6) * stride],
+                    keys[(i + 5) * stride], keys[(i + 4) * stride],
+                    keys[(i + 3) * stride], keys[(i + 2) * stride],
+                    keys[(i + 1) * stride], keys[i * stride]);
+            }
             __m256i lt = _mm256_cmpgt_epi32(target_vec, key_vec);
             int mask = _mm256_movemask_ps(_mm256_castsi256_ps(lt));
 
@@ -800,7 +875,8 @@ class btree_map
         return count;
     }
 
-    // AVX2 lower_bound for uint32_t - processes 8 keys at a time with manual loads
+    // AVX2 lower_bound for uint32_t - processes 8 keys at a time
+    // Optimized: use direct _mm256_loadu_si256 load for contiguous keys
     template <typename T>
     static auto simd_lower_bound_u32_avx2(const T* slots, size_type count, uint32_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(uint32_t))
@@ -813,11 +889,16 @@ class btree_map
         size_type i = 0;
 
         while (i + 8 <= count) {
-            __m256i key_vec = _mm256_set_epi32(
-                static_cast<int32_t>(keys[(i + 7) * stride]), static_cast<int32_t>(keys[(i + 6) * stride]),
-                static_cast<int32_t>(keys[(i + 5) * stride]), static_cast<int32_t>(keys[(i + 4) * stride]),
-                static_cast<int32_t>(keys[(i + 3) * stride]), static_cast<int32_t>(keys[(i + 2) * stride]),
-                static_cast<int32_t>(keys[(i + 1) * stride]), static_cast<int32_t>(keys[i * stride]));
+            __m256i key_vec;
+            if constexpr (stride == 1) {
+                key_vec = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(&keys[i]));
+            } else {
+                key_vec = _mm256_set_epi32(
+                    static_cast<int32_t>(keys[(i + 7) * stride]), static_cast<int32_t>(keys[(i + 6) * stride]),
+                    static_cast<int32_t>(keys[(i + 5) * stride]), static_cast<int32_t>(keys[(i + 4) * stride]),
+                    static_cast<int32_t>(keys[(i + 3) * stride]), static_cast<int32_t>(keys[(i + 2) * stride]),
+                    static_cast<int32_t>(keys[(i + 1) * stride]), static_cast<int32_t>(keys[i * stride]));
+            }
             key_vec = _mm256_xor_si256(key_vec, sign_bit);
             __m256i lt = _mm256_cmpgt_epi32(target_vec, key_vec);
             int mask = _mm256_movemask_ps(_mm256_castsi256_ps(lt));
@@ -1028,7 +1109,7 @@ class btree_map
 
 #ifdef BTREE_HAS_NEON
     // NEON lower_bound for int32_t keys (signed)
-    // Optimized: use bitmask to find first match without inner loop
+    // Optimized: use direct vld1q load for contiguous keys, bitmask for first match
     template <typename T>
     static auto neon_lower_bound_s32(const T* slots, size_type count, int32_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(int32_t))
@@ -1040,16 +1121,19 @@ class btree_map
         size_type i = 0;
 
         while (i + 4 <= count) {
-            int32x4_t key_vec = {keys[i * stride], keys[(i + 1) * stride], keys[(i + 2) * stride],
-                                 keys[(i + 3) * stride]};
-            uint32x4_t ge = vcgeq_s32(key_vec, target_vec);  // >= comparison directly
+            int32x4_t key_vec;
+            if constexpr (stride == 1) {
+                key_vec = vld1q_s32(&keys[i]);
+            } else {
+                key_vec = int32x4_t{keys[i * stride], keys[(i + 1) * stride], keys[(i + 2) * stride],
+                                    keys[(i + 3) * stride]};
+            }
+            uint32x4_t ge = vcgeq_s32(key_vec, target_vec);
 
-            // Narrow to 16-bit and extract as 64-bit value for bitmask
             uint16x4_t narrow = vmovn_u32(ge);
             uint64_t mask = vget_lane_u64(vreinterpret_u64_u16(narrow), 0);
 
             if (mask != 0) {
-                // Find first set 16-bit lane
                 return i + static_cast<size_type>(__builtin_ctzll(mask) / 16);
             }
             i += 4;
@@ -1062,7 +1146,7 @@ class btree_map
     }
 
     // NEON lower_bound for uint32_t keys (unsigned)
-    // Optimized: use bitmask to find first match without inner loop
+    // Optimized: use direct vld1q load for contiguous keys, bitmask for first match
     template <typename T>
     static auto neon_lower_bound_u32(const T* slots, size_type count, uint32_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(uint32_t))
@@ -1074,16 +1158,19 @@ class btree_map
         size_type i = 0;
 
         while (i + 4 <= count) {
-            uint32x4_t key_vec = {keys[i * stride], keys[(i + 1) * stride], keys[(i + 2) * stride],
-                                  keys[(i + 3) * stride]};
-            uint32x4_t ge = vcgeq_u32(key_vec, target_vec);  // >= comparison directly
+            uint32x4_t key_vec;
+            if constexpr (stride == 1) {
+                key_vec = vld1q_u32(&keys[i]);
+            } else {
+                key_vec = uint32x4_t{keys[i * stride], keys[(i + 1) * stride], keys[(i + 2) * stride],
+                                     keys[(i + 3) * stride]};
+            }
+            uint32x4_t ge = vcgeq_u32(key_vec, target_vec);
 
-            // Narrow to 16-bit and extract as 64-bit value for bitmask
             uint16x4_t narrow = vmovn_u32(ge);
             uint64_t mask = vget_lane_u64(vreinterpret_u64_u16(narrow), 0);
 
             if (mask != 0) {
-                // Find first set 16-bit lane
                 return i + static_cast<size_type>(__builtin_ctzll(mask) / 16);
             }
             i += 4;
@@ -1096,7 +1183,7 @@ class btree_map
     }
 
     // NEON lower_bound for int64_t keys (signed)
-    // Optimized: use bitmask to find first match without inner loop
+    // Optimized: use direct vld1q load for contiguous keys, bitmask for first match
     template <typename T>
     static auto neon_lower_bound_s64(const T* slots, size_type count, int64_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(int64_t))
@@ -1108,15 +1195,18 @@ class btree_map
         size_type i = 0;
 
         while (i + 2 <= count) {
-            int64x2_t key_vec = {keys[i * stride], keys[(i + 1) * stride]};
-            uint64x2_t ge = vcgeq_s64(key_vec, target_vec);  // >= comparison directly
+            int64x2_t key_vec;
+            if constexpr (stride == 1) {
+                key_vec = vld1q_s64(&keys[i]);
+            } else {
+                key_vec = int64x2_t{keys[i * stride], keys[(i + 1) * stride]};
+            }
+            uint64x2_t ge = vcgeq_s64(key_vec, target_vec);
 
-            // Narrow to 32-bit and extract for bitmask
             uint32x2_t narrow = vmovn_u64(ge);
             uint64_t mask = vget_lane_u64(vreinterpret_u64_u32(narrow), 0);
 
             if (mask != 0) {
-                // Find first set 32-bit lane
                 return i + static_cast<size_type>(__builtin_ctzll(mask) / 32);
             }
             i += 2;
@@ -1127,7 +1217,7 @@ class btree_map
     }
 
     // NEON lower_bound for uint64_t keys (unsigned)
-    // Optimized: use bitmask to find first match without inner loop
+    // Optimized: use direct vld1q load for contiguous keys, bitmask for first match
     template <typename T>
     static auto neon_lower_bound_u64(const T* slots, size_type count, uint64_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(uint64_t))
@@ -1139,15 +1229,18 @@ class btree_map
         size_type i = 0;
 
         while (i + 2 <= count) {
-            uint64x2_t key_vec = {keys[i * stride], keys[(i + 1) * stride]};
-            uint64x2_t ge = vcgeq_u64(key_vec, target_vec);  // >= comparison directly
+            uint64x2_t key_vec;
+            if constexpr (stride == 1) {
+                key_vec = vld1q_u64(&keys[i]);
+            } else {
+                key_vec = uint64x2_t{keys[i * stride], keys[(i + 1) * stride]};
+            }
+            uint64x2_t ge = vcgeq_u64(key_vec, target_vec);
 
-            // Narrow to 32-bit and extract for bitmask
             uint32x2_t narrow = vmovn_u64(ge);
             uint64_t mask = vget_lane_u64(vreinterpret_u64_u32(narrow), 0);
 
             if (mask != 0) {
-                // Find first set 32-bit lane
                 return i + static_cast<size_type>(__builtin_ctzll(mask) / 32);
             }
             i += 2;
@@ -1158,7 +1251,7 @@ class btree_map
     }
 
     // NEON lower_bound for int16_t keys (signed) - processes 8 keys at a time
-    // Optimized: use bitmask to find first match without inner loop
+    // Optimized: use direct vld1q load for contiguous keys, bitmask for first match
     template <typename T>
     static auto neon_lower_bound_s16(const T* slots, size_type count, int16_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(int16_t))
@@ -1170,17 +1263,20 @@ class btree_map
         size_type i = 0;
 
         while (i + 8 <= count) {
-            int16x8_t key_vec = {keys[i * stride],       keys[(i + 1) * stride], keys[(i + 2) * stride],
-                                 keys[(i + 3) * stride], keys[(i + 4) * stride], keys[(i + 5) * stride],
-                                 keys[(i + 6) * stride], keys[(i + 7) * stride]};
-            uint16x8_t ge = vcgeq_s16(key_vec, target_vec);  // >= comparison directly
+            int16x8_t key_vec;
+            if constexpr (stride == 1) {
+                key_vec = vld1q_s16(&keys[i]);
+            } else {
+                key_vec = int16x8_t{keys[i * stride],       keys[(i + 1) * stride], keys[(i + 2) * stride],
+                                    keys[(i + 3) * stride], keys[(i + 4) * stride], keys[(i + 5) * stride],
+                                    keys[(i + 6) * stride], keys[(i + 7) * stride]};
+            }
+            uint16x8_t ge = vcgeq_s16(key_vec, target_vec);
 
-            // Narrow to 8-bit and extract as 64-bit value for bitmask
             uint8x8_t narrow = vmovn_u16(ge);
             uint64_t mask = vget_lane_u64(vreinterpret_u64_u8(narrow), 0);
 
             if (mask != 0) {
-                // Find first set 8-bit lane
                 return i + static_cast<size_type>(__builtin_ctzll(mask) / 8);
             }
             i += 8;
@@ -1193,7 +1289,7 @@ class btree_map
     }
 
     // NEON lower_bound for uint16_t keys (unsigned) - processes 8 keys at a time
-    // Optimized: use bitmask to find first match without inner loop
+    // Optimized: use direct vld1q load for contiguous keys, bitmask for first match
     template <typename T>
     static auto neon_lower_bound_u16(const T* slots, size_type count, uint16_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(uint16_t))
@@ -1205,17 +1301,20 @@ class btree_map
         size_type i = 0;
 
         while (i + 8 <= count) {
-            uint16x8_t key_vec = {keys[i * stride],       keys[(i + 1) * stride], keys[(i + 2) * stride],
-                                  keys[(i + 3) * stride], keys[(i + 4) * stride], keys[(i + 5) * stride],
-                                  keys[(i + 6) * stride], keys[(i + 7) * stride]};
-            uint16x8_t ge = vcgeq_u16(key_vec, target_vec);  // >= comparison directly
+            uint16x8_t key_vec;
+            if constexpr (stride == 1) {
+                key_vec = vld1q_u16(&keys[i]);
+            } else {
+                key_vec = uint16x8_t{keys[i * stride],       keys[(i + 1) * stride], keys[(i + 2) * stride],
+                                     keys[(i + 3) * stride], keys[(i + 4) * stride], keys[(i + 5) * stride],
+                                     keys[(i + 6) * stride], keys[(i + 7) * stride]};
+            }
+            uint16x8_t ge = vcgeq_u16(key_vec, target_vec);
 
-            // Narrow to 8-bit and extract as 64-bit value for bitmask
             uint8x8_t narrow = vmovn_u16(ge);
             uint64_t mask = vget_lane_u64(vreinterpret_u64_u8(narrow), 0);
 
             if (mask != 0) {
-                // Find first set 8-bit lane
                 return i + static_cast<size_type>(__builtin_ctzll(mask) / 8);
             }
             i += 8;
@@ -1228,7 +1327,7 @@ class btree_map
     }
 
     // NEON lower_bound for int8_t keys (signed) - processes 16 keys at a time
-    // Optimized: use bitmask to find first match without inner loop
+    // Optimized: use direct vld1q load for contiguous keys, bitmask for first match
     template <typename T>
     static auto neon_lower_bound_s8(const T* slots, size_type count, int8_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(int8_t))
@@ -1240,14 +1339,18 @@ class btree_map
         size_type i = 0;
 
         while (i + 16 <= count) {
-            int8x16_t key_vec = {
-              keys[i * stride],        keys[(i + 1) * stride],  keys[(i + 2) * stride],  keys[(i + 3) * stride],
-              keys[(i + 4) * stride],  keys[(i + 5) * stride],  keys[(i + 6) * stride],  keys[(i + 7) * stride],
-              keys[(i + 8) * stride],  keys[(i + 9) * stride],  keys[(i + 10) * stride], keys[(i + 11) * stride],
-              keys[(i + 12) * stride], keys[(i + 13) * stride], keys[(i + 14) * stride], keys[(i + 15) * stride]};
-            uint8x16_t ge = vcgeq_s8(key_vec, target_vec);  // >= comparison directly
+            int8x16_t key_vec;
+            if constexpr (stride == 1) {
+                key_vec = vld1q_s8(&keys[i]);
+            } else {
+                key_vec = int8x16_t{
+                  keys[i * stride],        keys[(i + 1) * stride],  keys[(i + 2) * stride],  keys[(i + 3) * stride],
+                  keys[(i + 4) * stride],  keys[(i + 5) * stride],  keys[(i + 6) * stride],  keys[(i + 7) * stride],
+                  keys[(i + 8) * stride],  keys[(i + 9) * stride],  keys[(i + 10) * stride], keys[(i + 11) * stride],
+                  keys[(i + 12) * stride], keys[(i + 13) * stride], keys[(i + 14) * stride], keys[(i + 15) * stride]};
+            }
+            uint8x16_t ge = vcgeq_s8(key_vec, target_vec);
 
-            // Extract low and high 64-bit halves as bitmask
             uint64_t mask_lo = vgetq_lane_u64(vreinterpretq_u64_u8(ge), 0);
             if (mask_lo != 0) {
                 return i + static_cast<size_type>(__builtin_ctzll(mask_lo) / 8);
@@ -1266,7 +1369,7 @@ class btree_map
     }
 
     // NEON lower_bound for uint8_t keys (unsigned) - processes 16 keys at a time
-    // Optimized: use bitmask to find first match without inner loop
+    // Optimized: use direct vld1q load for contiguous keys, bitmask for first match
     template <typename T>
     static auto neon_lower_bound_u8(const T* slots, size_type count, uint8_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(uint8_t))
@@ -1278,14 +1381,18 @@ class btree_map
         size_type i = 0;
 
         while (i + 16 <= count) {
-            uint8x16_t key_vec = {
-              keys[i * stride],        keys[(i + 1) * stride],  keys[(i + 2) * stride],  keys[(i + 3) * stride],
-              keys[(i + 4) * stride],  keys[(i + 5) * stride],  keys[(i + 6) * stride],  keys[(i + 7) * stride],
-              keys[(i + 8) * stride],  keys[(i + 9) * stride],  keys[(i + 10) * stride], keys[(i + 11) * stride],
-              keys[(i + 12) * stride], keys[(i + 13) * stride], keys[(i + 14) * stride], keys[(i + 15) * stride]};
-            uint8x16_t ge = vcgeq_u8(key_vec, target_vec);  // >= comparison directly
+            uint8x16_t key_vec;
+            if constexpr (stride == 1) {
+                key_vec = vld1q_u8(&keys[i]);
+            } else {
+                key_vec = uint8x16_t{
+                  keys[i * stride],        keys[(i + 1) * stride],  keys[(i + 2) * stride],  keys[(i + 3) * stride],
+                  keys[(i + 4) * stride],  keys[(i + 5) * stride],  keys[(i + 6) * stride],  keys[(i + 7) * stride],
+                  keys[(i + 8) * stride],  keys[(i + 9) * stride],  keys[(i + 10) * stride], keys[(i + 11) * stride],
+                  keys[(i + 12) * stride], keys[(i + 13) * stride], keys[(i + 14) * stride], keys[(i + 15) * stride]};
+            }
+            uint8x16_t ge = vcgeq_u8(key_vec, target_vec);
 
-            // Extract low and high 64-bit halves as bitmask
             uint64_t mask_lo = vgetq_lane_u64(vreinterpretq_u64_u8(ge), 0);
             if (mask_lo != 0) {
                 return i + static_cast<size_type>(__builtin_ctzll(mask_lo) / 8);
@@ -1304,7 +1411,7 @@ class btree_map
     }
 
     // NEON lower_bound for float keys - processes 4 keys at a time
-    // Optimized: use bitmask to find first match without inner loop
+    // Optimized: use direct vld1q load for contiguous keys, bitmask for first match
     template <typename T>
     static auto neon_lower_bound_float(const T* slots, size_type count, float target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(float))
@@ -1316,16 +1423,19 @@ class btree_map
         size_type i = 0;
 
         while (i + 4 <= count) {
-            float32x4_t key_vec = {keys[i * stride], keys[(i + 1) * stride], keys[(i + 2) * stride],
-                                   keys[(i + 3) * stride]};
-            uint32x4_t ge = vcgeq_f32(key_vec, target_vec);  // >= comparison directly
+            float32x4_t key_vec;
+            if constexpr (stride == 1) {
+                key_vec = vld1q_f32(&keys[i]);
+            } else {
+                key_vec = float32x4_t{keys[i * stride], keys[(i + 1) * stride], keys[(i + 2) * stride],
+                                      keys[(i + 3) * stride]};
+            }
+            uint32x4_t ge = vcgeq_f32(key_vec, target_vec);
 
-            // Narrow to 16-bit and extract as 64-bit value for bitmask
             uint16x4_t narrow = vmovn_u32(ge);
             uint64_t mask = vget_lane_u64(vreinterpret_u64_u16(narrow), 0);
 
             if (mask != 0) {
-                // Find first set 16-bit lane
                 return i + static_cast<size_type>(__builtin_ctzll(mask) / 16);
             }
             i += 4;
@@ -1338,7 +1448,7 @@ class btree_map
     }
 
     // NEON lower_bound for double keys - processes 2 keys at a time
-    // Optimized: use bitmask to find first match without inner loop
+    // Optimized: use direct vld1q load for contiguous keys, bitmask for first match
     template <typename T>
     static auto neon_lower_bound_double(const T* slots, size_type count, double target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(double))
@@ -1350,15 +1460,18 @@ class btree_map
         size_type i = 0;
 
         while (i + 2 <= count) {
-            float64x2_t key_vec = {keys[i * stride], keys[(i + 1) * stride]};
-            uint64x2_t ge = vcgeq_f64(key_vec, target_vec);  // >= comparison directly
+            float64x2_t key_vec;
+            if constexpr (stride == 1) {
+                key_vec = vld1q_f64(&keys[i]);
+            } else {
+                key_vec = float64x2_t{keys[i * stride], keys[(i + 1) * stride]};
+            }
+            uint64x2_t ge = vcgeq_f64(key_vec, target_vec);
 
-            // Narrow to 32-bit and extract for bitmask
             uint32x2_t narrow = vmovn_u64(ge);
             uint64_t mask = vget_lane_u64(vreinterpret_u64_u32(narrow), 0);
 
             if (mask != 0) {
-                // Find first set 32-bit lane
                 return i + static_cast<size_type>(__builtin_ctzll(mask) / 32);
             }
             i += 2;

--- a/container/btree_map.hpp
+++ b/container/btree_map.hpp
@@ -1343,7 +1343,7 @@ class btree_map
     }
 
     // NEON lower_bound for int8_t keys (signed) - processes 16 keys at a time
-    // Optimized: use direct vld1q load for contiguous keys, bitmask for first match
+    // Optimized: use direct vld1q load for contiguous keys, vld2q for stride==2, bitmask for first match
     template <typename T>
     static auto neon_lower_bound_s8(const T* slots, size_type count, int8_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(int8_t))
@@ -1358,6 +1358,10 @@ class btree_map
             int8x16_t key_vec;
             if constexpr (stride == 1) {
                 key_vec = vld1q_s8(&keys[i]);
+            } else if constexpr (stride == 2) {
+                // Use vld2 for efficient strided load (e.g., btree_map<int8_t, int8_t>)
+                int8x16x2_t interleaved = vld2q_s8(&keys[i * 2]);
+                key_vec = interleaved.val[0];  // Keys are at even indices
             } else {
                 key_vec = int8x16_t{
                   keys[i * stride],        keys[(i + 1) * stride],  keys[(i + 2) * stride],  keys[(i + 3) * stride],
@@ -1385,7 +1389,7 @@ class btree_map
     }
 
     // NEON lower_bound for uint8_t keys (unsigned) - processes 16 keys at a time
-    // Optimized: use direct vld1q load for contiguous keys, bitmask for first match
+    // Optimized: use direct vld1q load for contiguous keys, vld2q for stride==2, bitmask for first match
     template <typename T>
     static auto neon_lower_bound_u8(const T* slots, size_type count, uint8_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(uint8_t))
@@ -1400,6 +1404,10 @@ class btree_map
             uint8x16_t key_vec;
             if constexpr (stride == 1) {
                 key_vec = vld1q_u8(&keys[i]);
+            } else if constexpr (stride == 2) {
+                // Use vld2 for efficient strided load (e.g., btree_map<uint8_t, uint8_t>)
+                uint8x16x2_t interleaved = vld2q_u8(&keys[i * 2]);
+                key_vec = interleaved.val[0];  // Keys are at even indices
             } else {
                 key_vec = uint8x16_t{
                   keys[i * stride],        keys[(i + 1) * stride],  keys[(i + 2) * stride],  keys[(i + 3) * stride],

--- a/container/btree_map.hpp
+++ b/container/btree_map.hpp
@@ -1028,6 +1028,7 @@ class btree_map
 
 #ifdef BTREE_HAS_NEON
     // NEON lower_bound for int32_t keys (signed)
+    // Optimized: use bitmask to find first match without inner loop
     template <typename T>
     static auto neon_lower_bound_s32(const T* slots, size_type count, int32_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(int32_t))
@@ -1041,13 +1042,15 @@ class btree_map
         while (i + 4 <= count) {
             int32x4_t key_vec = {keys[i * stride], keys[(i + 1) * stride], keys[(i + 2) * stride],
                                  keys[(i + 3) * stride]};
-            uint32x4_t lt = vcltq_s32(key_vec, target_vec);
+            uint32x4_t ge = vcgeq_s32(key_vec, target_vec);  // >= comparison directly
 
-            // Use vminvq_u32 to detect if any lane is 0 (key >= target)
-            if (vminvq_u32(lt) == 0) {
-                for (size_type j = 0; j < 4; ++j) {
-                    if (keys[(i + j) * stride] >= target) return i + j;
-                }
+            // Narrow to 16-bit and extract as 64-bit value for bitmask
+            uint16x4_t narrow = vmovn_u32(ge);
+            uint64_t mask = vget_lane_u64(vreinterpret_u64_u16(narrow), 0);
+
+            if (mask != 0) {
+                // Find first set 16-bit lane
+                return i + static_cast<size_type>(__builtin_ctzll(mask) / 16);
             }
             i += 4;
         }
@@ -1059,6 +1062,7 @@ class btree_map
     }
 
     // NEON lower_bound for uint32_t keys (unsigned)
+    // Optimized: use bitmask to find first match without inner loop
     template <typename T>
     static auto neon_lower_bound_u32(const T* slots, size_type count, uint32_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(uint32_t))
@@ -1072,13 +1076,15 @@ class btree_map
         while (i + 4 <= count) {
             uint32x4_t key_vec = {keys[i * stride], keys[(i + 1) * stride], keys[(i + 2) * stride],
                                   keys[(i + 3) * stride]};
-            uint32x4_t lt = vcltq_u32(key_vec, target_vec);
+            uint32x4_t ge = vcgeq_u32(key_vec, target_vec);  // >= comparison directly
 
-            // Use vminvq_u32 to detect if any lane is 0 (key >= target)
-            if (vminvq_u32(lt) == 0) {
-                for (size_type j = 0; j < 4; ++j) {
-                    if (keys[(i + j) * stride] >= target) return i + j;
-                }
+            // Narrow to 16-bit and extract as 64-bit value for bitmask
+            uint16x4_t narrow = vmovn_u32(ge);
+            uint64_t mask = vget_lane_u64(vreinterpret_u64_u16(narrow), 0);
+
+            if (mask != 0) {
+                // Find first set 16-bit lane
+                return i + static_cast<size_type>(__builtin_ctzll(mask) / 16);
             }
             i += 4;
         }
@@ -1090,6 +1096,7 @@ class btree_map
     }
 
     // NEON lower_bound for int64_t keys (signed)
+    // Optimized: use bitmask to find first match without inner loop
     template <typename T>
     static auto neon_lower_bound_s64(const T* slots, size_type count, int64_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(int64_t))
@@ -1102,13 +1109,15 @@ class btree_map
 
         while (i + 2 <= count) {
             int64x2_t key_vec = {keys[i * stride], keys[(i + 1) * stride]};
-            uint64x2_t lt = vcltq_s64(key_vec, target_vec);
+            uint64x2_t ge = vcgeq_s64(key_vec, target_vec);  // >= comparison directly
 
-            // Check if any key >= target (any lane is 0)
-            // AND lanes: result == 0 means at least one lane was 0
-            if ((vgetq_lane_u64(lt, 0) & vgetq_lane_u64(lt, 1)) == 0) {
-                if (keys[i * stride] >= target) return i;
-                if (keys[(i + 1) * stride] >= target) return i + 1;
+            // Narrow to 32-bit and extract for bitmask
+            uint32x2_t narrow = vmovn_u64(ge);
+            uint64_t mask = vget_lane_u64(vreinterpret_u64_u32(narrow), 0);
+
+            if (mask != 0) {
+                // Find first set 32-bit lane
+                return i + static_cast<size_type>(__builtin_ctzll(mask) / 32);
             }
             i += 2;
         }
@@ -1118,6 +1127,7 @@ class btree_map
     }
 
     // NEON lower_bound for uint64_t keys (unsigned)
+    // Optimized: use bitmask to find first match without inner loop
     template <typename T>
     static auto neon_lower_bound_u64(const T* slots, size_type count, uint64_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(uint64_t))
@@ -1130,13 +1140,15 @@ class btree_map
 
         while (i + 2 <= count) {
             uint64x2_t key_vec = {keys[i * stride], keys[(i + 1) * stride]};
-            uint64x2_t lt = vcltq_u64(key_vec, target_vec);
+            uint64x2_t ge = vcgeq_u64(key_vec, target_vec);  // >= comparison directly
 
-            // Check if any key >= target (any lane is 0)
-            // AND lanes: result == 0 means at least one lane was 0
-            if ((vgetq_lane_u64(lt, 0) & vgetq_lane_u64(lt, 1)) == 0) {
-                if (keys[i * stride] >= target) return i;
-                if (keys[(i + 1) * stride] >= target) return i + 1;
+            // Narrow to 32-bit and extract for bitmask
+            uint32x2_t narrow = vmovn_u64(ge);
+            uint64_t mask = vget_lane_u64(vreinterpret_u64_u32(narrow), 0);
+
+            if (mask != 0) {
+                // Find first set 32-bit lane
+                return i + static_cast<size_type>(__builtin_ctzll(mask) / 32);
             }
             i += 2;
         }

--- a/container/btree_map.hpp
+++ b/container/btree_map.hpp
@@ -1259,7 +1259,7 @@ class btree_map
     }
 
     // NEON lower_bound for int16_t keys (signed) - processes 8 keys at a time
-    // Optimized: use direct vld1q load for contiguous keys, bitmask for first match
+    // Optimized: use direct vld1q load for contiguous keys, vld2q for stride==2, bitmask for first match
     template <typename T>
     static auto neon_lower_bound_s16(const T* slots, size_type count, int16_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(int16_t))
@@ -1274,6 +1274,10 @@ class btree_map
             int16x8_t key_vec;
             if constexpr (stride == 1) {
                 key_vec = vld1q_s16(&keys[i]);
+            } else if constexpr (stride == 2) {
+                // Use vld2 for efficient strided load (e.g., btree_map<int16_t, int16_t>)
+                int16x8x2_t interleaved = vld2q_s16(&keys[i * 2]);
+                key_vec = interleaved.val[0];  // Keys are at even indices
             } else {
                 key_vec = int16x8_t{keys[i * stride],       keys[(i + 1) * stride], keys[(i + 2) * stride],
                                     keys[(i + 3) * stride], keys[(i + 4) * stride], keys[(i + 5) * stride],
@@ -1297,7 +1301,7 @@ class btree_map
     }
 
     // NEON lower_bound for uint16_t keys (unsigned) - processes 8 keys at a time
-    // Optimized: use direct vld1q load for contiguous keys, bitmask for first match
+    // Optimized: use direct vld1q load for contiguous keys, vld2q for stride==2, bitmask for first match
     template <typename T>
     static auto neon_lower_bound_u16(const T* slots, size_type count, uint16_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(uint16_t))
@@ -1312,6 +1316,10 @@ class btree_map
             uint16x8_t key_vec;
             if constexpr (stride == 1) {
                 key_vec = vld1q_u16(&keys[i]);
+            } else if constexpr (stride == 2) {
+                // Use vld2 for efficient strided load (e.g., btree_map<uint16_t, uint16_t>)
+                uint16x8x2_t interleaved = vld2q_u16(&keys[i * 2]);
+                key_vec = interleaved.val[0];  // Keys are at even indices
             } else {
                 key_vec = uint16x8_t{keys[i * stride],       keys[(i + 1) * stride], keys[(i + 2) * stride],
                                      keys[(i + 3) * stride], keys[(i + 4) * stride], keys[(i + 5) * stride],

--- a/container/btree_map.hpp
+++ b/container/btree_map.hpp
@@ -1435,7 +1435,7 @@ class btree_map
     }
 
     // NEON lower_bound for float keys - processes 4 keys at a time
-    // Optimized: use direct vld1q load for contiguous keys, bitmask for first match
+    // Optimized: use direct vld1q load for contiguous keys, vld2q for stride==2, bitmask for first match
     template <typename T>
     static auto neon_lower_bound_float(const T* slots, size_type count, float target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(float))
@@ -1450,6 +1450,10 @@ class btree_map
             float32x4_t key_vec;
             if constexpr (stride == 1) {
                 key_vec = vld1q_f32(&keys[i]);
+            } else if constexpr (stride == 2) {
+                // Use vld2 for efficient strided load (e.g., btree_map<float, float>)
+                float32x4x2_t interleaved = vld2q_f32(&keys[i * 2]);
+                key_vec = interleaved.val[0];  // Keys are at even indices
             } else {
                 key_vec = float32x4_t{keys[i * stride], keys[(i + 1) * stride], keys[(i + 2) * stride],
                                       keys[(i + 3) * stride]};

--- a/container/btree_map.hpp
+++ b/container/btree_map.hpp
@@ -1109,7 +1109,7 @@ class btree_map
 
 #ifdef BTREE_HAS_NEON
     // NEON lower_bound for int32_t keys (signed)
-    // Optimized: use direct vld1q load for contiguous keys, bitmask for first match
+    // Optimized: use direct vld1q load for contiguous keys, vld2q for stride==2, bitmask for first match
     template <typename T>
     static auto neon_lower_bound_s32(const T* slots, size_type count, int32_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(int32_t))
@@ -1124,6 +1124,10 @@ class btree_map
             int32x4_t key_vec;
             if constexpr (stride == 1) {
                 key_vec = vld1q_s32(&keys[i]);
+            } else if constexpr (stride == 2) {
+                // Use vld2 for efficient strided load (e.g., btree_map<int32_t, int32_t>)
+                int32x4x2_t interleaved = vld2q_s32(&keys[i * 2]);
+                key_vec = interleaved.val[0];  // Keys are at even indices
             } else {
                 key_vec = int32x4_t{keys[i * stride], keys[(i + 1) * stride], keys[(i + 2) * stride],
                                     keys[(i + 3) * stride]};
@@ -1146,7 +1150,7 @@ class btree_map
     }
 
     // NEON lower_bound for uint32_t keys (unsigned)
-    // Optimized: use direct vld1q load for contiguous keys, bitmask for first match
+    // Optimized: use direct vld1q load for contiguous keys, vld2q for stride==2, bitmask for first match
     template <typename T>
     static auto neon_lower_bound_u32(const T* slots, size_type count, uint32_t target) noexcept -> size_type
     requires(sizeof(T) >= sizeof(uint32_t))
@@ -1161,6 +1165,10 @@ class btree_map
             uint32x4_t key_vec;
             if constexpr (stride == 1) {
                 key_vec = vld1q_u32(&keys[i]);
+            } else if constexpr (stride == 2) {
+                // Use vld2 for efficient strided load (e.g., btree_map<uint32_t, uint32_t>)
+                uint32x4x2_t interleaved = vld2q_u32(&keys[i * 2]);
+                key_vec = interleaved.val[0];  // Keys are at even indices
             } else {
                 key_vec = uint32x4_t{keys[i * stride], keys[(i + 1) * stride], keys[(i + 2) * stride],
                                      keys[(i + 3) * stride]};


### PR DESCRIPTION
## Summary
- Fix NEON SIMD lower_bound to use correct `vminvq` reduction instead of `vmaxvq`
- Optimize NEON lower_bound using bitmask instead of inner loop for better performance
- Add direct SIMD vector loads (`vld1q_*`, `_mm_loadu_si128`, `_mm256_loadu_si256`) for contiguous keys (stride==1)
- Add `vld2q` interleaved load optimization for stride==2 cases (btree_map)
- Make libc++ optional in CMake build with `USE_LIBCXX_DEFAULT` option

## NEON vld2q Optimization for btree_map

For `btree_map<K, V>` where `sizeof(K) == sizeof(V)`, the `vld2q` instruction efficiently loads interleaved key-value data:

| Key Type | Before | After | Improvement |
|----------|--------|-------|-------------|
| int32_t (10K) | 72 ns | 64 ns | **+11%** |
| int32_t (100K) | 113 ns | 100 ns | **+12%** |
| int16_t (10K) | 66 ns | 47 ns | **+29%** |
| int16_t (100K) | 88 ns | 68 ns | **+23%** |
| int8_t (100) | 41 ns | 18 ns | **+56%** |
| int8_t (200) | 45 ns | 28 ns | **+38%** |
| float (10K) | 72 ns | 62 ns | **+14%** |
| float (100K) | 113 ns | 102 ns | **+10%** |

**Note**: int64_t/double vld2q tested but showed no improvement (only 2 elements per vector).

## btree_set vs absl::btree_set (ARM64)

| Operation | Speedup vs absl |
|-----------|-----------------|
| Sorted Insert | 10-12x faster |
| Random Insert | 2-3x faster |
| Find | 1.0-1.8x faster |
| Lower_bound | 0.9-1.7x faster |
| Iterate | 5-7x faster |
| Erase | 1.3-2.6x faster |

## Optimizations Evaluated

| Optimization | Result |
|--------------|--------|
| vld2q stride==2 (int8-float) | ✅ +10-56% improvement |
| vld1q stride==1 (direct load) | ✅ Committed |
| vld2q for int64/double | ❌ No improvement (2 elem/vec) |
| Loop unrolling NEON | ❌ 4-6% slower, reverted |
| Simplify int64 narrowing | ❌ 5-10% slower, reverted |
| Iterator is_leaf caching | ❌ No measurable improvement |
| Node memory layout | ✅ Already well-optimized |

## Test plan
- [x] All 229 tests pass
- [x] Benchmark verified improvements across multiple key types
- [x] Tested on ARM64 (AWS Graviton)

🤖 Generated with [Claude Code](https://claude.com/claude-code)