### PR TITLE
feat: add PMR support for dense_map

### DIFF
--- a/container/btree_map.hpp
+++ b/container/btree_map.hpp
@@ -3978,7 +3978,16 @@ class btree_map
     // Copy assignment - O(n) deep copy of tree structure
     auto operator=(const btree_map& other) -> btree_map& {
         if (this != &other) {
-            destroy_node(_root);
+            using AllocTraits = std::allocator_traits<Allocator>;
+            if constexpr (AllocTraits::propagate_on_container_copy_assignment::value) {
+                // Allocator propagates: destroy with old allocator, then copy allocator
+                destroy_node(_root);
+                _leaf_alloc = other._leaf_alloc;
+                _internal_alloc = other._internal_alloc;
+            } else {
+                // Allocator does not propagate (PMR): keep our allocator
+                destroy_node(_root);
+            }
             _comp = other._comp;
             _size = other._size;
             _root = deep_copy_node(other._root, nullptr);
@@ -3988,19 +3997,58 @@ class btree_map
     }
 
     // Move assignment
-    auto operator=(btree_map&& other) noexcept -> btree_map& {
+    auto operator=(btree_map&& other) noexcept(
+        std::allocator_traits<Allocator>::propagate_on_container_move_assignment::value ||
+        std::allocator_traits<Allocator>::is_always_equal::value) -> btree_map& {
         if (this != &other) {
-            destroy_node(_root);
-            _root = other._root;
-            _rightmost_leaf = other._rightmost_leaf;
-            _size = other._size;
+            using AllocTraits = std::allocator_traits<Allocator>;
             _comp = std::move(other._comp);
-            other._root = nullptr;
-            other._rightmost_leaf = nullptr;
-            other._size = 0;
+
+            if constexpr (AllocTraits::propagate_on_container_move_assignment::value) {
+                // Allocator propagates: destroy with old allocator, steal resources, take allocator
+                destroy_node(_root);
+                _leaf_alloc = std::move(other._leaf_alloc);
+                _internal_alloc = std::move(other._internal_alloc);
+                move_resources_from(other);
+            } else if constexpr (AllocTraits::is_always_equal::value) {
+                // Allocators are always equal: can steal resources
+                destroy_node(_root);
+                move_resources_from(other);
+            } else {
+                // Allocators may differ (PMR case)
+                if (_leaf_alloc == other._leaf_alloc) {
+                    // Allocators are equal: can steal resources
+                    destroy_node(_root);
+                    move_resources_from(other);
+                } else {
+                    // Allocators differ: must move elements individually
+                    clear();
+                    for (auto&& [k, v] : other) {
+                        if constexpr (is_set_mode) {
+                            insert(std::move(const_cast<Key&>(k)));
+                        } else {
+                            insert(std::move(const_cast<Key&>(k)), std::move(const_cast<Value&>(v)));
+                        }
+                    }
+                    other.clear();
+                }
+            }
         }
         return *this;
     }
+
+private:
+    // Helper: steal resources from other (used when allocators are equal)
+    void move_resources_from(btree_map& other) noexcept {
+        _root = other._root;
+        _rightmost_leaf = other._rightmost_leaf;
+        _size = other._size;
+        other._root = nullptr;
+        other._rightmost_leaf = nullptr;
+        other._size = 0;
+    }
+
+public:
 
     // Capacity
     [[nodiscard]] auto empty() const noexcept -> bool { return _size == 0; }

--- a/container/concurrent_skiplist.hpp
+++ b/container/concurrent_skiplist.hpp
@@ -19,6 +19,8 @@
 #include <atomic>
 #include <cstdint>
 #include <functional>
+#include <memory>
+#include <memory_resource>
 #include <optional>
 #include <thread>
 
@@ -35,15 +37,22 @@ namespace stdb::container {
  *   5. Simplified node structure
  */
 
-template <typename Key, typename Value, typename Compare = std::less<Key>, uint8_t MaxLevel = 12>
+template <typename Key, typename Value, typename Compare = std::less<Key>,
+          typename Alloc = std::allocator<std::pair<const Key, Value>>, uint8_t MaxLevel = 12>
 class concurrent_skiplist {
    public:
     using key_type = Key;
     using mapped_type = Value;
     using value_type = std::pair<const Key, Value>;
     using size_type = std::size_t;
+    using allocator_type = Alloc;
 
    private:
+    using AllocTraits = std::allocator_traits<Alloc>;
+    // Rebind to byte allocator for variable-sized node allocation
+    using ByteAlloc = typename AllocTraits::template rebind_alloc<std::byte>;
+    using ByteAllocTraits = std::allocator_traits<ByteAlloc>;
+
     // Marked pointer: use low bit to indicate logical deletion
     template <typename T>
     struct MarkedPtr {
@@ -66,11 +75,26 @@ class concurrent_skiplist {
         uint8_t height;
         std::atomic<MarkedPtr<Node>> next[1];  // flexible array
 
-        static Node* create(const Key& k, const Value& v, uint8_t h) {
-            void* mem = ::operator new(sizeof(Node) + h * sizeof(std::atomic<MarkedPtr<Node>>));
+        static size_t alloc_size(uint8_t h) {
+            return sizeof(Node) + h * sizeof(std::atomic<MarkedPtr<Node>>);
+        }
+
+        static Node* create(const Key& k, const Value& v, uint8_t h, ByteAlloc& alloc) {
+            size_t size = alloc_size(h);
+            void* mem = ByteAllocTraits::allocate(alloc, size);
             Node* node = static_cast<Node*>(mem);
-            new (&node->key) Key(k);
-            new (&node->value) Value(v);
+            try {
+                new (&node->key) Key(k);
+                try {
+                    new (&node->value) Value(v);
+                } catch (...) {
+                    node->key.~Key();
+                    throw;
+                }
+            } catch (...) {
+                ByteAllocTraits::deallocate(alloc, static_cast<std::byte*>(mem), size);
+                throw;
+            }
             node->height = h;
             for (uint8_t i = 0; i <= h; ++i) {
                 new (&node->next[i]) std::atomic<MarkedPtr<Node>>(MarkedPtr<Node>());
@@ -78,11 +102,22 @@ class concurrent_skiplist {
             return node;
         }
 
-        static Node* create(Key&& k, Value&& v, uint8_t h) {
-            void* mem = ::operator new(sizeof(Node) + h * sizeof(std::atomic<MarkedPtr<Node>>));
+        static Node* create(Key&& k, Value&& v, uint8_t h, ByteAlloc& alloc) {
+            size_t size = alloc_size(h);
+            void* mem = ByteAllocTraits::allocate(alloc, size);
             Node* node = static_cast<Node*>(mem);
-            new (&node->key) Key(std::move(k));
-            new (&node->value) Value(std::move(v));
+            try {
+                new (&node->key) Key(std::move(k));
+                try {
+                    new (&node->value) Value(std::move(v));
+                } catch (...) {
+                    node->key.~Key();
+                    throw;
+                }
+            } catch (...) {
+                ByteAllocTraits::deallocate(alloc, static_cast<std::byte*>(mem), size);
+                throw;
+            }
             node->height = h;
             for (uint8_t i = 0; i <= h; ++i) {
                 new (&node->next[i]) std::atomic<MarkedPtr<Node>>(MarkedPtr<Node>());
@@ -90,10 +125,11 @@ class concurrent_skiplist {
             return node;
         }
 
-        void destroy() {
+        void destroy(ByteAlloc& alloc) {
+            size_t size = alloc_size(height);
             key.~Key();
             value.~Value();
-            ::operator delete(this);
+            ByteAllocTraits::deallocate(alloc, reinterpret_cast<std::byte*>(this), size);
         }
     };
 
@@ -124,13 +160,26 @@ class concurrent_skiplist {
     // Comparator on its own to avoid interference
     alignas(64) Compare _cmp;
 
+    // Allocator (mutable because allocation may happen in const-qualified contexts internally)
+    mutable ByteAlloc _alloc;
+
     // Simplified memory management:
     // - Don't free nodes during operation (leave in list, just marked)
     // - Only clean up in destructor
     // This is safe and simple, though it leaks memory during heavy delete workloads
+    //
+    // NOTE: For PMR usage, the underlying memory_resource must be thread-safe
+    // (e.g., std::pmr::synchronized_pool_resource). Using non-thread-safe resources
+    // with concurrent operations is undefined behavior.
 
    public:
-    concurrent_skiplist() {
+    concurrent_skiplist() : _alloc() {
+        for (uint8_t i = 0; i <= MaxLevel; ++i) {
+            _head[i].store(MarkedPtr<Node>(), std::memory_order_relaxed);
+        }
+    }
+
+    explicit concurrent_skiplist(const Alloc& alloc) : _alloc(alloc) {
         for (uint8_t i = 0; i <= MaxLevel; ++i) {
             _head[i].store(MarkedPtr<Node>(), std::memory_order_relaxed);
         }
@@ -141,13 +190,17 @@ class concurrent_skiplist {
         Node* curr = _head[0].load(std::memory_order_relaxed).ptr();
         while (curr) {
             Node* next = curr->next[0].load(std::memory_order_relaxed).ptr();
-            curr->destroy();
+            curr->destroy(_alloc);
             curr = next;
         }
     }
 
     concurrent_skiplist(const concurrent_skiplist&) = delete;
     concurrent_skiplist& operator=(const concurrent_skiplist&) = delete;
+
+    [[nodiscard]] auto get_allocator() const noexcept -> allocator_type {
+        return allocator_type(_alloc);
+    }
 
     // =========================================================================
     // Find - ultra-optimized for speed
@@ -223,7 +276,7 @@ class concurrent_skiplist {
     // =========================================================================
     bool insert(const Key& key, const Value& value) {
         uint8_t height = random_height();
-        Node* new_node = Node::create(key, value, height);
+        Node* new_node = Node::create(key, value, height, _alloc);
 
         // Update max height
         uint8_t old_h = _height.load(std::memory_order_relaxed);
@@ -238,7 +291,7 @@ class concurrent_skiplist {
             // Find insert position
             if (!find_insert_position(key, preds, succs)) {
                 // Key exists
-                new_node->destroy();
+                new_node->destroy(_alloc);
                 return false;
             }
 
@@ -296,7 +349,7 @@ class concurrent_skiplist {
 
     bool insert(Key&& key, Value&& value) {
         uint8_t height = random_height();
-        Node* new_node = Node::create(std::move(key), std::move(value), height);
+        Node* new_node = Node::create(std::move(key), std::move(value), height, _alloc);
 
         uint8_t old_h = _height.load(std::memory_order_relaxed);
         while (height > old_h) {
@@ -308,7 +361,7 @@ class concurrent_skiplist {
 
         while (true) {
             if (!find_insert_position(new_node->key, preds, succs)) {
-                new_node->destroy();
+                new_node->destroy(_alloc);
                 return false;
             }
 
@@ -532,7 +585,25 @@ class concurrent_skiplist {
     }
 };
 
-template <typename Key, typename Value, typename Compare = std::less<Key>>
-using concurrent_skiplist_map = concurrent_skiplist<Key, Value, Compare>;
+template <typename Key, typename Value, typename Compare = std::less<Key>,
+          typename Alloc = std::allocator<std::pair<const Key, Value>>>
+using concurrent_skiplist_map = concurrent_skiplist<Key, Value, Compare, Alloc>;
 
 }  // namespace stdb::container
+
+// PMR type aliases
+// NOTE: When using PMR with concurrent_skiplist, the underlying memory_resource
+// MUST be thread-safe (e.g., std::pmr::synchronized_pool_resource).
+// Using non-thread-safe resources like monotonic_buffer_resource or
+// unsynchronized_pool_resource with concurrent operations is undefined behavior.
+namespace stdb::pmr {
+template <typename Key, typename Value, typename Compare = std::less<Key>, uint8_t MaxLevel = 12>
+using concurrent_skiplist =
+    container::concurrent_skiplist<Key, Value, Compare,
+                                   std::pmr::polymorphic_allocator<std::pair<const Key, Value>>, MaxLevel>;
+
+template <typename Key, typename Value, typename Compare = std::less<Key>>
+using concurrent_skiplist_map =
+    container::concurrent_skiplist<Key, Value, Compare,
+                                   std::pmr::polymorphic_allocator<std::pair<const Key, Value>>>;
+}  // namespace stdb::pmr

--- a/container/dense_map.hpp
+++ b/container/dense_map.hpp
@@ -965,12 +965,26 @@ public:
                         }
                     } else if constexpr (kUseFlat) {
                         std::memcpy(buckets_, other.buckets_, other.capacity_ * sizeof(detail::Bucket));
+                        // Ensure values array is large enough
+                        if (other.size_ > values_capacity_) {
+                            SlotAlloc slot_alloc(alloc_);
+                            std::allocator_traits<SlotAlloc>::deallocate(slot_alloc, values_, values_capacity_);
+                            values_capacity_ = other.values_capacity_;
+                            values_ = std::allocator_traits<SlotAlloc>::allocate(slot_alloc, values_capacity_);
+                        }
                         for (size_t i = 0; i < other.size_; ++i) {
                             AllocTraits::construct(alloc_, values_ + i, other.values_[i]);
                         }
                     } else {
                         std::memcpy(ctrl_, other.ctrl_, other.capacity_ + kGroupWidth + 1);
                         std::memcpy(value_indices_, other.value_indices_, other.capacity_ * sizeof(uint32_t));
+                        // Ensure values array is large enough
+                        if (other.size_ > values_capacity_) {
+                            SlotAlloc slot_alloc(alloc_);
+                            std::allocator_traits<SlotAlloc>::deallocate(slot_alloc, values_, values_capacity_);
+                            values_capacity_ = other.values_capacity_;
+                            values_ = std::allocator_traits<SlotAlloc>::allocate(slot_alloc, values_capacity_);
+                        }
                         for (size_t i = 0; i < other.size_; ++i) {
                             AllocTraits::construct(alloc_, values_ + i, other.values_[i]);
                         }
@@ -1459,12 +1473,26 @@ private:
             }
         } else if constexpr (kUseFlat) {
             std::memcpy(buckets_, other.buckets_, other.capacity_ * sizeof(detail::Bucket));
+            // Ensure values array is large enough
+            if (other.size_ > values_capacity_) {
+                SlotAlloc slot_alloc(alloc_);
+                std::allocator_traits<SlotAlloc>::deallocate(slot_alloc, values_, values_capacity_);
+                values_capacity_ = other.values_capacity_;
+                values_ = std::allocator_traits<SlotAlloc>::allocate(slot_alloc, values_capacity_);
+            }
             for (size_t i = 0; i < other.size_; ++i) {
                 AllocTraits::construct(alloc_, values_ + i, std::move(other.values_[i]));
             }
         } else {
             std::memcpy(ctrl_, other.ctrl_, other.capacity_ + kGroupWidth + 1);
             std::memcpy(value_indices_, other.value_indices_, other.capacity_ * sizeof(uint32_t));
+            // Ensure values array is large enough
+            if (other.size_ > values_capacity_) {
+                SlotAlloc slot_alloc(alloc_);
+                std::allocator_traits<SlotAlloc>::deallocate(slot_alloc, values_, values_capacity_);
+                values_capacity_ = other.values_capacity_;
+                values_ = std::allocator_traits<SlotAlloc>::allocate(slot_alloc, values_capacity_);
+            }
             for (size_t i = 0; i < other.size_; ++i) {
                 AllocTraits::construct(alloc_, values_ + i, std::move(other.values_[i]));
             }

--- a/container/dense_map.hpp
+++ b/container/dense_map.hpp
@@ -28,6 +28,7 @@
 #include <iterator>
 #include <limits>
 #include <memory>
+#include <memory_resource>
 #include <new>
 #include <stdexcept>
 #include <string>
@@ -801,6 +802,10 @@ public:
     // Constructors
     dense_map() = default;
 
+    // Allocator-only constructor (required for PMR support)
+    explicit dense_map(const Allocator& alloc)
+        : alloc_(alloc) {}
+
     explicit dense_map(size_type bucket_count, const Hash& hash = Hash(),
                        const KeyEqual& equal = KeyEqual(),
                        const Allocator& alloc = Allocator())
@@ -844,6 +849,37 @@ public:
         }
     }
 
+    // Allocator-extended copy constructor (required for PMR support)
+    dense_map(const dense_map& other, const Allocator& alloc)
+        : hash_(other.hash_),
+          key_equal_(other.key_equal_),
+          alloc_(alloc) {
+        if (other.size_ > 0) {
+            initialize(other.capacity_);
+            if constexpr (kUseInline) {
+                for (size_t i = 0; i < other.capacity_; ++i) {
+                    if (detail::is_full(other.ctrl_[i])) {
+                        ctrl_[i] = other.ctrl_[i];
+                        AllocTraits::construct(alloc_, slots_ + i, other.slots_[i]);
+                    }
+                }
+            } else if constexpr (kUseFlat) {
+                std::memcpy(buckets_, other.buckets_, other.capacity_ * sizeof(detail::Bucket));
+                for (size_t i = 0; i < other.size_; ++i) {
+                    AllocTraits::construct(alloc_, values_ + i, other.values_[i]);
+                }
+            } else {
+                std::memcpy(ctrl_, other.ctrl_, other.capacity_ + kGroupWidth + 1);
+                std::memcpy(value_indices_, other.value_indices_, other.capacity_ * sizeof(uint32_t));
+                for (size_t i = 0; i < other.size_; ++i) {
+                    AllocTraits::construct(alloc_, values_ + i, other.values_[i]);
+                }
+            }
+            size_ = other.size_;
+            growth_left_ = other.growth_left_;
+        }
+    }
+
     dense_map(dense_map&& other) noexcept
         : slots_(other.slots_),
           buckets_(other.buckets_),
@@ -870,6 +906,28 @@ public:
         other.shift_ = 64;
     }
 
+    // Allocator-extended move constructor (required for PMR support)
+    dense_map(dense_map&& other, const Allocator& alloc)
+        : hash_(std::move(other.hash_)),
+          key_equal_(std::move(other.key_equal_)),
+          alloc_(alloc) {
+        if constexpr (AllocTraits::is_always_equal::value) {
+            // Allocators are always equal, can steal resources
+            move_resources_from(other);
+        } else {
+            if (alloc_ == other.alloc_) {
+                // Allocators are equal, can steal resources
+                move_resources_from(other);
+            } else {
+                // Allocators differ, must move elements individually
+                if (other.size_ > 0) {
+                    initialize(other.capacity_);
+                    move_elements_from(other);
+                }
+            }
+        }
+    }
+
     dense_map(std::initializer_list<value_type> init, size_type bucket_count = 0,
               const Hash& hash = Hash(), const KeyEqual& equal = KeyEqual(),
               const Allocator& alloc = Allocator())
@@ -886,40 +944,76 @@ public:
 
     dense_map& operator=(const dense_map& other) {
         if (this != &other) {
-            dense_map tmp(other);
-            swap(tmp);
+            if constexpr (AllocTraits::propagate_on_container_copy_assignment::value) {
+                // Allocator propagates: use allocator-extended copy constructor
+                dense_map tmp(other, other.alloc_);
+                swap(tmp);
+                alloc_ = other.alloc_;
+            } else {
+                // Allocator does not propagate (PMR): keep our allocator, copy elements
+                destroy();
+                hash_ = other.hash_;
+                key_equal_ = other.key_equal_;
+                if (other.size_ > 0) {
+                    initialize(other.capacity_);
+                    if constexpr (kUseInline) {
+                        for (size_t i = 0; i < other.capacity_; ++i) {
+                            if (detail::is_full(other.ctrl_[i])) {
+                                ctrl_[i] = other.ctrl_[i];
+                                AllocTraits::construct(alloc_, slots_ + i, other.slots_[i]);
+                            }
+                        }
+                    } else if constexpr (kUseFlat) {
+                        std::memcpy(buckets_, other.buckets_, other.capacity_ * sizeof(detail::Bucket));
+                        for (size_t i = 0; i < other.size_; ++i) {
+                            AllocTraits::construct(alloc_, values_ + i, other.values_[i]);
+                        }
+                    } else {
+                        std::memcpy(ctrl_, other.ctrl_, other.capacity_ + kGroupWidth + 1);
+                        std::memcpy(value_indices_, other.value_indices_, other.capacity_ * sizeof(uint32_t));
+                        for (size_t i = 0; i < other.size_; ++i) {
+                            AllocTraits::construct(alloc_, values_ + i, other.values_[i]);
+                        }
+                    }
+                    size_ = other.size_;
+                    growth_left_ = other.growth_left_;
+                }
+            }
         }
         return *this;
     }
 
-    dense_map& operator=(dense_map&& other) noexcept {
+    dense_map& operator=(dense_map&& other) noexcept(
+        AllocTraits::propagate_on_container_move_assignment::value ||
+        AllocTraits::is_always_equal::value) {
         if (this != &other) {
-            destroy();
-            slots_ = other.slots_;
-            buckets_ = other.buckets_;
-            value_indices_ = other.value_indices_;
-            values_ = other.values_;
-            values_capacity_ = other.values_capacity_;
-            ctrl_ = other.ctrl_;
-            size_ = other.size_;
-            capacity_ = other.capacity_;
-            growth_left_ = other.growth_left_;
-            shift_ = other.shift_;
             hash_ = std::move(other.hash_);
             key_equal_ = std::move(other.key_equal_);
+
             if constexpr (AllocTraits::propagate_on_container_move_assignment::value) {
+                // Allocator propagates: destroy our resources and steal other's
+                destroy();
                 alloc_ = std::move(other.alloc_);
+                move_resources_from(other);
+            } else if constexpr (AllocTraits::is_always_equal::value) {
+                // Allocators are always equal: can steal resources
+                destroy();
+                move_resources_from(other);
+            } else {
+                // Allocators may differ (PMR case)
+                if (alloc_ == other.alloc_) {
+                    // Allocators are equal: can steal resources
+                    destroy();
+                    move_resources_from(other);
+                } else {
+                    // Allocators differ: must move elements individually
+                    destroy();
+                    if (other.size_ > 0) {
+                        initialize(other.capacity_);
+                        move_elements_from(other);
+                    }
+                }
             }
-            other.slots_ = nullptr;
-            other.buckets_ = nullptr;
-            other.value_indices_ = nullptr;
-            other.values_ = nullptr;
-            other.values_capacity_ = 0;
-            other.ctrl_ = nullptr;
-            other.size_ = 0;
-            other.capacity_ = 0;
-            other.growth_left_ = 0;
-            other.shift_ = 64;
         }
         return *this;
     }
@@ -1327,6 +1421,56 @@ private:
         }
 
         reset_growth();
+    }
+
+    // Helper: steal resources from other (used when allocators are equal)
+    void move_resources_from(dense_map& other) noexcept {
+        slots_ = other.slots_;
+        buckets_ = other.buckets_;
+        value_indices_ = other.value_indices_;
+        values_ = other.values_;
+        values_capacity_ = other.values_capacity_;
+        ctrl_ = other.ctrl_;
+        size_ = other.size_;
+        capacity_ = other.capacity_;
+        growth_left_ = other.growth_left_;
+        shift_ = other.shift_;
+
+        other.slots_ = nullptr;
+        other.buckets_ = nullptr;
+        other.value_indices_ = nullptr;
+        other.values_ = nullptr;
+        other.values_capacity_ = 0;
+        other.ctrl_ = nullptr;
+        other.size_ = 0;
+        other.capacity_ = 0;
+        other.growth_left_ = 0;
+        other.shift_ = 64;
+    }
+
+    // Helper: move elements from other (used when allocators differ)
+    void move_elements_from(dense_map& other) {
+        if constexpr (kUseInline) {
+            for (size_t i = 0; i < other.capacity_; ++i) {
+                if (detail::is_full(other.ctrl_[i])) {
+                    ctrl_[i] = other.ctrl_[i];
+                    AllocTraits::construct(alloc_, slots_ + i, std::move(other.slots_[i]));
+                }
+            }
+        } else if constexpr (kUseFlat) {
+            std::memcpy(buckets_, other.buckets_, other.capacity_ * sizeof(detail::Bucket));
+            for (size_t i = 0; i < other.size_; ++i) {
+                AllocTraits::construct(alloc_, values_ + i, std::move(other.values_[i]));
+            }
+        } else {
+            std::memcpy(ctrl_, other.ctrl_, other.capacity_ + kGroupWidth + 1);
+            std::memcpy(value_indices_, other.value_indices_, other.capacity_ * sizeof(uint32_t));
+            for (size_t i = 0; i < other.size_; ++i) {
+                AllocTraits::construct(alloc_, values_ + i, std::move(other.values_[i]));
+            }
+        }
+        size_ = other.size_;
+        growth_left_ = other.growth_left_;
     }
 
     void destroy() {
@@ -2133,5 +2277,24 @@ void swap(dense_map<K, V, H, E, A, M>& lhs,
 // Type alias for convenience
 template <typename Key, typename Value>
 using fast_map = dense_map<Key, Value>;
+
+// ============================================================================
+// PMR (Polymorphic Memory Resource) type aliases
+// ============================================================================
+namespace pmr {
+
+template <typename Key, typename T = void, typename Hash = dense_hash<Key>,
+          typename KeyEqual = std::equal_to<Key>,
+          typename MemoryPolicy = default_memory_policy<Key, T>>
+using dense_map = stdb::container::dense_map<
+    Key, T, Hash, KeyEqual,
+    std::pmr::polymorphic_allocator<std::conditional_t<detail::is_map_v<T>, std::pair<Key, T>, Key>>,
+    MemoryPolicy>;
+
+// Convenience aliases
+template <typename Key, typename Value>
+using fast_map = dense_map<Key, Value>;
+
+}  // namespace pmr
 
 }  // namespace stdb::container

--- a/container/devectra.hpp
+++ b/container/devectra.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 #include <algorithm>
+#include <memory_resource>
 #include <stdexcept>
 
 #include "container_base.hpp"
@@ -56,12 +57,14 @@ class devectra
     using const_reference = const T&;
     using rvalue_reference = T&&;
     using allocator_type = Alloc;
+    using AllocTraits = std::allocator_traits<Alloc>;
 
    private:
     T* _buffer = nullptr;     // Start of allocated buffer
     size_type _offset = 0;    // Offset from buffer start to first element
     size_type _size = 0;      // Number of elements
     size_type _capacity = 0;  // Total buffer capacity
+    [[no_unique_address]] Alloc _alloc;
 
     static constexpr size_type kDefaultCapacity = 8;
     // Use 2x growth factor (matches libstdc++ std::vector for better performance)
@@ -82,17 +85,16 @@ class devectra
     [[nodiscard]] auto back_spare() const noexcept -> size_type { return _capacity - _offset - _size; }
 
     void allocate(size_type cap) {
-        _buffer = static_cast<T*>(std::malloc(cap * sizeof(T)));
-        if (_buffer == nullptr) [[unlikely]] {
-            throw std::bad_alloc();
-        }
+        _buffer = AllocTraits::allocate(_alloc, cap);
         _capacity = cap;
     }
 
     void deallocate() noexcept {
-        std::free(_buffer);
-        _buffer = nullptr;
-        _capacity = 0;
+        if (_buffer != nullptr) {
+            AllocTraits::deallocate(_alloc, _buffer, _capacity);
+            _buffer = nullptr;
+            _capacity = 0;
+        }
     }
 
     // Grow the buffer, centering elements to leave space at both ends
@@ -102,10 +104,7 @@ class devectra
             new_cap = kDefaultCapacity;
         }
 
-        T* new_buffer = static_cast<T*>(std::malloc(new_cap * sizeof(T)));
-        if (new_buffer == nullptr) [[unlikely]] {
-            throw std::bad_alloc();
-        }
+        T* new_buffer = AllocTraits::allocate(_alloc, new_cap);
 
         // Center elements in new buffer
         size_type new_offset = (new_cap - _size) / 2;
@@ -171,10 +170,7 @@ class devectra
             new_cap = kDefaultCapacity;
         }
 
-        T* new_buffer = static_cast<T*>(std::malloc(new_cap * sizeof(T)));
-        if (new_buffer == nullptr) [[unlikely]] {
-            throw std::bad_alloc();
-        }
+        T* new_buffer = AllocTraits::allocate(_alloc, new_cap);
 
         // Center elements in new buffer
         size_type new_offset = (new_cap - _size) / 2;
@@ -240,10 +236,7 @@ class devectra
             new_cap = kDefaultCapacity;
         }
 
-        T* new_buffer = static_cast<T*>(std::malloc(new_cap * sizeof(T)));
-        if (new_buffer == nullptr) [[unlikely]] {
-            throw std::bad_alloc();
-        }
+        T* new_buffer = AllocTraits::allocate(_alloc, new_cap);
 
         // Center elements in new buffer
         size_type new_offset = (new_cap - _size) / 2;
@@ -268,8 +261,11 @@ class devectra
     // Default constructor
     constexpr devectra() noexcept = default;
 
+    // Allocator-only constructor
+    explicit devectra(const Alloc& alloc) noexcept : _alloc(alloc) {}
+
     // Constructor with size
-    explicit devectra(size_type count) {
+    explicit devectra(size_type count, const Alloc& alloc = Alloc()) : _alloc(alloc) {
         if (count > 0) {
             allocate(count);
             _offset = 0;
@@ -279,7 +275,7 @@ class devectra
     }
 
     // Constructor with size and value
-    devectra(size_type count, const T& value) {
+    devectra(size_type count, const T& value, const Alloc& alloc = Alloc()) : _alloc(alloc) {
         if (count > 0) {
             allocate(count);
             _offset = 0;
@@ -290,7 +286,7 @@ class devectra
 
     // Constructor from iterators
     template <std::forward_iterator InputIt>
-    devectra(InputIt first, InputIt last) {
+    devectra(InputIt first, InputIt last, const Alloc& alloc = Alloc()) : _alloc(alloc) {
         auto dist = std::distance(first, last);
         if (dist > 0) {
             size_type count = static_cast<size_type>(dist);
@@ -302,10 +298,22 @@ class devectra
     }
 
     // Constructor from initializer list
-    devectra(std::initializer_list<T> init) : devectra(init.begin(), init.end()) {}
+    devectra(std::initializer_list<T> init, const Alloc& alloc = Alloc())
+        : devectra(init.begin(), init.end(), alloc) {}
 
     // Copy constructor
-    devectra(const devectra& other) {
+    devectra(const devectra& other)
+        : _alloc(AllocTraits::select_on_container_copy_construction(other._alloc)) {
+        if (other._size > 0) {
+            allocate(other._size);
+            _offset = 0;
+            _size = other._size;
+            copy_range(data_start(), other.data_start(), other.data_end());
+        }
+    }
+
+    // Allocator-extended copy constructor
+    devectra(const devectra& other, const Alloc& alloc) : _alloc(alloc) {
         if (other._size > 0) {
             allocate(other._size);
             _offset = 0;
@@ -316,11 +324,48 @@ class devectra
 
     // Move constructor
     devectra(devectra&& other) noexcept
-        : _buffer(other._buffer), _offset(other._offset), _size(other._size), _capacity(other._capacity) {
+        : _buffer(other._buffer),
+          _offset(other._offset),
+          _size(other._size),
+          _capacity(other._capacity),
+          _alloc(std::move(other._alloc)) {
         other._buffer = nullptr;
         other._offset = 0;
         other._size = 0;
         other._capacity = 0;
+    }
+
+    // Allocator-extended move constructor
+    devectra(devectra&& other, const Alloc& alloc) : _alloc(alloc) {
+        if constexpr (AllocTraits::is_always_equal::value) {
+            // Allocators always equal - can steal resources
+            _buffer = other._buffer;
+            _offset = other._offset;
+            _size = other._size;
+            _capacity = other._capacity;
+            other._buffer = nullptr;
+            other._offset = 0;
+            other._size = 0;
+            other._capacity = 0;
+        } else if (_alloc == other._alloc) {
+            // Same allocator - can steal resources
+            _buffer = other._buffer;
+            _offset = other._offset;
+            _size = other._size;
+            _capacity = other._capacity;
+            other._buffer = nullptr;
+            other._offset = 0;
+            other._size = 0;
+            other._capacity = 0;
+        } else {
+            // Different allocators - must move elements
+            if (other._size > 0) {
+                allocate(other._size);
+                _offset = 0;
+                _size = other._size;
+                (void)move_range_without_overlap(data_start(), other.data_start(), other.data_end());
+            }
+        }
     }
 
     // Copy assignment
@@ -329,11 +374,28 @@ class devectra
             return *this;
         }
 
+        constexpr bool propagate = AllocTraits::propagate_on_container_copy_assignment::value;
+        const bool alloc_equal = _alloc == other._alloc;
+
         destroy_range(data_start(), data_end());
 
-        if (other._size > _capacity) {
-            deallocate();
-            allocate(other._size);
+        // If allocators differ and we're propagating, we must reallocate
+        if constexpr (propagate) {
+            if (!alloc_equal) {
+                deallocate();
+                _alloc = other._alloc;
+                if (other._size > 0) {
+                    allocate(other._size);
+                }
+            } else if (other._size > _capacity) {
+                deallocate();
+                allocate(other._size);
+            }
+        } else {
+            if (other._size > _capacity) {
+                deallocate();
+                allocate(other._size);
+            }
         }
 
         _offset = 0;
@@ -345,24 +407,58 @@ class devectra
     }
 
     // Move assignment
-    auto operator=(devectra&& other) noexcept -> devectra& {
+    auto operator=(devectra&& other) noexcept(
+        AllocTraits::propagate_on_container_move_assignment::value ||
+        AllocTraits::is_always_equal::value) -> devectra& {
         if (this == &other) [[unlikely]] {
             return *this;
         }
 
+        constexpr bool propagate = AllocTraits::propagate_on_container_move_assignment::value;
+        constexpr bool always_equal = AllocTraits::is_always_equal::value;
+
         destroy_range(data_start(), data_end());
-        deallocate();
 
-        _buffer = other._buffer;
-        _offset = other._offset;
-        _size = other._size;
-        _capacity = other._capacity;
-
-        other._buffer = nullptr;
-        other._offset = 0;
-        other._size = 0;
-        other._capacity = 0;
-
+        if constexpr (propagate || always_equal) {
+            // Can always steal resources
+            deallocate();
+            _buffer = other._buffer;
+            _offset = other._offset;
+            _size = other._size;
+            _capacity = other._capacity;
+            if constexpr (propagate) {
+                _alloc = std::move(other._alloc);
+            }
+            other._buffer = nullptr;
+            other._offset = 0;
+            other._size = 0;
+            other._capacity = 0;
+        } else {
+            // Must check allocator equality at runtime
+            if (_alloc == other._alloc) {
+                // Same allocator - steal resources
+                deallocate();
+                _buffer = other._buffer;
+                _offset = other._offset;
+                _size = other._size;
+                _capacity = other._capacity;
+                other._buffer = nullptr;
+                other._offset = 0;
+                other._size = 0;
+                other._capacity = 0;
+            } else {
+                // Different allocators - move elements
+                if (other._size > _capacity) {
+                    deallocate();
+                    allocate(other._size);
+                }
+                _offset = 0;
+                _size = other._size;
+                if (_size > 0) {
+                    (void)move_range_without_overlap(data_start(), other.data_start(), other.data_end());
+                }
+            }
+        }
         return *this;
     }
 
@@ -385,6 +481,8 @@ class devectra
     [[nodiscard]] auto front_capacity() const noexcept -> size_type { return front_spare(); }
 
     [[nodiscard]] auto back_capacity() const noexcept -> size_type { return back_spare(); }
+
+    [[nodiscard]] auto get_allocator() const noexcept -> allocator_type { return _alloc; }
 
     void reserve(size_type new_cap) {
         if (new_cap > _capacity) {
@@ -415,8 +513,10 @@ class devectra
             return;
         }
 
-        T* new_buffer = static_cast<T*>(std::malloc(_size * sizeof(T)));
-        if (new_buffer == nullptr) [[unlikely]] {
+        T* new_buffer = nullptr;
+        try {
+            new_buffer = AllocTraits::allocate(_alloc, _size);
+        } catch (...) {
             return;  // Don't throw, just keep current allocation
         }
 
@@ -767,7 +867,18 @@ class devectra
     }
 
     // Swap
-    void swap(devectra& other) noexcept {
+    void swap(devectra& other) noexcept(
+        AllocTraits::propagate_on_container_swap::value ||
+        AllocTraits::is_always_equal::value) {
+        // For PMR: only swap if allocators are equal or propagate_on_container_swap is true
+        // UB if neither condition is met and allocators differ (per standard)
+        if constexpr (AllocTraits::propagate_on_container_swap::value) {
+            std::swap(_alloc, other._alloc);
+        }
+        // Assert allocators are equal if not propagating (UB otherwise per standard)
+        Assert(AllocTraits::propagate_on_container_swap::value ||
+                   AllocTraits::is_always_equal::value || _alloc == other._alloc,
+               "swap with unequal allocators is undefined behavior");
         std::swap(_buffer, other._buffer);
         std::swap(_offset, other._offset);
         std::swap(_size, other._size);
@@ -878,8 +989,8 @@ class devectra
 };
 
 // Comparison operators
-template <typename T>
-auto operator==(const devectra<T>& lhs, const devectra<T>& rhs) -> bool {
+template <typename T, typename Alloc>
+auto operator==(const devectra<T, Alloc>& lhs, const devectra<T, Alloc>& rhs) -> bool {
     if (lhs.size() != rhs.size()) return false;
     if (lhs.size() == 0) return true;
     // Use memcmp only for types with unique object representations (no padding)
@@ -893,8 +1004,8 @@ auto operator==(const devectra<T>& lhs, const devectra<T>& rhs) -> bool {
     }
 }
 
-template <typename T>
-auto operator<=>(const devectra<T>& lhs, const devectra<T>& rhs) -> std::strong_ordering {
+template <typename T, typename Alloc>
+auto operator<=>(const devectra<T, Alloc>& lhs, const devectra<T, Alloc>& rhs) -> std::strong_ordering {
     for (std::size_t i = 0; i < std::min(lhs.size(), rhs.size()); ++i) {
         if (lhs[i] < rhs[i]) return std::strong_ordering::less;
         if (lhs[i] > rhs[i]) return std::strong_ordering::greater;
@@ -906,23 +1017,30 @@ auto operator<=>(const devectra<T>& lhs, const devectra<T>& rhs) -> std::strong_
 
 }  // namespace stdb::container
 
+// PMR type alias
+namespace stdb::pmr {
+template <typename T>
+using devectra = container::devectra<T, std::pmr::polymorphic_allocator<T>>;
+}  // namespace stdb::pmr
+
 namespace std {
 
-template <typename T>
-constexpr void swap(stdb::container::devectra<T>& lhs, stdb::container::devectra<T>& rhs) noexcept {
+template <typename T, typename Alloc>
+constexpr void swap(stdb::container::devectra<T, Alloc>& lhs,
+                    stdb::container::devectra<T, Alloc>& rhs) noexcept(noexcept(lhs.swap(rhs))) {
     lhs.swap(rhs);
 }
 
-template <typename T, typename U>
-constexpr auto erase(stdb::container::devectra<T>& vec, const U& value) -> std::size_t {
+template <typename T, typename Alloc, typename U>
+constexpr auto erase(stdb::container::devectra<T, Alloc>& vec, const U& value) -> std::size_t {
     auto it = std::remove(vec.begin(), vec.end(), value);
     auto count = vec.end() - it;
     vec.erase(it, vec.end());
     return count;
 }
 
-template <typename T, typename Pred>
-constexpr auto erase_if(stdb::container::devectra<T>& vec, Pred pred) -> std::size_t {
+template <typename T, typename Alloc, typename Pred>
+constexpr auto erase_if(stdb::container::devectra<T, Alloc>& vec, Pred pred) -> std::size_t {
     auto it = std::remove_if(vec.begin(), vec.end(), pred);
     auto count = vec.end() - it;
     vec.erase(it, vec.end());

--- a/container/skiplist_map.hpp
+++ b/container/skiplist_map.hpp
@@ -24,6 +24,7 @@
 #include <iterator>
 #include <limits>
 #include <memory>
+#include <memory_resource>
 #include <random>
 #include <stdexcept>
 #include <utility>
@@ -504,7 +505,11 @@ class skiplist_map
     // Copy assignment
     skiplist_map& operator=(const skiplist_map& other) {
         if (this != &other) {
+            using AllocTraits = std::allocator_traits<byte_allocator_type>;
             clear();
+            if constexpr (AllocTraits::propagate_on_container_copy_assignment::value) {
+                _alloc = other._alloc;
+            }
             _comp = other._comp;
             copy_from(other);
         }
@@ -512,19 +517,52 @@ class skiplist_map
     }
 
     // Move assignment
-    skiplist_map& operator=(skiplist_map&& other) noexcept {
+    skiplist_map& operator=(skiplist_map&& other) noexcept(
+        std::allocator_traits<byte_allocator_type>::propagate_on_container_move_assignment::value ||
+        std::allocator_traits<byte_allocator_type>::is_always_equal::value) {
         if (this != &other) {
-            clear();
-            _head = other._head;
-            _size = other._size;
+            using AllocTraits = std::allocator_traits<byte_allocator_type>;
             _comp = std::move(other._comp);
-            _alloc = std::move(other._alloc);
             _rng_state = other._rng_state;
-            other._head = head_node{};
-            other._size = 0;
+
+            if constexpr (AllocTraits::propagate_on_container_move_assignment::value) {
+                // Allocator propagates: clear with old allocator, steal resources, take allocator
+                clear();
+                _alloc = std::move(other._alloc);
+                move_resources_from(other);
+            } else if constexpr (AllocTraits::is_always_equal::value) {
+                // Allocators are always equal: can steal resources
+                clear();
+                move_resources_from(other);
+            } else {
+                // Allocators may differ (PMR case)
+                if (_alloc == other._alloc) {
+                    // Allocators are equal: can steal resources
+                    clear();
+                    move_resources_from(other);
+                } else {
+                    // Allocators differ: must move elements individually
+                    clear();
+                    for (auto&& [k, v] : other) {
+                        insert(std::move(const_cast<Key&>(k)), std::move(const_cast<Value&>(v)));
+                    }
+                    other.clear();
+                }
+            }
         }
         return *this;
     }
+
+private:
+    // Helper: steal resources from other (used when allocators are equal)
+    void move_resources_from(skiplist_map& other) noexcept {
+        _head = other._head;
+        _size = other._size;
+        other._head = head_node{};
+        other._size = 0;
+    }
+
+public:
 
     // Initializer list assignment
     skiplist_map& operator=(std::initializer_list<value_type> init) {
@@ -976,11 +1014,14 @@ class skiplist_map
 
     // Swap
     void swap(skiplist_map& other) noexcept {
-        std::swap(_head, other._head);
-        std::swap(_size, other._size);
-        std::swap(_comp, other._comp);
-        std::swap(_alloc, other._alloc);
-        std::swap(_rng_state, other._rng_state);
+        using std::swap;
+        swap(_head, other._head);
+        swap(_size, other._size);
+        swap(_comp, other._comp);
+        swap(_rng_state, other._rng_state);
+        if constexpr (std::allocator_traits<byte_allocator_type>::propagate_on_container_swap::value) {
+            swap(_alloc, other._alloc);
+        }
     }
 
     // Merge
@@ -1246,3 +1287,17 @@ template <typename Key, typename Value, typename Compare = std::less<Key>>
 using skiplist_map_default = skiplist_map<Key, Value, Compare>;
 
 }  // namespace stdb::container
+
+// ============================================================================
+// PMR (Polymorphic Memory Resource) type aliases
+// ============================================================================
+namespace stdb::pmr {
+
+template <typename Key, typename Value, typename Compare = std::less<Key>,
+          uint8_t MaxLevel = 16, uint8_t Probability = 4>
+using skiplist_map = container::skiplist_map<
+    Key, Value, Compare,
+    std::pmr::polymorphic_allocator<std::pair<const Key, Value>>,
+    MaxLevel, Probability>;
+
+}  // namespace stdb::pmr

--- a/container/skiplist_set.hpp
+++ b/container/skiplist_set.hpp
@@ -545,3 +545,17 @@ template <typename Key, typename Compare = std::less<Key>>
 using skiplist_set_default = skiplist_set<Key, Compare>;
 
 }  // namespace stdb::container
+
+// ============================================================================
+// PMR (Polymorphic Memory Resource) type aliases
+// ============================================================================
+namespace stdb::pmr {
+
+template <typename Key, typename Compare = std::less<Key>,
+          uint8_t MaxLevel = 32, uint8_t Probability = 4>
+using skiplist_set = container::skiplist_set<
+    Key, Compare,
+    std::pmr::polymorphic_allocator<Key>,
+    MaxLevel, Probability>;
+
+}  // namespace stdb::pmr

--- a/container/small_vectra.hpp
+++ b/container/small_vectra.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 #include <algorithm>
+#include <memory_resource>
 
 #include "container_base.hpp"
 
@@ -54,12 +55,15 @@ class small_vectra
     static constexpr size_type inline_capacity = N;
 
    private:
+    using AllocTraits = std::allocator_traits<Alloc>;
+
     // Inline storage - properly aligned for T
     alignas(T) std::byte _inline_storage[N * sizeof(T)];
 
     T* _start;   // buffer start
     T* _finish;  // valid end (one past last element)
     T* _edge;    // buffer end (capacity boundary)
+    [[no_unique_address]] Alloc _alloc;
 
     [[nodiscard, gnu::always_inline]] auto inline_ptr() noexcept -> T* { return reinterpret_cast<T*>(_inline_storage); }
 
@@ -73,16 +77,13 @@ class small_vectra
 
     void allocate_heap(size_type cap) {
         Assert(cap > N, "allocate_heap should only be called when cap > N");
-        _start = static_cast<T*>(std::malloc(cap * sizeof(T)));
-        if (_start == nullptr) [[unlikely]] {
-            throw std::bad_alloc();
-        }
+        _start = AllocTraits::allocate(_alloc, cap);
         _edge = _start + cap;
     }
 
     void free_heap() noexcept {
         if (!is_inline()) {
-            std::free(_start);
+            AllocTraits::deallocate(_alloc, _start, capacity());
         }
     }
 
@@ -112,6 +113,7 @@ class small_vectra
         T* old_start = _start;
         T* old_finish = _finish;
         size_type old_size = size();
+        size_type old_cap = capacity();
 
         allocate_heap(new_cap);
         _finish = _start + old_size;
@@ -120,7 +122,7 @@ class small_vectra
             (void)move_range_without_overlap(_start, old_start, old_finish);
             destroy_range(old_start, old_finish);
         }
-        std::free(old_start);
+        AllocTraits::deallocate(_alloc, old_start, old_cap);
     }
 
     // Shrink heap storage to fit current size
@@ -132,12 +134,9 @@ class small_vectra
         T* old_start = _start;
         T* old_finish = _finish;
         size_type old_size = size();
+        size_type old_cap = capacity();
 
-        _start = static_cast<T*>(std::malloc(new_cap * sizeof(T)));
-        if (_start == nullptr) [[unlikely]] {
-            _start = old_start;  // Restore on failure
-            throw std::bad_alloc();
-        }
+        _start = AllocTraits::allocate(_alloc, new_cap);
         _edge = _start + new_cap;
         _finish = _start + old_size;
 
@@ -145,7 +144,7 @@ class small_vectra
             (void)move_range_without_overlap(_start, old_start, old_finish);
             destroy_range(old_start, old_finish);
         }
-        std::free(old_start);
+        AllocTraits::deallocate(_alloc, old_start, old_cap);
     }
 
     // Reallocate (handles both inline->heap and heap->larger heap)
@@ -165,17 +164,15 @@ class small_vectra
         T* old_start = _start;
         T* old_finish = _finish;
         size_type old_size = static_cast<size_type>(old_finish - old_start);
+        size_type old_cap = capacity();
         bool was_inline = is_inline();
 
         // Allocate new buffer
-        T* new_start = static_cast<T*>(std::malloc(new_cap * sizeof(T)));
-        if (new_start == nullptr) [[unlikely]] {
-            throw std::bad_alloc();
-        }
+        T* new_start = AllocTraits::allocate(_alloc, new_cap);
 
         // Construct new element first (at the end position)
         T* new_finish = new_start + old_size;
-        new (new_finish) T(std::forward<Args>(args)...);
+        AllocTraits::construct(_alloc, new_finish, std::forward<Args>(args)...);
         ++new_finish;
 
         // Relocate old elements to new buffer
@@ -185,9 +182,9 @@ class small_vectra
             } else {
                 T* dst = new_start;
                 for (T* src = old_start; src != old_finish; ++src, ++dst) {
-                    new (dst) T(std::move(*src));
+                    AllocTraits::construct(_alloc, dst, std::move(*src));
                     if constexpr (NeedsCleanUp<T>) {
-                        src->~T();
+                        AllocTraits::destroy(_alloc, src);
                     }
                 }
             }
@@ -200,7 +197,7 @@ class small_vectra
 
         // Free old buffer if on heap
         if (!was_inline) {
-            std::free(old_start);
+            AllocTraits::deallocate(_alloc, old_start, old_cap);
         }
     }
 
@@ -220,9 +217,15 @@ class small_vectra
     constexpr small_vectra() noexcept
         : _start(reinterpret_cast<T*>(_inline_storage)),
           _finish(reinterpret_cast<T*>(_inline_storage)),
-          _edge(reinterpret_cast<T*>(_inline_storage) + N) {}
+          _edge(reinterpret_cast<T*>(_inline_storage) + N),
+          _alloc() {}
 
-    constexpr explicit small_vectra([[maybe_unused]] const Alloc& alloc) noexcept : small_vectra() {}
+    // Allocator-only constructor (required for PMR support)
+    constexpr explicit small_vectra(const Alloc& alloc) noexcept
+        : _start(reinterpret_cast<T*>(_inline_storage)),
+          _finish(reinterpret_cast<T*>(_inline_storage)),
+          _edge(reinterpret_cast<T*>(_inline_storage) + N),
+          _alloc(alloc) {}
 
     // Constructor with size
     explicit small_vectra(size_type count) : small_vectra() {
@@ -266,7 +269,27 @@ class small_vectra
     small_vectra(std::initializer_list<T> init) : small_vectra(init.begin(), init.end()) {}
 
     // Copy constructor
-    small_vectra(const small_vectra& other) : small_vectra() {
+    small_vectra(const small_vectra& other)
+        : _start(reinterpret_cast<T*>(_inline_storage)),
+          _finish(reinterpret_cast<T*>(_inline_storage)),
+          _edge(reinterpret_cast<T*>(_inline_storage) + N),
+          _alloc(AllocTraits::select_on_container_copy_construction(other._alloc)) {
+        size_type other_size = other.size();
+        if (other_size > N) {
+            allocate_heap(other_size);
+        }
+        if (other_size > 0) {
+            copy_range(_start, other._start, other._finish);
+            _finish = _start + other_size;
+        }
+    }
+
+    // Allocator-extended copy constructor (required for PMR support)
+    small_vectra(const small_vectra& other, const Alloc& alloc)
+        : _start(reinterpret_cast<T*>(_inline_storage)),
+          _finish(reinterpret_cast<T*>(_inline_storage)),
+          _edge(reinterpret_cast<T*>(_inline_storage) + N),
+          _alloc(alloc) {
         size_type other_size = other.size();
         if (other_size > N) {
             allocate_heap(other_size);
@@ -278,7 +301,11 @@ class small_vectra
     }
 
     // Move constructor
-    small_vectra(small_vectra&& other) noexcept : small_vectra() {
+    small_vectra(small_vectra&& other) noexcept
+        : _start(reinterpret_cast<T*>(_inline_storage)),
+          _finish(reinterpret_cast<T*>(_inline_storage)),
+          _edge(reinterpret_cast<T*>(_inline_storage) + N),
+          _alloc(std::move(other._alloc)) {
         if (other.is_inline()) {
             // Move elements from other's inline storage to our inline storage
             size_type other_size = other.size();
@@ -300,6 +327,58 @@ class small_vectra
         }
     }
 
+    // Allocator-extended move constructor (required for PMR support)
+    small_vectra(small_vectra&& other, const Alloc& alloc)
+        : _start(reinterpret_cast<T*>(_inline_storage)),
+          _finish(reinterpret_cast<T*>(_inline_storage)),
+          _edge(reinterpret_cast<T*>(_inline_storage) + N),
+          _alloc(alloc) {
+        if constexpr (AllocTraits::is_always_equal::value) {
+            // Allocators are always equal, can steal heap resources
+            move_from_other(other);
+        } else {
+            if (_alloc == other._alloc) {
+                // Allocators are equal, can steal heap resources
+                move_from_other(other);
+            } else {
+                // Allocators differ, must move elements individually
+                size_type other_size = other.size();
+                if (other_size > N) {
+                    allocate_heap(other_size);
+                }
+                if (other_size > 0) {
+                    (void)move_range_without_overlap(_start, other._start, other._finish);
+                    destroy_range(other._start, other._finish);
+                    _finish = _start + other_size;
+                }
+                other._finish = other._start;
+            }
+        }
+    }
+
+private:
+    // Helper for move constructor when allocators are equal
+    void move_from_other(small_vectra& other) noexcept {
+        if (other.is_inline()) {
+            size_type other_size = other.size();
+            if (other_size > 0) {
+                (void)move_range_without_overlap(_start, other._start, other._finish);
+                destroy_range(other._start, other._finish);
+                _finish = _start + other_size;
+            }
+            other._finish = other._start;
+        } else {
+            _start = other._start;
+            _finish = other._finish;
+            _edge = other._edge;
+            other._start = other.inline_ptr();
+            other._finish = other._start;
+            other._edge = other._start + N;
+        }
+    }
+
+public:
+
     // Copy assignment
     auto operator=(const small_vectra& other) -> small_vectra& {
         if (this == &other) [[unlikely]] {
@@ -310,6 +389,16 @@ class small_vectra
 
         // Destroy current elements
         destroy_range(_start, _finish);
+
+        if constexpr (AllocTraits::propagate_on_container_copy_assignment::value) {
+            // Allocator propagates: may need to reallocate with new allocator
+            if (_alloc != other._alloc) {
+                free_heap();
+                _alloc = other._alloc;
+                _start = inline_ptr();
+                _edge = _start + N;
+            }
+        }
 
         if (other_size > capacity()) {
             // Need more capacity
@@ -332,17 +421,59 @@ class small_vectra
     }
 
     // Move assignment
-    auto operator=(small_vectra&& other) noexcept -> small_vectra& {
+    auto operator=(small_vectra&& other) noexcept(
+        AllocTraits::propagate_on_container_move_assignment::value ||
+        AllocTraits::is_always_equal::value) -> small_vectra& {
         if (this == &other) [[unlikely]] {
             return *this;
         }
 
-        // Destroy current elements and free heap if needed
+        // Destroy current elements
         destroy_range(_start, _finish);
-        free_heap();
 
+        if constexpr (AllocTraits::propagate_on_container_move_assignment::value) {
+            // Allocator propagates: free with old allocator, take new allocator, steal resources
+            free_heap();
+            _alloc = std::move(other._alloc);
+            move_assign_from(other);
+        } else if constexpr (AllocTraits::is_always_equal::value) {
+            // Allocators are always equal: can steal heap resources
+            free_heap();
+            move_assign_from(other);
+        } else {
+            // Allocators may differ (PMR case)
+            if (_alloc == other._alloc) {
+                // Allocators are equal: can steal heap resources
+                free_heap();
+                move_assign_from(other);
+            } else {
+                // Allocators differ: must move elements individually
+                size_type other_size = other.size();
+                if (other_size > capacity()) {
+                    free_heap();
+                    if (other_size > N) {
+                        allocate_heap(other_size);
+                    } else {
+                        _start = inline_ptr();
+                        _edge = _start + N;
+                    }
+                }
+                if (other_size > 0) {
+                    (void)move_range_without_overlap(_start, other._start, other._finish);
+                    destroy_range(other._start, other._finish);
+                }
+                _finish = _start + other_size;
+                other._finish = other._start;
+            }
+        }
+
+        return *this;
+    }
+
+private:
+    // Helper for move assignment when we can steal resources
+    void move_assign_from(small_vectra& other) noexcept {
         if (other.is_inline()) {
-            // Move elements from other's inline storage
             _start = inline_ptr();
             _edge = _start + N;
             size_type other_size = other.size();
@@ -353,18 +484,16 @@ class small_vectra
             _finish = _start + other_size;
             other._finish = other._start;
         } else {
-            // Steal heap pointer
             _start = other._start;
             _finish = other._finish;
             _edge = other._edge;
-            // Reset other to inline
             other._start = other.inline_ptr();
             other._finish = other._start;
             other._edge = other._start + N;
         }
-
-        return *this;
     }
+
+public:
 
     ~small_vectra() {
         destroy_range(_start, _finish);
@@ -404,13 +533,14 @@ class small_vectra
             // Can move back to inline storage
             T* old_start = _start;
             T* old_finish = _finish;
+            size_type old_cap = capacity();
             _start = inline_ptr();
             _edge = _start + N;
             if (sz > 0) {
                 (void)move_range_without_overlap(_start, old_start, old_finish);
             }
             _finish = _start + sz;
-            std::free(old_start);
+            AllocTraits::deallocate(_alloc, old_start, old_cap);
         } else if (sz > N && sz < capacity()) {
             // Shrink heap allocation
             shrink_heap(sz);
@@ -853,7 +983,15 @@ class small_vectra
             *this = std::move(other);
             other = std::move(temp);
         }
+
+        // Swap allocators if propagate_on_container_swap is true
+        if constexpr (AllocTraits::propagate_on_container_swap::value) {
+            std::swap(_alloc, other._alloc);
+        }
     }
+
+    // Get allocator
+    [[nodiscard]] allocator_type get_allocator() const noexcept { return _alloc; }
 
    private:
     // Helper for backward move (handles overlap correctly)
@@ -918,6 +1056,16 @@ auto operator<=>(const small_vectra<T, N>& lhs, const small_vectra<T, N>& rhs) -
 }
 
 }  // namespace stdb::container
+
+// ============================================================================
+// PMR (Polymorphic Memory Resource) type aliases
+// ============================================================================
+namespace stdb::pmr {
+
+template <typename T, std::size_t N = (sizeof(T) >= 64 ? 1 : 64 / sizeof(T))>
+using small_vectra = container::small_vectra<T, N, std::pmr::polymorphic_allocator<T>>;
+
+}  // namespace stdb::pmr
 
 namespace std {
 

--- a/tests/btree_map_test.cc
+++ b/tests/btree_map_test.cc
@@ -2337,4 +2337,187 @@ TEST_CASE("btree_map::copy_constructor_comprehensive") {
     }
 }
 
+// ============================================================================
+// PMR (Polymorphic Memory Resource) Tests
+// ============================================================================
+
+#ifdef BTREE_HAS_PMR
+
+TEST_CASE("btree_map::pmr") {
+    SUBCASE("basic operations with monotonic_buffer_resource") {
+        std::array<std::byte, 8192> buffer;
+        std::pmr::monotonic_buffer_resource resource(buffer.data(), buffer.size(),
+                                                     std::pmr::null_memory_resource());
+
+        stdb::pmr::btree_map<int, std::string> map(&resource);
+
+        map[1] = "one";
+        map[2] = "two";
+        map[3] = "three";
+
+        CHECK_EQ(map.size(), 3);
+        CHECK_EQ(map[1], "one");
+        CHECK_EQ(map[2], "two");
+        CHECK_EQ(map[3], "three");
+
+        map.erase(2);
+        CHECK_EQ(map.size(), 2);
+        CHECK(map.find(2) == map.end());
+    }
+
+    SUBCASE("allocator-only constructor") {
+        std::pmr::monotonic_buffer_resource resource;
+        stdb::pmr::btree_map<int, int> map(&resource);
+
+        CHECK(map.empty());
+        CHECK_EQ(map.size(), 0);
+
+        map[42] = 100;
+        CHECK_EQ(map.size(), 1);
+        CHECK_EQ(map[42], 100);
+    }
+
+    SUBCASE("allocator-extended copy constructor") {
+        std::pmr::monotonic_buffer_resource resource1;
+        std::pmr::monotonic_buffer_resource resource2;
+
+        stdb::pmr::btree_map<int, int> map1(&resource1);
+        map1[1] = 10;
+        map1[2] = 20;
+
+        stdb::pmr::btree_map<int, int> map2(map1, &resource2);
+
+        CHECK_EQ(map2.size(), 2);
+        CHECK_EQ(map2[1], 10);
+        CHECK_EQ(map2[2], 20);
+        CHECK_EQ(map2.get_allocator().resource(), &resource2);
+    }
+
+    SUBCASE("allocator-extended move constructor - same resource") {
+        std::pmr::monotonic_buffer_resource resource;
+
+        stdb::pmr::btree_map<int, int> map1(&resource);
+        map1[1] = 10;
+        map1[2] = 20;
+
+        stdb::pmr::btree_map<int, int> map2(std::move(map1), &resource);
+
+        CHECK_EQ(map2.size(), 2);
+        CHECK_EQ(map2[1], 10);
+        CHECK_EQ(map2[2], 20);
+        CHECK(map1.empty());  // Resources were stolen
+    }
+
+    SUBCASE("allocator-extended move constructor - different resource") {
+        std::pmr::monotonic_buffer_resource resource1;
+        std::pmr::monotonic_buffer_resource resource2;
+
+        stdb::pmr::btree_map<int, int> map1(&resource1);
+        map1[1] = 10;
+        map1[2] = 20;
+
+        stdb::pmr::btree_map<int, int> map2(std::move(map1), &resource2);
+
+        CHECK_EQ(map2.size(), 2);
+        CHECK_EQ(map2[1], 10);
+        CHECK_EQ(map2[2], 20);
+        CHECK_EQ(map2.get_allocator().resource(), &resource2);
+    }
+
+    SUBCASE("copy assignment - keeps allocator") {
+        std::pmr::monotonic_buffer_resource resource1;
+        std::pmr::monotonic_buffer_resource resource2;
+
+        stdb::pmr::btree_map<int, int> map1(&resource1);
+        map1[1] = 10;
+        map1[2] = 20;
+
+        stdb::pmr::btree_map<int, int> map2(&resource2);
+        map2[3] = 30;
+
+        map2 = map1;
+
+        CHECK_EQ(map2.size(), 2);
+        CHECK_EQ(map2[1], 10);
+        CHECK_EQ(map2[2], 20);
+        CHECK_EQ(map2.get_allocator().resource(), &resource2);  // Kept original allocator
+    }
+
+    SUBCASE("move assignment - same resource") {
+        std::pmr::monotonic_buffer_resource resource;
+
+        stdb::pmr::btree_map<int, int> map1(&resource);
+        map1[1] = 10;
+        map1[2] = 20;
+
+        stdb::pmr::btree_map<int, int> map2(&resource);
+        map2[3] = 30;
+
+        map2 = std::move(map1);
+
+        CHECK_EQ(map2.size(), 2);
+        CHECK_EQ(map2[1], 10);
+        CHECK_EQ(map2[2], 20);
+        CHECK(map1.empty());  // Resources were stolen
+    }
+
+    SUBCASE("move assignment - different resource") {
+        std::pmr::monotonic_buffer_resource resource1;
+        std::pmr::monotonic_buffer_resource resource2;
+
+        stdb::pmr::btree_map<int, int> map1(&resource1);
+        map1[1] = 10;
+        map1[2] = 20;
+
+        stdb::pmr::btree_map<int, int> map2(&resource2);
+        map2[3] = 30;
+
+        map2 = std::move(map1);
+
+        CHECK_EQ(map2.size(), 2);
+        CHECK_EQ(map2[1], 10);
+        CHECK_EQ(map2[2], 20);
+        CHECK_EQ(map2.get_allocator().resource(), &resource2);  // Kept original allocator
+    }
+
+    SUBCASE("string keys with PMR") {
+        std::pmr::monotonic_buffer_resource resource;
+        stdb::pmr::btree_map<std::string, int> map(&resource);
+
+        map["hello"] = 1;
+        map["world"] = 2;
+        map["test"] = 3;
+
+        CHECK_EQ(map.size(), 3);
+        CHECK_EQ(map["hello"], 1);
+        CHECK_EQ(map["world"], 2);
+        CHECK_EQ(map["test"], 3);
+
+        int count = 0;
+        for (const auto& [key, value] : map) {
+            (void)key;
+            (void)value;
+            ++count;
+        }
+        CHECK_EQ(count, 3);
+    }
+
+    SUBCASE("btree_set with PMR") {
+        std::pmr::monotonic_buffer_resource resource;
+        stdb::pmr::btree_set<int> set(&resource);
+
+        set.insert(1);
+        set.insert(2);
+        set.insert(3);
+
+        CHECK_EQ(set.size(), 3);
+        CHECK(set.contains(1));
+        CHECK(set.contains(2));
+        CHECK(set.contains(3));
+        CHECK(!set.contains(4));
+    }
+}
+
+#endif  // BTREE_HAS_PMR
+
 }  // namespace stdb::container

--- a/tests/concurrent_skiplist_test.cc
+++ b/tests/concurrent_skiplist_test.cc
@@ -1,0 +1,305 @@
+/*
+ * Copyright 2025 ClapDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "container/concurrent_skiplist.hpp"
+
+#include <doctest/doctest.h>
+
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace stdb::container {
+// NOLINTBEGIN
+
+TEST_CASE("concurrent_skiplist::basic") {
+    SUBCASE("default constructor") {
+        concurrent_skiplist<int, std::string> sl;
+        CHECK(sl.empty());
+        CHECK_EQ(sl.size(), 0);
+    }
+
+    SUBCASE("insert and find") {
+        concurrent_skiplist<int, std::string> sl;
+        CHECK(sl.insert(1, "one"));
+        CHECK(sl.insert(2, "two"));
+        CHECK(sl.insert(3, "three"));
+
+        CHECK_EQ(sl.size(), 3);
+
+        auto v1 = sl.find(1);
+        CHECK(v1.has_value());
+        CHECK_EQ(*v1, "one");
+
+        auto v2 = sl.find(2);
+        CHECK(v2.has_value());
+        CHECK_EQ(*v2, "two");
+
+        auto v3 = sl.find(3);
+        CHECK(v3.has_value());
+        CHECK_EQ(*v3, "three");
+
+        auto v4 = sl.find(4);
+        CHECK_FALSE(v4.has_value());
+    }
+
+    SUBCASE("contains") {
+        concurrent_skiplist<int, int> sl;
+        sl.insert(10, 100);
+        sl.insert(20, 200);
+
+        CHECK(sl.contains(10));
+        CHECK(sl.contains(20));
+        CHECK_FALSE(sl.contains(30));
+    }
+
+    SUBCASE("duplicate insert returns false") {
+        concurrent_skiplist<int, std::string> sl;
+        CHECK(sl.insert(1, "one"));
+        CHECK_FALSE(sl.insert(1, "uno"));  // duplicate key
+
+        auto v = sl.find(1);
+        CHECK(v.has_value());
+        CHECK_EQ(*v, "one");  // original value preserved
+    }
+
+    SUBCASE("erase") {
+        concurrent_skiplist<int, std::string> sl;
+        sl.insert(1, "one");
+        sl.insert(2, "two");
+        sl.insert(3, "three");
+
+        CHECK(sl.erase(2));
+        CHECK_FALSE(sl.contains(2));
+        CHECK_EQ(sl.size(), 2);
+
+        CHECK_FALSE(sl.erase(2));  // already erased
+        CHECK_FALSE(sl.erase(100));  // never existed
+    }
+
+    SUBCASE("for_each") {
+        concurrent_skiplist<int, int> sl;
+        sl.insert(1, 10);
+        sl.insert(2, 20);
+        sl.insert(3, 30);
+
+        int sum_keys = 0;
+        int sum_values = 0;
+        sl.for_each([&](const int& k, const int& v) {
+            sum_keys += k;
+            sum_values += v;
+        });
+
+        CHECK_EQ(sum_keys, 6);
+        CHECK_EQ(sum_values, 60);
+    }
+
+    SUBCASE("move insert") {
+        concurrent_skiplist<std::string, std::string> sl;
+        std::string key = "key";
+        std::string value = "value";
+
+        CHECK(sl.insert(std::move(key), std::move(value)));
+        CHECK(key.empty());  // moved from
+        CHECK(value.empty());
+
+        auto v = sl.find("key");
+        CHECK(v.has_value());
+        CHECK_EQ(*v, "value");
+    }
+}
+
+TEST_CASE("concurrent_skiplist::pmr") {
+    SUBCASE("pmr type alias exists") {
+        // Use synchronized_pool_resource for thread-safety
+        std::pmr::synchronized_pool_resource pool;
+        stdb::pmr::concurrent_skiplist<int, std::string> sl(&pool);
+
+        CHECK(sl.insert(1, "one"));
+        CHECK(sl.insert(2, "two"));
+
+        CHECK_EQ(sl.size(), 2);
+        CHECK(sl.contains(1));
+        CHECK(sl.contains(2));
+
+        auto v = sl.find(1);
+        CHECK(v.has_value());
+        CHECK_EQ(*v, "one");
+    }
+
+    SUBCASE("allocator constructor") {
+        std::pmr::synchronized_pool_resource pool;
+        std::pmr::polymorphic_allocator<std::pair<const int, int>> alloc(&pool);
+
+        concurrent_skiplist<int, int, std::less<int>,
+                           std::pmr::polymorphic_allocator<std::pair<const int, int>>> sl(alloc);
+
+        sl.insert(10, 100);
+        sl.insert(20, 200);
+
+        CHECK_EQ(sl.size(), 2);
+        CHECK(sl.get_allocator().resource() == &pool);
+    }
+
+    SUBCASE("get_allocator returns correct allocator") {
+        std::pmr::synchronized_pool_resource pool;
+        stdb::pmr::concurrent_skiplist<int, int> sl(&pool);
+
+        auto alloc = sl.get_allocator();
+        CHECK(alloc.resource() == &pool);
+    }
+
+    SUBCASE("pmr erase works correctly") {
+        std::pmr::synchronized_pool_resource pool;
+        stdb::pmr::concurrent_skiplist<int, std::string> sl(&pool);
+
+        sl.insert(1, "one");
+        sl.insert(2, "two");
+        sl.insert(3, "three");
+
+        CHECK(sl.erase(2));
+        CHECK_FALSE(sl.contains(2));
+        CHECK_EQ(sl.size(), 2);
+    }
+
+    SUBCASE("pmr concurrent_skiplist_map alias") {
+        std::pmr::synchronized_pool_resource pool;
+        stdb::pmr::concurrent_skiplist_map<std::string, int> sl(&pool);
+
+        sl.insert("one", 1);
+        sl.insert("two", 2);
+
+        CHECK_EQ(sl.size(), 2);
+        CHECK(sl.contains("one"));
+
+        auto v = sl.find("two");
+        CHECK(v.has_value());
+        CHECK_EQ(*v, 2);
+    }
+
+    SUBCASE("pmr with many insertions") {
+        std::pmr::synchronized_pool_resource pool;
+        stdb::pmr::concurrent_skiplist<int, int> sl(&pool);
+
+        constexpr int N = 1000;
+        for (int i = 0; i < N; ++i) {
+            CHECK(sl.insert(i, i * 10));
+        }
+
+        CHECK_EQ(sl.size(), N);
+
+        for (int i = 0; i < N; ++i) {
+            auto v = sl.find(i);
+            CHECK(v.has_value());
+            CHECK_EQ(*v, i * 10);
+        }
+    }
+}
+
+TEST_CASE("concurrent_skiplist::concurrent") {
+    SUBCASE("concurrent inserts") {
+        concurrent_skiplist<int, int> sl;
+        constexpr int num_threads = 4;
+        constexpr int ops_per_thread = 1000;
+
+        std::vector<std::thread> threads;
+        for (int t = 0; t < num_threads; ++t) {
+            threads.emplace_back([&sl, t]() {
+                for (int i = 0; i < ops_per_thread; ++i) {
+                    int key = t * ops_per_thread + i;
+                    sl.insert(key, key * 10);
+                }
+            });
+        }
+
+        for (auto& th : threads) {
+            th.join();
+        }
+
+        CHECK_EQ(sl.size(), num_threads * ops_per_thread);
+    }
+
+    SUBCASE("concurrent inserts and finds") {
+        concurrent_skiplist<int, int> sl;
+
+        // Pre-populate
+        for (int i = 0; i < 100; ++i) {
+            sl.insert(i, i);
+        }
+
+        std::atomic<bool> done{false};
+        std::atomic<int> found_count{0};
+
+        // Reader thread
+        std::thread reader([&]() {
+            while (!done.load(std::memory_order_relaxed)) {
+                for (int i = 0; i < 100; ++i) {
+                    if (sl.contains(i)) {
+                        found_count.fetch_add(1, std::memory_order_relaxed);
+                    }
+                }
+            }
+        });
+
+        // Writer thread
+        std::thread writer([&]() {
+            for (int i = 100; i < 200; ++i) {
+                sl.insert(i, i);
+            }
+            done.store(true, std::memory_order_relaxed);
+        });
+
+        reader.join();
+        writer.join();
+
+        CHECK_EQ(sl.size(), 200);
+        CHECK_GT(found_count.load(), 0);
+    }
+
+    SUBCASE("concurrent with pmr") {
+        std::pmr::synchronized_pool_resource pool;
+        stdb::pmr::concurrent_skiplist<int, int> sl(&pool);
+
+        constexpr int num_threads = 4;
+        constexpr int ops_per_thread = 500;
+
+        std::vector<std::thread> threads;
+        for (int t = 0; t < num_threads; ++t) {
+            threads.emplace_back([&sl, t]() {
+                for (int i = 0; i < ops_per_thread; ++i) {
+                    int key = t * ops_per_thread + i;
+                    sl.insert(key, key);
+                }
+            });
+        }
+
+        for (auto& th : threads) {
+            th.join();
+        }
+
+        CHECK_EQ(sl.size(), num_threads * ops_per_thread);
+
+        // Verify all values
+        for (int i = 0; i < num_threads * ops_per_thread; ++i) {
+            auto v = sl.find(i);
+            CHECK(v.has_value());
+            CHECK_EQ(*v, i);
+        }
+    }
+}
+
+// NOLINTEND
+}  // namespace stdb::container

--- a/tests/dense_map_test.cc
+++ b/tests/dense_map_test.cc
@@ -1462,4 +1462,206 @@ TEST_CASE("dense_map::simd_bitmask_correctness") {
     }
 }
 
+// ============================================================================
+// PMR (Polymorphic Memory Resource) Tests
+// ============================================================================
+
+TEST_CASE("dense_map::pmr") {
+    SUBCASE("basic operations with monotonic_buffer_resource") {
+        // Create a buffer and monotonic resource
+        std::array<std::byte, 4096> buffer;
+        std::pmr::monotonic_buffer_resource resource(buffer.data(), buffer.size(),
+                                                     std::pmr::null_memory_resource());
+
+        // Create a PMR dense_map
+        pmr::dense_map<int, std::string> map(&resource);
+
+        // Basic insert and find
+        map[1] = "one";
+        map[2] = "two";
+        map[3] = "three";
+
+        CHECK_EQ(map.size(), 3);
+        CHECK_EQ(map[1], "one");
+        CHECK_EQ(map[2], "two");
+        CHECK_EQ(map[3], "three");
+
+        // Erase
+        map.erase(2);
+        CHECK_EQ(map.size(), 2);
+        CHECK(map.find(2) == map.end());
+    }
+
+    SUBCASE("allocator-only constructor") {
+        std::pmr::monotonic_buffer_resource resource;
+        pmr::dense_map<int, int> map(&resource);
+
+        CHECK(map.empty());
+        CHECK_EQ(map.size(), 0);
+
+        map[42] = 100;
+        CHECK_EQ(map.size(), 1);
+        CHECK_EQ(map[42], 100);
+    }
+
+    SUBCASE("copy constructor uses select_on_container_copy_construction") {
+        std::pmr::monotonic_buffer_resource resource1;
+        std::pmr::monotonic_buffer_resource resource2;
+
+        pmr::dense_map<int, int> map1(&resource1);
+        map1[1] = 10;
+        map1[2] = 20;
+
+        // Copy constructor - for PMR, uses default memory resource (not resource1)
+        pmr::dense_map<int, int> map2(map1);
+
+        CHECK_EQ(map2.size(), 2);
+        CHECK_EQ(map2[1], 10);
+        CHECK_EQ(map2[2], 20);
+    }
+
+    SUBCASE("allocator-extended copy constructor") {
+        std::pmr::monotonic_buffer_resource resource1;
+        std::pmr::monotonic_buffer_resource resource2;
+
+        pmr::dense_map<int, int> map1(&resource1);
+        map1[1] = 10;
+        map1[2] = 20;
+
+        // Copy with explicit allocator
+        pmr::dense_map<int, int> map2(map1, &resource2);
+
+        CHECK_EQ(map2.size(), 2);
+        CHECK_EQ(map2[1], 10);
+        CHECK_EQ(map2[2], 20);
+        CHECK_EQ(map2.get_allocator().resource(), &resource2);
+    }
+
+    SUBCASE("allocator-extended move constructor - same resource") {
+        std::pmr::monotonic_buffer_resource resource;
+
+        pmr::dense_map<int, int> map1(&resource);
+        map1[1] = 10;
+        map1[2] = 20;
+
+        // Move with same allocator - should steal resources
+        pmr::dense_map<int, int> map2(std::move(map1), &resource);
+
+        CHECK_EQ(map2.size(), 2);
+        CHECK_EQ(map2[1], 10);
+        CHECK_EQ(map2[2], 20);
+        CHECK(map1.empty());  // Resources were stolen
+    }
+
+    SUBCASE("allocator-extended move constructor - different resource") {
+        std::pmr::monotonic_buffer_resource resource1;
+        std::pmr::monotonic_buffer_resource resource2;
+
+        pmr::dense_map<int, int> map1(&resource1);
+        map1[1] = 10;
+        map1[2] = 20;
+
+        // Move with different allocator - must copy elements
+        pmr::dense_map<int, int> map2(std::move(map1), &resource2);
+
+        CHECK_EQ(map2.size(), 2);
+        CHECK_EQ(map2[1], 10);
+        CHECK_EQ(map2[2], 20);
+        CHECK_EQ(map2.get_allocator().resource(), &resource2);
+    }
+
+    SUBCASE("copy assignment - keeps allocator") {
+        std::pmr::monotonic_buffer_resource resource1;
+        std::pmr::monotonic_buffer_resource resource2;
+
+        pmr::dense_map<int, int> map1(&resource1);
+        map1[1] = 10;
+        map1[2] = 20;
+
+        pmr::dense_map<int, int> map2(&resource2);
+        map2[3] = 30;
+
+        // Copy assignment - PMR does not propagate allocator
+        map2 = map1;
+
+        CHECK_EQ(map2.size(), 2);
+        CHECK_EQ(map2[1], 10);
+        CHECK_EQ(map2[2], 20);
+        CHECK_EQ(map2.get_allocator().resource(), &resource2);  // Kept original allocator
+    }
+
+    SUBCASE("move assignment - same resource") {
+        std::pmr::monotonic_buffer_resource resource;
+
+        pmr::dense_map<int, int> map1(&resource);
+        map1[1] = 10;
+        map1[2] = 20;
+
+        pmr::dense_map<int, int> map2(&resource);
+        map2[3] = 30;
+
+        // Move assignment - same resource, should steal resources
+        map2 = std::move(map1);
+
+        CHECK_EQ(map2.size(), 2);
+        CHECK_EQ(map2[1], 10);
+        CHECK_EQ(map2[2], 20);
+        CHECK(map1.empty());  // Resources were stolen
+    }
+
+    SUBCASE("move assignment - different resource") {
+        std::pmr::monotonic_buffer_resource resource1;
+        std::pmr::monotonic_buffer_resource resource2;
+
+        pmr::dense_map<int, int> map1(&resource1);
+        map1[1] = 10;
+        map1[2] = 20;
+
+        pmr::dense_map<int, int> map2(&resource2);
+        map2[3] = 30;
+
+        // Move assignment - different resource, must move elements
+        map2 = std::move(map1);
+
+        CHECK_EQ(map2.size(), 2);
+        CHECK_EQ(map2[1], 10);
+        CHECK_EQ(map2[2], 20);
+        CHECK_EQ(map2.get_allocator().resource(), &resource2);  // Kept original allocator
+    }
+
+    SUBCASE("string keys with PMR") {
+        std::pmr::monotonic_buffer_resource resource;
+        pmr::dense_map<std::string, int> map(&resource);
+
+        map["hello"] = 1;
+        map["world"] = 2;
+        map["test"] = 3;
+
+        CHECK_EQ(map.size(), 3);
+        CHECK_EQ(map["hello"], 1);
+        CHECK_EQ(map["world"], 2);
+        CHECK_EQ(map["test"], 3);
+
+        // Test iteration
+        int count = 0;
+        for (const auto& [key, value] : map) {
+            (void)key;
+            (void)value;
+            ++count;
+        }
+        CHECK_EQ(count, 3);
+    }
+
+    SUBCASE("pmr::fast_map alias") {
+        std::pmr::monotonic_buffer_resource resource;
+        pmr::fast_map<int, std::string> map(&resource);
+
+        map[1] = "one";
+        map[2] = "two";
+
+        CHECK_EQ(map.size(), 2);
+        CHECK_EQ(map[1], "one");
+    }
+}
+
 }  // namespace stdb::container

--- a/tests/devectra_test.cc
+++ b/tests/devectra_test.cc
@@ -619,5 +619,208 @@ TEST_CASE("devectra::deque_like_usage") {
     }
 }
 
+TEST_CASE("devectra::pmr") {
+    SUBCASE("pmr type alias exists") {
+        std::array<std::byte, 1024> buffer;
+        std::pmr::monotonic_buffer_resource mbr(buffer.data(), buffer.size());
+        stdb::pmr::devectra<int> dv(&mbr);
+        dv.push_back(1);
+        dv.push_back(2);
+        dv.push_front(0);
+        CHECK_EQ(dv.size(), 3);
+        CHECK_EQ(dv[0], 0);
+        CHECK_EQ(dv[1], 1);
+        CHECK_EQ(dv[2], 2);
+    }
+
+    SUBCASE("allocator-only constructor") {
+        std::array<std::byte, 1024> buffer;
+        std::pmr::monotonic_buffer_resource mbr(buffer.data(), buffer.size());
+        std::pmr::polymorphic_allocator<int> alloc(&mbr);
+        devectra<int, std::pmr::polymorphic_allocator<int>> dv(alloc);
+        CHECK(dv.empty());
+        CHECK(dv.get_allocator() == alloc);
+    }
+
+    SUBCASE("constructor with size and allocator") {
+        std::array<std::byte, 1024> buffer;
+        std::pmr::monotonic_buffer_resource mbr(buffer.data(), buffer.size());
+        std::pmr::polymorphic_allocator<int> alloc(&mbr);
+        devectra<int, std::pmr::polymorphic_allocator<int>> dv(5, alloc);
+        CHECK_EQ(dv.size(), 5);
+        CHECK(dv.get_allocator() == alloc);
+    }
+
+    SUBCASE("constructor with size, value and allocator") {
+        std::array<std::byte, 1024> buffer;
+        std::pmr::monotonic_buffer_resource mbr(buffer.data(), buffer.size());
+        std::pmr::polymorphic_allocator<int> alloc(&mbr);
+        devectra<int, std::pmr::polymorphic_allocator<int>> dv(5, 42, alloc);
+        CHECK_EQ(dv.size(), 5);
+        for (int i = 0; i < 5; ++i) {
+            CHECK_EQ(dv[i], 42);
+        }
+        CHECK(dv.get_allocator() == alloc);
+    }
+
+    SUBCASE("copy constructor uses select_on_container_copy_construction") {
+        std::array<std::byte, 1024> buffer1;
+        std::pmr::monotonic_buffer_resource mbr1(buffer1.data(), buffer1.size());
+        std::pmr::polymorphic_allocator<int> alloc1(&mbr1);
+
+        devectra<int, std::pmr::polymorphic_allocator<int>> dv1(alloc1);
+        dv1.push_back(1);
+        dv1.push_back(2);
+        dv1.push_back(3);
+
+        // Copy constructor - PMR uses default resource for copies
+        devectra<int, std::pmr::polymorphic_allocator<int>> dv2(dv1);
+        CHECK_EQ(dv2.size(), 3);
+        CHECK_EQ(dv2[0], 1);
+        // PMR polymorphic_allocator selects default resource for copies
+        CHECK(dv2.get_allocator().resource() == std::pmr::get_default_resource());
+    }
+
+    SUBCASE("allocator-extended copy constructor") {
+        std::array<std::byte, 1024> buffer1, buffer2;
+        std::pmr::monotonic_buffer_resource mbr1(buffer1.data(), buffer1.size());
+        std::pmr::monotonic_buffer_resource mbr2(buffer2.data(), buffer2.size());
+        std::pmr::polymorphic_allocator<int> alloc1(&mbr1);
+        std::pmr::polymorphic_allocator<int> alloc2(&mbr2);
+
+        devectra<int, std::pmr::polymorphic_allocator<int>> dv1(alloc1);
+        dv1.push_back(1);
+        dv1.push_back(2);
+
+        devectra<int, std::pmr::polymorphic_allocator<int>> dv2(dv1, alloc2);
+        CHECK_EQ(dv2.size(), 2);
+        CHECK_EQ(dv2[0], 1);
+        CHECK_EQ(dv2[1], 2);
+        CHECK(dv2.get_allocator() == alloc2);
+    }
+
+    SUBCASE("allocator-extended move constructor with same allocator") {
+        std::array<std::byte, 2048> buffer;
+        std::pmr::monotonic_buffer_resource mbr(buffer.data(), buffer.size());
+        std::pmr::polymorphic_allocator<int> alloc(&mbr);
+
+        devectra<int, std::pmr::polymorphic_allocator<int>> dv1(alloc);
+        dv1.push_back(1);
+        dv1.push_back(2);
+        auto* old_data = dv1.data();
+
+        devectra<int, std::pmr::polymorphic_allocator<int>> dv2(std::move(dv1), alloc);
+        CHECK_EQ(dv2.size(), 2);
+        CHECK_EQ(dv2.data(), old_data);  // Resources stolen
+        CHECK(dv1.empty());
+    }
+
+    SUBCASE("allocator-extended move constructor with different allocator") {
+        std::array<std::byte, 1024> buffer1, buffer2;
+        std::pmr::monotonic_buffer_resource mbr1(buffer1.data(), buffer1.size());
+        std::pmr::monotonic_buffer_resource mbr2(buffer2.data(), buffer2.size());
+        std::pmr::polymorphic_allocator<int> alloc1(&mbr1);
+        std::pmr::polymorphic_allocator<int> alloc2(&mbr2);
+
+        devectra<int, std::pmr::polymorphic_allocator<int>> dv1(alloc1);
+        dv1.push_back(1);
+        dv1.push_back(2);
+        auto* old_data = dv1.data();
+
+        devectra<int, std::pmr::polymorphic_allocator<int>> dv2(std::move(dv1), alloc2);
+        CHECK_EQ(dv2.size(), 2);
+        CHECK_NE(dv2.data(), old_data);  // Cannot steal, must copy
+        CHECK_EQ(dv2[0], 1);
+        CHECK_EQ(dv2[1], 2);
+        CHECK(dv2.get_allocator() == alloc2);
+    }
+
+    SUBCASE("copy assignment does not propagate allocator for PMR") {
+        std::array<std::byte, 1024> buffer1, buffer2;
+        std::pmr::monotonic_buffer_resource mbr1(buffer1.data(), buffer1.size());
+        std::pmr::monotonic_buffer_resource mbr2(buffer2.data(), buffer2.size());
+        std::pmr::polymorphic_allocator<int> alloc1(&mbr1);
+        std::pmr::polymorphic_allocator<int> alloc2(&mbr2);
+
+        devectra<int, std::pmr::polymorphic_allocator<int>> dv1(alloc1);
+        dv1.push_back(1);
+        dv1.push_back(2);
+
+        devectra<int, std::pmr::polymorphic_allocator<int>> dv2(alloc2);
+        dv2.push_back(10);
+
+        dv2 = dv1;
+        CHECK_EQ(dv2.size(), 2);
+        CHECK_EQ(dv2[0], 1);
+        // Allocator not propagated for PMR
+        CHECK(dv2.get_allocator() == alloc2);
+    }
+
+    SUBCASE("move assignment with same allocator steals resources") {
+        std::array<std::byte, 2048> buffer;
+        std::pmr::monotonic_buffer_resource mbr(buffer.data(), buffer.size());
+        std::pmr::polymorphic_allocator<int> alloc(&mbr);
+
+        devectra<int, std::pmr::polymorphic_allocator<int>> dv1(alloc);
+        dv1.push_back(1);
+        dv1.push_back(2);
+        auto* old_data = dv1.data();
+
+        devectra<int, std::pmr::polymorphic_allocator<int>> dv2(alloc);
+        dv2.push_back(10);
+
+        dv2 = std::move(dv1);
+        CHECK_EQ(dv2.size(), 2);
+        CHECK_EQ(dv2.data(), old_data);  // Resources stolen
+        CHECK(dv1.empty());
+    }
+
+    SUBCASE("move assignment with different allocator moves elements") {
+        std::array<std::byte, 1024> buffer1, buffer2;
+        std::pmr::monotonic_buffer_resource mbr1(buffer1.data(), buffer1.size());
+        std::pmr::monotonic_buffer_resource mbr2(buffer2.data(), buffer2.size());
+        std::pmr::polymorphic_allocator<int> alloc1(&mbr1);
+        std::pmr::polymorphic_allocator<int> alloc2(&mbr2);
+
+        devectra<int, std::pmr::polymorphic_allocator<int>> dv1(alloc1);
+        dv1.push_back(1);
+        dv1.push_back(2);
+        auto* old_data = dv1.data();
+
+        devectra<int, std::pmr::polymorphic_allocator<int>> dv2(alloc2);
+        dv2.push_back(10);
+
+        dv2 = std::move(dv1);
+        CHECK_EQ(dv2.size(), 2);
+        CHECK_NE(dv2.data(), old_data);  // Cannot steal, must move elements
+        CHECK_EQ(dv2[0], 1);
+        CHECK_EQ(dv2[1], 2);
+        CHECK(dv2.get_allocator() == alloc2);  // Allocator not propagated
+    }
+
+    SUBCASE("swap with same allocator") {
+        std::array<std::byte, 2048> buffer;
+        std::pmr::monotonic_buffer_resource mbr(buffer.data(), buffer.size());
+        std::pmr::polymorphic_allocator<int> alloc(&mbr);
+
+        devectra<int, std::pmr::polymorphic_allocator<int>> dv1(alloc);
+        dv1.push_back(1);
+        dv1.push_back(2);
+        auto* data1 = dv1.data();
+
+        devectra<int, std::pmr::polymorphic_allocator<int>> dv2(alloc);
+        dv2.push_back(10);
+        dv2.push_back(20);
+        dv2.push_back(30);
+        auto* data2 = dv2.data();
+
+        dv1.swap(dv2);
+        CHECK_EQ(dv1.size(), 3);
+        CHECK_EQ(dv2.size(), 2);
+        CHECK_EQ(dv1.data(), data2);
+        CHECK_EQ(dv2.data(), data1);
+    }
+}
+
 // NOLINTEND
 }  // namespace stdb::container

--- a/tests/pmr_fuzz_test.cc
+++ b/tests/pmr_fuzz_test.cc
@@ -1,0 +1,952 @@
+/*
+ * Copyright 2025 ClapDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * PMR Fuzz Testing
+ *
+ * This file contains fuzz tests to verify PMR implementations work correctly
+ * under heavy load with random operations. Tests cover:
+ * - Large data volumes (10K-100K+ operations)
+ * - Random operation sequences (insert, erase, find, copy, move)
+ * - Memory resource switching
+ * - Allocator propagation semantics
+ * - Edge cases (empty, single element, etc.)
+ */
+
+#include "container/btree_map.hpp"
+#include "container/concurrent_skiplist.hpp"
+#include "container/dense_map.hpp"
+#include "container/devectra.hpp"
+#include "container/skiplist_map.hpp"
+#include "container/small_vectra.hpp"
+
+#include <doctest/doctest.h>
+
+#include <algorithm>
+#include <deque>
+#include <map>
+#include <random>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace stdb::container {
+// NOLINTBEGIN
+
+// ============================================================================
+// Fuzz Test Utilities
+// ============================================================================
+
+class FuzzRng {
+   public:
+    explicit FuzzRng(uint64_t seed = 42) : _rng(seed) {}
+
+    int randint(int min, int max) {
+        std::uniform_int_distribution<int> dist(min, max);
+        return dist(_rng);
+    }
+
+    size_t randsize(size_t min, size_t max) {
+        std::uniform_int_distribution<size_t> dist(min, max);
+        return dist(_rng);
+    }
+
+    double randdouble(double min, double max) {
+        std::uniform_real_distribution<double> dist(min, max);
+        return dist(_rng);
+    }
+
+    std::string randstring(size_t len) {
+        static const char charset[] = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        std::string result;
+        result.reserve(len);
+        for (size_t i = 0; i < len; ++i) {
+            result += charset[randint(0, sizeof(charset) - 2)];
+        }
+        return result;
+    }
+
+    template <typename Container>
+    typename Container::value_type& pick(Container& c) {
+        auto it = c.begin();
+        std::advance(it, randsize(0, c.size() - 1));
+        return *it;
+    }
+
+   private:
+    std::mt19937_64 _rng;
+};
+
+// Track allocations to verify no leaks
+class TrackingMemoryResource : public std::pmr::memory_resource {
+   public:
+    TrackingMemoryResource() = default;
+
+    size_t allocation_count() const { return _alloc_count; }
+    size_t deallocation_count() const { return _dealloc_count; }
+    size_t bytes_allocated() const { return _bytes_allocated; }
+    size_t bytes_deallocated() const { return _bytes_deallocated; }
+    size_t outstanding_bytes() const { return _bytes_allocated - _bytes_deallocated; }
+
+    bool balanced() const {
+        return _alloc_count == _dealloc_count && _bytes_allocated == _bytes_deallocated;
+    }
+
+   protected:
+    void* do_allocate(size_t bytes, size_t alignment) override {
+        ++_alloc_count;
+        _bytes_allocated += bytes;
+        return std::pmr::get_default_resource()->allocate(bytes, alignment);
+    }
+
+    void do_deallocate(void* p, size_t bytes, size_t alignment) override {
+        ++_dealloc_count;
+        _bytes_deallocated += bytes;
+        std::pmr::get_default_resource()->deallocate(p, bytes, alignment);
+    }
+
+    bool do_is_equal(const std::pmr::memory_resource& other) const noexcept override {
+        return this == &other;
+    }
+
+   private:
+    size_t _alloc_count = 0;
+    size_t _dealloc_count = 0;
+    size_t _bytes_allocated = 0;
+    size_t _bytes_deallocated = 0;
+};
+
+// ============================================================================
+// Map Container Fuzz Tests (dense_map, btree_map, skiplist_map)
+// ============================================================================
+
+// dense_map fuzz test (hash map - different template signature)
+void fuzz_dense_map_operations(size_t num_ops, uint64_t seed) {
+    TrackingMemoryResource resource;
+    using Alloc = std::pmr::polymorphic_allocator<std::pair<int, std::string>>;
+    Alloc alloc(&resource);
+
+    {
+        dense_map<int, std::string, dense_hash<int>, std::equal_to<int>, Alloc> map(alloc);
+        std::unordered_map<int, std::string> reference;
+
+        FuzzRng rng(seed);
+
+        for (size_t i = 0; i < num_ops; ++i) {
+            int op = rng.randint(0, 99);
+            int key = rng.randint(0, 10000);
+            std::string value = rng.randstring(rng.randsize(1, 50));
+
+            if (op < 50) {
+                auto [it, inserted] = map.insert({key, value});
+                auto [ref_it, ref_inserted] = reference.insert({key, value});
+                CHECK_EQ(inserted, ref_inserted);
+            } else if (op < 70) {
+                auto it = map.find(key);
+                auto ref_it = reference.find(key);
+                CHECK_EQ((it != map.end()), (ref_it != reference.end()));
+                if (it != map.end() && ref_it != reference.end()) {
+                    CHECK_EQ(it->second, ref_it->second);
+                }
+            } else if (op < 85) {
+                size_t erased = map.erase(key);
+                size_t ref_erased = reference.erase(key);
+                CHECK_EQ(erased, ref_erased);
+            } else if (op < 90) {
+                map[key] = value;
+                reference[key] = value;
+            } else if (op < 95) {
+                CHECK_EQ(map.size(), reference.size());
+            } else {
+                if (rng.randint(0, 9) == 0) {
+                    map.clear();
+                    reference.clear();
+                }
+            }
+        }
+
+        CHECK_EQ(map.size(), reference.size());
+        for (const auto& [k, v] : reference) {
+            auto it = map.find(k);
+            CHECK(it != map.end());
+            if (it != map.end()) {
+                CHECK_EQ(it->second, v);
+            }
+        }
+    }
+
+    CHECK_MESSAGE(resource.balanced(),
+                  "Memory leak detected: allocated=" << resource.bytes_allocated()
+                                                     << " deallocated=" << resource.bytes_deallocated());
+}
+
+// btree_map fuzz test (ordered map)
+void fuzz_btree_map_operations(size_t num_ops, uint64_t seed) {
+    TrackingMemoryResource resource;
+    using Alloc = std::pmr::polymorphic_allocator<std::pair<const int, std::string>>;
+    Alloc alloc(&resource);
+
+    {
+        btree_map<int, std::string, std::less<int>, Alloc> map(alloc);
+        std::map<int, std::string> reference;
+
+        FuzzRng rng(seed);
+
+        for (size_t i = 0; i < num_ops; ++i) {
+            int op = rng.randint(0, 99);
+            int key = rng.randint(0, 10000);
+            std::string value = rng.randstring(rng.randsize(1, 50));
+
+            if (op < 50) {
+                auto [it, inserted] = map.insert({key, value});
+                auto [ref_it, ref_inserted] = reference.insert({key, value});
+                CHECK_EQ(inserted, ref_inserted);
+            } else if (op < 70) {
+                auto it = map.find(key);
+                auto ref_it = reference.find(key);
+                CHECK_EQ((it != map.end()), (ref_it != reference.end()));
+                if (it != map.end() && ref_it != reference.end()) {
+                    CHECK_EQ(it->second, ref_it->second);
+                }
+            } else if (op < 85) {
+                size_t erased = map.erase(key);
+                size_t ref_erased = reference.erase(key);
+                CHECK_EQ(erased, ref_erased);
+            } else if (op < 90) {
+                map[key] = value;
+                reference[key] = value;
+            } else if (op < 95) {
+                CHECK_EQ(map.size(), reference.size());
+            } else {
+                if (rng.randint(0, 9) == 0) {
+                    map.clear();
+                    reference.clear();
+                }
+            }
+        }
+
+        CHECK_EQ(map.size(), reference.size());
+        for (const auto& [k, v] : reference) {
+            auto it = map.find(k);
+            CHECK(it != map.end());
+            if (it != map.end()) {
+                CHECK_EQ(it->second, v);
+            }
+        }
+    }
+
+    CHECK_MESSAGE(resource.balanced(),
+                  "Memory leak detected: allocated=" << resource.bytes_allocated()
+                                                     << " deallocated=" << resource.bytes_deallocated());
+}
+
+// skiplist_map fuzz test
+void fuzz_skiplist_map_operations(size_t num_ops, uint64_t seed) {
+    TrackingMemoryResource resource;
+    using Alloc = std::pmr::polymorphic_allocator<std::pair<const int, std::string>>;
+    Alloc alloc(&resource);
+
+    {
+        skiplist_map<int, std::string, std::less<int>, Alloc> map(alloc);
+        std::map<int, std::string> reference;
+
+        FuzzRng rng(seed);
+
+        for (size_t i = 0; i < num_ops; ++i) {
+            int op = rng.randint(0, 99);
+            int key = rng.randint(0, 10000);
+            std::string value = rng.randstring(rng.randsize(1, 50));
+
+            if (op < 50) {
+                auto [it, inserted] = map.insert({key, value});
+                auto [ref_it, ref_inserted] = reference.insert({key, value});
+                CHECK_EQ(inserted, ref_inserted);
+            } else if (op < 70) {
+                auto it = map.find(key);
+                auto ref_it = reference.find(key);
+                CHECK_EQ((it != map.end()), (ref_it != reference.end()));
+                if (it != map.end() && ref_it != reference.end()) {
+                    CHECK_EQ(it->second, ref_it->second);
+                }
+            } else if (op < 85) {
+                size_t erased = map.erase(key);
+                size_t ref_erased = reference.erase(key);
+                CHECK_EQ(erased, ref_erased);
+            } else if (op < 95) {
+                CHECK_EQ(map.size(), reference.size());
+            } else {
+                if (rng.randint(0, 9) == 0) {
+                    map.clear();
+                    reference.clear();
+                }
+            }
+        }
+
+        CHECK_EQ(map.size(), reference.size());
+        for (const auto& [k, v] : reference) {
+            auto it = map.find(k);
+            CHECK(it != map.end());
+            if (it != map.end()) {
+                CHECK_EQ(it->second, v);
+            }
+        }
+    }
+
+    CHECK_MESSAGE(resource.balanced(),
+                  "Memory leak detected: allocated=" << resource.bytes_allocated()
+                                                     << " deallocated=" << resource.bytes_deallocated());
+}
+
+TEST_CASE("pmr_fuzz::dense_map") {
+    SUBCASE("1K operations") { fuzz_dense_map_operations(1000, 12345); }
+    SUBCASE("5K operations") { fuzz_dense_map_operations(5000, 67890); }
+    SUBCASE("different seed 1") { fuzz_dense_map_operations(2000, 11111); }
+    SUBCASE("different seed 2") { fuzz_dense_map_operations(2000, 22222); }
+}
+
+TEST_CASE("pmr_fuzz::btree_map") {
+    SUBCASE("1K operations") { fuzz_btree_map_operations(1000, 12345); }
+    SUBCASE("5K operations") { fuzz_btree_map_operations(5000, 67890); }
+    SUBCASE("different seed 1") { fuzz_btree_map_operations(2000, 33333); }
+    SUBCASE("different seed 2") { fuzz_btree_map_operations(2000, 44444); }
+}
+
+TEST_CASE("pmr_fuzz::skiplist_map") {
+    SUBCASE("1K operations") { fuzz_skiplist_map_operations(1000, 12345); }
+    SUBCASE("5K operations") { fuzz_skiplist_map_operations(5000, 67890); }
+    SUBCASE("different seed 1") { fuzz_skiplist_map_operations(2000, 55555); }
+    SUBCASE("different seed 2") { fuzz_skiplist_map_operations(2000, 66666); }
+}
+
+// ============================================================================
+// Vector Container Fuzz Tests (small_vectra, devectra)
+// ============================================================================
+
+void fuzz_small_vectra_operations(size_t num_ops, uint64_t seed) {
+    TrackingMemoryResource resource;
+    using Alloc = std::pmr::polymorphic_allocator<std::string>;
+    Alloc alloc(&resource);
+
+    {
+        small_vectra<std::string, 4, Alloc> vec(alloc);
+        std::vector<std::string> reference;
+
+        FuzzRng rng(seed);
+
+        for (size_t i = 0; i < num_ops; ++i) {
+            int op = rng.randint(0, 99);
+            std::string value = rng.randstring(rng.randsize(1, 100));
+
+            if (op < 40) {
+                // push_back
+                vec.push_back(value);
+                reference.push_back(value);
+            } else if (op < 55) {
+                // pop_back
+                if (!vec.empty()) {
+                    vec.pop_back();
+                    reference.pop_back();
+                }
+            } else if (op < 65) {
+                // Random access
+                if (!vec.empty()) {
+                    size_t idx = rng.randsize(0, vec.size() - 1);
+                    CHECK_EQ(vec[idx], reference[idx]);
+                }
+            } else if (op < 75) {
+                // Erase at position
+                if (!vec.empty()) {
+                    size_t idx = rng.randsize(0, vec.size() - 1);
+                    vec.erase(vec.begin() + idx);
+                    reference.erase(reference.begin() + idx);
+                }
+            } else if (op < 85) {
+                // Insert at position
+                if (vec.size() < 10000) {  // Limit size to avoid OOM
+                    size_t idx = vec.empty() ? 0 : rng.randsize(0, vec.size());
+                    vec.insert(vec.begin() + idx, value);
+                    reference.insert(reference.begin() + idx, value);
+                }
+            } else if (op < 90) {
+                // Size check
+                CHECK_EQ(vec.size(), reference.size());
+            } else if (op < 95) {
+                // Reserve
+                size_t cap = rng.randsize(vec.size(), vec.size() + 100);
+                vec.reserve(cap);
+                reference.reserve(cap);
+            } else {
+                // Clear occasionally
+                if (rng.randint(0, 19) == 0) {
+                    vec.clear();
+                    reference.clear();
+                }
+            }
+        }
+
+        // Final consistency check
+        CHECK_EQ(vec.size(), reference.size());
+        for (size_t i = 0; i < vec.size(); ++i) {
+            CHECK_EQ(vec[i], reference[i]);
+        }
+    }
+
+    CHECK_MESSAGE(resource.balanced(),
+                  "Memory leak detected: allocated=" << resource.bytes_allocated()
+                                                     << " deallocated=" << resource.bytes_deallocated());
+}
+
+void fuzz_devectra_operations(size_t num_ops, uint64_t seed) {
+    TrackingMemoryResource resource;
+    std::pmr::polymorphic_allocator<std::string> alloc(&resource);
+
+    {
+        devectra<std::string, decltype(alloc)> vec(alloc);
+        std::deque<std::string> reference;  // Use deque as reference for devectra
+
+        FuzzRng rng(seed);
+
+        for (size_t i = 0; i < num_ops; ++i) {
+            int op = rng.randint(0, 99);
+            std::string value = rng.randstring(rng.randsize(1, 100));
+
+            if (op < 25) {
+                // push_back
+                vec.push_back(value);
+                reference.push_back(value);
+            } else if (op < 50) {
+                // push_front
+                vec.push_front(value);
+                reference.push_front(value);
+            } else if (op < 60) {
+                // pop_back
+                if (!vec.empty()) {
+                    vec.pop_back();
+                    reference.pop_back();
+                }
+            } else if (op < 70) {
+                // pop_front
+                if (!vec.empty()) {
+                    vec.pop_front();
+                    reference.pop_front();
+                }
+            } else if (op < 80) {
+                // Random access
+                if (!vec.empty()) {
+                    size_t idx = rng.randsize(0, vec.size() - 1);
+                    CHECK_EQ(vec[idx], reference[idx]);
+                }
+            } else if (op < 90) {
+                // Size check
+                CHECK_EQ(vec.size(), reference.size());
+            } else {
+                // Clear occasionally
+                if (rng.randint(0, 19) == 0) {
+                    vec.clear();
+                    reference.clear();
+                }
+            }
+        }
+
+        // Final consistency check
+        CHECK_EQ(vec.size(), reference.size());
+        for (size_t i = 0; i < vec.size(); ++i) {
+            CHECK_EQ(vec[i], reference[i]);
+        }
+    }
+
+    CHECK_MESSAGE(resource.balanced(),
+                  "Memory leak detected: allocated=" << resource.bytes_allocated()
+                                                     << " deallocated=" << resource.bytes_deallocated());
+}
+
+TEST_CASE("pmr_fuzz::small_vectra") {
+    SUBCASE("1K operations") { fuzz_small_vectra_operations(1000, 12345); }
+    SUBCASE("5K operations") { fuzz_small_vectra_operations(5000, 67890); }
+    SUBCASE("different seed 1") { fuzz_small_vectra_operations(2000, 77777); }
+    SUBCASE("different seed 2") { fuzz_small_vectra_operations(2000, 88888); }
+}
+
+TEST_CASE("pmr_fuzz::devectra") {
+    SUBCASE("1K operations") { fuzz_devectra_operations(1000, 12345); }
+    SUBCASE("5K operations") { fuzz_devectra_operations(5000, 67890); }
+    SUBCASE("different seed 1") { fuzz_devectra_operations(2000, 99999); }
+    SUBCASE("different seed 2") { fuzz_devectra_operations(2000, 10101); }
+}
+
+// ============================================================================
+// Copy/Move Semantics Fuzz Tests
+// ============================================================================
+
+TEST_CASE("pmr_fuzz::copy_move_semantics") {
+    SUBCASE("dense_map copy/move stress") {
+        TrackingMemoryResource res1, res2;
+        using Alloc = std::pmr::polymorphic_allocator<std::pair<int, std::string>>;
+        Alloc alloc1(&res1);
+        Alloc alloc2(&res2);
+
+        FuzzRng rng(54321);
+
+        for (int trial = 0; trial < 100; ++trial) {
+            dense_map<int, std::string, dense_hash<int>, std::equal_to<int>, Alloc> map1(alloc1);
+            dense_map<int, std::string, dense_hash<int>, std::equal_to<int>, Alloc> map2(alloc2);
+
+            // Fill map1
+            size_t n = rng.randsize(10, 500);
+            for (size_t i = 0; i < n; ++i) {
+                map1[rng.randint(0, 1000)] = rng.randstring(20);
+            }
+
+            // Copy assignment (different allocators - should not propagate for PMR)
+            map2 = map1;
+            CHECK_EQ(map2.size(), map1.size());
+            CHECK(map2.get_allocator().resource() == &res2);  // Allocator not propagated
+
+            // Move assignment (different allocators - should move elements, not steal)
+            dense_map<int, std::string, dense_hash<int>, std::equal_to<int>, Alloc> map3(alloc1);
+            for (size_t i = 0; i < n / 2; ++i) {
+                map3[rng.randint(0, 1000)] = rng.randstring(20);
+            }
+            size_t map3_size = map3.size();
+            map2 = std::move(map3);
+            CHECK_EQ(map2.size(), map3_size);
+        }
+
+        // Both resources should be balanced after all maps destroyed
+        CHECK(res1.balanced());
+        CHECK(res2.balanced());
+    }
+
+    SUBCASE("small_vectra copy/move stress") {
+        TrackingMemoryResource res1, res2;
+        std::pmr::polymorphic_allocator<std::string> alloc1(&res1);
+        std::pmr::polymorphic_allocator<std::string> alloc2(&res2);
+
+        FuzzRng rng(65432);
+
+        for (int trial = 0; trial < 100; ++trial) {
+            small_vectra<std::string, 4, decltype(alloc1)> vec1(alloc1);
+            small_vectra<std::string, 4, decltype(alloc2)> vec2(alloc2);
+
+            // Fill vec1
+            size_t n = rng.randsize(1, 100);
+            for (size_t i = 0; i < n; ++i) {
+                vec1.push_back(rng.randstring(30));
+            }
+
+            // Copy assignment
+            vec2 = vec1;
+            CHECK_EQ(vec2.size(), vec1.size());
+
+            // Move assignment
+            small_vectra<std::string, 4, decltype(alloc1)> vec3(alloc1);
+            for (size_t i = 0; i < n / 2; ++i) {
+                vec3.push_back(rng.randstring(30));
+            }
+            size_t vec3_size = vec3.size();
+            vec2 = std::move(vec3);
+            CHECK_EQ(vec2.size(), vec3_size);
+        }
+
+        CHECK(res1.balanced());
+        CHECK(res2.balanced());
+    }
+
+    SUBCASE("devectra copy/move stress") {
+        TrackingMemoryResource res1, res2;
+        std::pmr::polymorphic_allocator<std::string> alloc1(&res1);
+        std::pmr::polymorphic_allocator<std::string> alloc2(&res2);
+
+        FuzzRng rng(76543);
+
+        for (int trial = 0; trial < 100; ++trial) {
+            devectra<std::string, decltype(alloc1)> vec1(alloc1);
+            devectra<std::string, decltype(alloc2)> vec2(alloc2);
+
+            // Fill vec1 with mixed front/back operations
+            size_t n = rng.randsize(1, 100);
+            for (size_t i = 0; i < n; ++i) {
+                if (rng.randint(0, 1)) {
+                    vec1.push_back(rng.randstring(30));
+                } else {
+                    vec1.push_front(rng.randstring(30));
+                }
+            }
+
+            // Copy assignment
+            vec2 = vec1;
+            CHECK_EQ(vec2.size(), vec1.size());
+
+            // Move assignment
+            devectra<std::string, decltype(alloc1)> vec3(alloc1);
+            for (size_t i = 0; i < n / 2; ++i) {
+                vec3.push_back(rng.randstring(30));
+            }
+            size_t vec3_size = vec3.size();
+            vec2 = std::move(vec3);
+            CHECK_EQ(vec2.size(), vec3_size);
+        }
+
+        CHECK(res1.balanced());
+        CHECK(res2.balanced());
+    }
+}
+
+// ============================================================================
+// Concurrent Skiplist Fuzz Tests
+// ============================================================================
+
+TEST_CASE("pmr_fuzz::concurrent_skiplist") {
+    SUBCASE("single thread 1K ops") {
+        std::pmr::synchronized_pool_resource pool;
+        stdb::pmr::concurrent_skiplist<int, std::string> sl(&pool);
+        std::unordered_map<int, std::string> reference;
+
+        FuzzRng rng(11111);
+        constexpr size_t num_ops = 1000;
+
+        for (size_t i = 0; i < num_ops; ++i) {
+            int op = rng.randint(0, 99);
+            int key = rng.randint(0, 5000);
+            std::string value = rng.randstring(rng.randsize(1, 30));
+
+            if (op < 60) {
+                // Insert
+                bool inserted = sl.insert(key, value);
+                auto [it, ref_inserted] = reference.insert({key, value});
+                CHECK_EQ(inserted, ref_inserted);
+            } else if (op < 80) {
+                // Find
+                auto result = sl.find(key);
+                auto ref_it = reference.find(key);
+                CHECK_EQ(result.has_value(), (ref_it != reference.end()));
+            } else {
+                // Erase
+                bool erased = sl.erase(key);
+                bool ref_erased = reference.erase(key) > 0;
+                CHECK_EQ(erased, ref_erased);
+            }
+        }
+
+        CHECK_EQ(sl.size(), reference.size());
+    }
+
+    SUBCASE("multi-thread stress test") {
+        std::pmr::synchronized_pool_resource pool;
+        stdb::pmr::concurrent_skiplist<int, int> sl(&pool);
+
+        constexpr int num_threads = 4;
+        constexpr int ops_per_thread = 500;
+
+        std::vector<std::thread> threads;
+        std::atomic<int> successful_inserts{0};
+
+        for (int t = 0; t < num_threads; ++t) {
+            threads.emplace_back([&sl, &successful_inserts, t]() {
+                FuzzRng rng(t * 1000 + 12345);
+                for (int i = 0; i < ops_per_thread; ++i) {
+                    int op = rng.randint(0, 99);
+                    int key = rng.randint(0, 10000);
+
+                    if (op < 50) {
+                        if (sl.insert(key, key * 10)) {
+                            successful_inserts.fetch_add(1, std::memory_order_relaxed);
+                        }
+                    } else if (op < 80) {
+                        sl.contains(key);
+                    } else {
+                        sl.erase(key);
+                    }
+                }
+            });
+        }
+
+        for (auto& th : threads) {
+            th.join();
+        }
+
+        // Verify data integrity
+        sl.for_each([](const int& k, const int& v) { CHECK_EQ(v, k * 10); });
+    }
+
+    SUBCASE("high contention scenario") {
+        std::pmr::synchronized_pool_resource pool;
+        stdb::pmr::concurrent_skiplist<int, int> sl(&pool);
+
+        constexpr int num_threads = 4;
+        constexpr int key_range = 100;  // Small range = high contention
+        constexpr int ops_per_thread = 500;
+
+        std::vector<std::thread> threads;
+
+        for (int t = 0; t < num_threads; ++t) {
+            threads.emplace_back([&sl, t]() {
+                FuzzRng rng(t * 7777);
+                for (int i = 0; i < ops_per_thread; ++i) {
+                    int op = rng.randint(0, 99);
+                    int key = rng.randint(0, key_range);
+
+                    if (op < 40) {
+                        sl.insert(key, key);
+                    } else if (op < 70) {
+                        sl.find(key);
+                    } else {
+                        sl.erase(key);
+                    }
+                }
+            });
+        }
+
+        for (auto& th : threads) {
+            th.join();
+        }
+
+        // Just verify no crashes and data is consistent
+        sl.for_each([](const int& k, const int& v) { CHECK_EQ(v, k); });
+    }
+}
+
+// ============================================================================
+// Large Scale Tests
+// ============================================================================
+
+TEST_CASE("pmr_fuzz::large_scale") {
+    SUBCASE("dense_map 10K elements") {
+        TrackingMemoryResource resource;
+        using Alloc = std::pmr::polymorphic_allocator<std::pair<int, int>>;
+        Alloc alloc(&resource);
+
+        {
+            dense_map<int, int, dense_hash<int>, std::equal_to<int>, Alloc> map(alloc);
+
+            constexpr int N = 10000;
+            for (int i = 0; i < N; ++i) {
+                map[i] = i * 2;
+            }
+
+            CHECK_EQ(map.size(), N);
+
+            // Verify all elements
+            for (int i = 0; i < N; ++i) {
+                auto it = map.find(i);
+                CHECK(it != map.end());
+                CHECK_EQ(it->second, i * 2);
+            }
+
+            // Erase half
+            for (int i = 0; i < N; i += 2) {
+                map.erase(i);
+            }
+
+            CHECK_EQ(map.size(), N / 2);
+        }
+
+        CHECK(resource.balanced());
+    }
+
+    SUBCASE("btree_map 10K elements") {
+        TrackingMemoryResource resource;
+        using Alloc = std::pmr::polymorphic_allocator<std::pair<const int, int>>;
+        Alloc alloc(&resource);
+
+        {
+            btree_map<int, int, std::less<int>, Alloc> map(alloc);
+
+            constexpr int N = 10000;
+            for (int i = 0; i < N; ++i) {
+                map[i] = i * 3;
+            }
+
+            CHECK_EQ(map.size(), N);
+
+            // Verify in order (btree maintains order)
+            int expected = 0;
+            for (const auto& [k, v] : map) {
+                CHECK_EQ(k, expected);
+                CHECK_EQ(v, expected * 3);
+                ++expected;
+            }
+        }
+
+        CHECK(resource.balanced());
+    }
+
+    SUBCASE("small_vectra large strings") {
+        TrackingMemoryResource resource;
+        std::pmr::polymorphic_allocator<std::string> alloc(&resource);
+
+        {
+            small_vectra<std::string, 2, decltype(alloc)> vec(alloc);
+
+            constexpr int N = 1000;
+            for (int i = 0; i < N; ++i) {
+                // Large strings to stress memory allocation
+                vec.push_back(std::string(1000, 'a' + (i % 26)));
+            }
+
+            CHECK_EQ(vec.size(), N);
+
+            // Verify
+            for (int i = 0; i < N; ++i) {
+                CHECK_EQ(vec[i].size(), 1000);
+                CHECK_EQ(vec[i][0], 'a' + (i % 26));
+            }
+        }
+
+        CHECK(resource.balanced());
+    }
+
+    SUBCASE("devectra alternating push") {
+        TrackingMemoryResource resource;
+        std::pmr::polymorphic_allocator<int> alloc(&resource);
+
+        {
+            devectra<int, decltype(alloc)> vec(alloc);
+
+            constexpr int N = 5000;
+            for (int i = 0; i < N; ++i) {
+                if (i % 2 == 0) {
+                    vec.push_back(i);
+                } else {
+                    vec.push_front(-i);
+                }
+            }
+
+            CHECK_EQ(vec.size(), N);
+
+            // Verify front elements are negative, back elements are positive
+            CHECK_LT(vec.front(), 0);
+            CHECK_GE(vec.back(), 0);
+        }
+
+        CHECK(resource.balanced());
+    }
+}
+
+// ============================================================================
+// Edge Cases
+// ============================================================================
+
+TEST_CASE("pmr_fuzz::edge_cases") {
+    SUBCASE("empty container operations") {
+        TrackingMemoryResource resource;
+        using MapAlloc = std::pmr::polymorphic_allocator<std::pair<int, int>>;
+        using VecAlloc = std::pmr::polymorphic_allocator<int>;
+        MapAlloc map_alloc(&resource);
+        VecAlloc vec_alloc(&resource);
+
+        {
+            dense_map<int, int, dense_hash<int>, std::equal_to<int>, MapAlloc> map(map_alloc);
+            small_vectra<int, 4, VecAlloc> vec(vec_alloc);
+            devectra<int, VecAlloc> dvec(vec_alloc);
+
+            // Operations on empty containers
+            CHECK(map.empty());
+            CHECK(vec.empty());
+            CHECK(dvec.empty());
+
+            CHECK(map.find(42) == map.end());
+            CHECK_EQ(map.erase(42), 0);
+
+            // Copy empty
+            auto map2 = map;
+            auto vec2 = vec;
+            auto dvec2 = dvec;
+
+            CHECK(map2.empty());
+            CHECK(vec2.empty());
+            CHECK(dvec2.empty());
+
+            // Move empty
+            auto map3 = std::move(map2);
+            auto vec3 = std::move(vec2);
+            auto dvec3 = std::move(dvec2);
+
+            CHECK(map3.empty());
+            CHECK(vec3.empty());
+            CHECK(dvec3.empty());
+        }
+
+        CHECK(resource.balanced());
+    }
+
+    SUBCASE("single element") {
+        TrackingMemoryResource resource;
+        using MapAlloc = std::pmr::polymorphic_allocator<std::pair<int, int>>;
+        using VecAlloc = std::pmr::polymorphic_allocator<int>;
+        MapAlloc map_alloc(&resource);
+        VecAlloc vec_alloc(&resource);
+
+        {
+            dense_map<int, int, dense_hash<int>, std::equal_to<int>, MapAlloc> map(map_alloc);
+            small_vectra<int, 4, VecAlloc> vec(vec_alloc);
+            devectra<int, VecAlloc> dvec(vec_alloc);
+
+            map[1] = 100;
+            vec.push_back(200);
+            dvec.push_front(300);
+
+            CHECK_EQ(map.size(), 1);
+            CHECK_EQ(vec.size(), 1);
+            CHECK_EQ(dvec.size(), 1);
+
+            // Copy single element
+            auto map2 = map;
+            auto vec2 = vec;
+            auto dvec2 = dvec;
+
+            CHECK_EQ(map2[1], 100);
+            CHECK_EQ(vec2[0], 200);
+            CHECK_EQ(dvec2[0], 300);
+
+            // Erase single element
+            map.erase(1);
+            vec.pop_back();
+            dvec.pop_front();
+
+            CHECK(map.empty());
+            CHECK(vec.empty());
+            CHECK(dvec.empty());
+        }
+
+        CHECK(resource.balanced());
+    }
+
+    SUBCASE("repeated insert/erase same key") {
+        TrackingMemoryResource resource;
+        using Alloc = std::pmr::polymorphic_allocator<std::pair<int, std::string>>;
+        Alloc alloc(&resource);
+
+        {
+            dense_map<int, std::string, dense_hash<int>, std::equal_to<int>, Alloc> map(alloc);
+
+            constexpr int iterations = 1000;
+            for (int i = 0; i < iterations; ++i) {
+                map[42] = "value" + std::to_string(i);
+                CHECK_EQ(map.size(), 1);
+                map.erase(42);
+                CHECK(map.empty());
+            }
+        }
+
+        CHECK(resource.balanced());
+    }
+}
+
+// NOLINTEND
+}  // namespace stdb::container

--- a/tests/skiplist_map_test.cc
+++ b/tests/skiplist_map_test.cc
@@ -2101,4 +2101,183 @@ TEST_CASE("skiplist_set::compare_with_std_set") {
     }
 }
 
+// ============================================================================
+// PMR (Polymorphic Memory Resource) Tests
+// ============================================================================
+
+TEST_CASE("skiplist_map::pmr") {
+    SUBCASE("basic operations with monotonic_buffer_resource") {
+        std::array<std::byte, 8192> buffer;
+        std::pmr::monotonic_buffer_resource resource(buffer.data(), buffer.size(),
+                                                     std::pmr::null_memory_resource());
+
+        stdb::pmr::skiplist_map<int, std::string> map(&resource);
+
+        map[1] = "one";
+        map[2] = "two";
+        map[3] = "three";
+
+        CHECK_EQ(map.size(), 3);
+        CHECK_EQ(map[1], "one");
+        CHECK_EQ(map[2], "two");
+        CHECK_EQ(map[3], "three");
+
+        map.erase(2);
+        CHECK_EQ(map.size(), 2);
+        CHECK(map.find(2) == map.end());
+    }
+
+    SUBCASE("allocator-only constructor") {
+        std::pmr::monotonic_buffer_resource resource;
+        stdb::pmr::skiplist_map<int, int> map(&resource);
+
+        CHECK(map.empty());
+        CHECK_EQ(map.size(), 0);
+
+        map[42] = 100;
+        CHECK_EQ(map.size(), 1);
+        CHECK_EQ(map[42], 100);
+    }
+
+    SUBCASE("allocator-extended copy constructor") {
+        std::pmr::monotonic_buffer_resource resource1;
+        std::pmr::monotonic_buffer_resource resource2;
+
+        stdb::pmr::skiplist_map<int, int> map1(&resource1);
+        map1[1] = 10;
+        map1[2] = 20;
+
+        stdb::pmr::skiplist_map<int, int> map2(map1, &resource2);
+
+        CHECK_EQ(map2.size(), 2);
+        CHECK_EQ(map2[1], 10);
+        CHECK_EQ(map2[2], 20);
+        CHECK_EQ(map2.get_allocator().resource(), &resource2);
+    }
+
+    SUBCASE("allocator-extended move constructor - same resource") {
+        std::pmr::monotonic_buffer_resource resource;
+
+        stdb::pmr::skiplist_map<int, int> map1(&resource);
+        map1[1] = 10;
+        map1[2] = 20;
+
+        stdb::pmr::skiplist_map<int, int> map2(std::move(map1), &resource);
+
+        CHECK_EQ(map2.size(), 2);
+        CHECK_EQ(map2[1], 10);
+        CHECK_EQ(map2[2], 20);
+        CHECK(map1.empty());  // Resources were stolen
+    }
+
+    SUBCASE("allocator-extended move constructor - different resource") {
+        std::pmr::monotonic_buffer_resource resource1;
+        std::pmr::monotonic_buffer_resource resource2;
+
+        stdb::pmr::skiplist_map<int, int> map1(&resource1);
+        map1[1] = 10;
+        map1[2] = 20;
+
+        stdb::pmr::skiplist_map<int, int> map2(std::move(map1), &resource2);
+
+        CHECK_EQ(map2.size(), 2);
+        CHECK_EQ(map2[1], 10);
+        CHECK_EQ(map2[2], 20);
+        CHECK_EQ(map2.get_allocator().resource(), &resource2);
+    }
+
+    SUBCASE("copy assignment - keeps allocator") {
+        std::pmr::monotonic_buffer_resource resource1;
+        std::pmr::monotonic_buffer_resource resource2;
+
+        stdb::pmr::skiplist_map<int, int> map1(&resource1);
+        map1[1] = 10;
+        map1[2] = 20;
+
+        stdb::pmr::skiplist_map<int, int> map2(&resource2);
+        map2[3] = 30;
+
+        map2 = map1;
+
+        CHECK_EQ(map2.size(), 2);
+        CHECK_EQ(map2[1], 10);
+        CHECK_EQ(map2[2], 20);
+        CHECK_EQ(map2.get_allocator().resource(), &resource2);  // Kept original allocator
+    }
+
+    SUBCASE("move assignment - same resource") {
+        std::pmr::monotonic_buffer_resource resource;
+
+        stdb::pmr::skiplist_map<int, int> map1(&resource);
+        map1[1] = 10;
+        map1[2] = 20;
+
+        stdb::pmr::skiplist_map<int, int> map2(&resource);
+        map2[3] = 30;
+
+        map2 = std::move(map1);
+
+        CHECK_EQ(map2.size(), 2);
+        CHECK_EQ(map2[1], 10);
+        CHECK_EQ(map2[2], 20);
+        CHECK(map1.empty());  // Resources were stolen
+    }
+
+    SUBCASE("move assignment - different resource") {
+        std::pmr::monotonic_buffer_resource resource1;
+        std::pmr::monotonic_buffer_resource resource2;
+
+        stdb::pmr::skiplist_map<int, int> map1(&resource1);
+        map1[1] = 10;
+        map1[2] = 20;
+
+        stdb::pmr::skiplist_map<int, int> map2(&resource2);
+        map2[3] = 30;
+
+        map2 = std::move(map1);
+
+        CHECK_EQ(map2.size(), 2);
+        CHECK_EQ(map2[1], 10);
+        CHECK_EQ(map2[2], 20);
+        CHECK_EQ(map2.get_allocator().resource(), &resource2);  // Kept original allocator
+    }
+
+    SUBCASE("string keys with PMR") {
+        std::pmr::monotonic_buffer_resource resource;
+        stdb::pmr::skiplist_map<std::string, int> map(&resource);
+
+        map["hello"] = 1;
+        map["world"] = 2;
+        map["test"] = 3;
+
+        CHECK_EQ(map.size(), 3);
+        CHECK_EQ(map["hello"], 1);
+        CHECK_EQ(map["world"], 2);
+        CHECK_EQ(map["test"], 3);
+
+        int count = 0;
+        for (const auto& [key, value] : map) {
+            (void)key;
+            (void)value;
+            ++count;
+        }
+        CHECK_EQ(count, 3);
+    }
+
+    SUBCASE("skiplist_set with PMR") {
+        std::pmr::monotonic_buffer_resource resource;
+        stdb::pmr::skiplist_set<int> set(&resource);
+
+        set.insert(1);
+        set.insert(2);
+        set.insert(3);
+
+        CHECK_EQ(set.size(), 3);
+        CHECK(set.contains(1));
+        CHECK(set.contains(2));
+        CHECK(set.contains(3));
+        CHECK(!set.contains(4));
+    }
+}
+
 }  // namespace stdb::container

--- a/tests/small_vectra_test.cc
+++ b/tests/small_vectra_test.cc
@@ -701,5 +701,212 @@ TEST_CASE("small_vectra::std_erase") {
     }
 }
 
+// ============================================================================
+// PMR (Polymorphic Memory Resource) Tests
+// ============================================================================
+
+TEST_CASE("small_vectra::pmr") {
+    SUBCASE("basic operations with monotonic_buffer_resource - inline storage") {
+        std::array<std::byte, 4096> buffer;
+        std::pmr::monotonic_buffer_resource resource(buffer.data(), buffer.size(),
+                                                     std::pmr::null_memory_resource());
+
+        stdb::pmr::small_vectra<int, 8> vec(&resource);
+
+        // Use inline storage (< 8 elements)
+        vec.push_back(1);
+        vec.push_back(2);
+        vec.push_back(3);
+
+        CHECK_EQ(vec.size(), 3);
+        CHECK(vec.is_small());  // Should be in inline storage
+        CHECK_EQ(vec[0], 1);
+        CHECK_EQ(vec[1], 2);
+        CHECK_EQ(vec[2], 3);
+    }
+
+    SUBCASE("basic operations with monotonic_buffer_resource - heap storage") {
+        std::array<std::byte, 4096> buffer;
+        std::pmr::monotonic_buffer_resource resource(buffer.data(), buffer.size(),
+                                                     std::pmr::null_memory_resource());
+
+        stdb::pmr::small_vectra<int, 4> vec(&resource);
+
+        // Force heap allocation (> 4 elements)
+        for (int i = 0; i < 10; ++i) {
+            vec.push_back(i);
+        }
+
+        CHECK_EQ(vec.size(), 10);
+        CHECK(!vec.is_small());  // Should be on heap
+        for (int i = 0; i < 10; ++i) {
+            CHECK_EQ(vec[i], i);
+        }
+    }
+
+    SUBCASE("allocator-only constructor") {
+        std::pmr::monotonic_buffer_resource resource;
+        stdb::pmr::small_vectra<int, 8> vec(&resource);
+
+        CHECK(vec.empty());
+        CHECK_EQ(vec.size(), 0);
+        CHECK(vec.is_small());
+
+        vec.push_back(42);
+        CHECK_EQ(vec.size(), 1);
+        CHECK_EQ(vec[0], 42);
+    }
+
+    SUBCASE("allocator-extended copy constructor") {
+        std::pmr::monotonic_buffer_resource resource1;
+        std::pmr::monotonic_buffer_resource resource2;
+
+        stdb::pmr::small_vectra<int, 8> vec1(&resource1);
+        vec1.push_back(10);
+        vec1.push_back(20);
+        vec1.push_back(30);
+
+        stdb::pmr::small_vectra<int, 8> vec2(vec1, &resource2);
+
+        CHECK_EQ(vec2.size(), 3);
+        CHECK_EQ(vec2[0], 10);
+        CHECK_EQ(vec2[1], 20);
+        CHECK_EQ(vec2[2], 30);
+        CHECK_EQ(vec2.get_allocator().resource(), &resource2);
+    }
+
+    SUBCASE("allocator-extended move constructor - same resource") {
+        std::pmr::monotonic_buffer_resource resource;
+
+        stdb::pmr::small_vectra<int, 4> vec1(&resource);
+        // Force heap allocation
+        for (int i = 0; i < 10; ++i) {
+            vec1.push_back(i);
+        }
+
+        stdb::pmr::small_vectra<int, 4> vec2(std::move(vec1), &resource);
+
+        CHECK_EQ(vec2.size(), 10);
+        for (int i = 0; i < 10; ++i) {
+            CHECK_EQ(vec2[i], i);
+        }
+        CHECK(vec1.empty());  // Resources were stolen
+    }
+
+    SUBCASE("allocator-extended move constructor - different resource") {
+        std::pmr::monotonic_buffer_resource resource1;
+        std::pmr::monotonic_buffer_resource resource2;
+
+        stdb::pmr::small_vectra<int, 4> vec1(&resource1);
+        for (int i = 0; i < 10; ++i) {
+            vec1.push_back(i);
+        }
+
+        stdb::pmr::small_vectra<int, 4> vec2(std::move(vec1), &resource2);
+
+        CHECK_EQ(vec2.size(), 10);
+        for (int i = 0; i < 10; ++i) {
+            CHECK_EQ(vec2[i], i);
+        }
+        CHECK_EQ(vec2.get_allocator().resource(), &resource2);
+    }
+
+    SUBCASE("copy assignment - keeps allocator") {
+        std::pmr::monotonic_buffer_resource resource1;
+        std::pmr::monotonic_buffer_resource resource2;
+
+        stdb::pmr::small_vectra<int, 8> vec1(&resource1);
+        vec1.push_back(10);
+        vec1.push_back(20);
+
+        stdb::pmr::small_vectra<int, 8> vec2(&resource2);
+        vec2.push_back(30);
+
+        vec2 = vec1;
+
+        CHECK_EQ(vec2.size(), 2);
+        CHECK_EQ(vec2[0], 10);
+        CHECK_EQ(vec2[1], 20);
+        CHECK_EQ(vec2.get_allocator().resource(), &resource2);  // Kept original allocator
+    }
+
+    SUBCASE("move assignment - same resource") {
+        std::pmr::monotonic_buffer_resource resource;
+
+        stdb::pmr::small_vectra<int, 4> vec1(&resource);
+        for (int i = 0; i < 10; ++i) {
+            vec1.push_back(i);
+        }
+
+        stdb::pmr::small_vectra<int, 4> vec2(&resource);
+        vec2.push_back(100);
+
+        vec2 = std::move(vec1);
+
+        CHECK_EQ(vec2.size(), 10);
+        for (int i = 0; i < 10; ++i) {
+            CHECK_EQ(vec2[i], i);
+        }
+        CHECK(vec1.empty());  // Resources were stolen
+    }
+
+    SUBCASE("move assignment - different resource") {
+        std::pmr::monotonic_buffer_resource resource1;
+        std::pmr::monotonic_buffer_resource resource2;
+
+        stdb::pmr::small_vectra<int, 4> vec1(&resource1);
+        for (int i = 0; i < 10; ++i) {
+            vec1.push_back(i);
+        }
+
+        stdb::pmr::small_vectra<int, 4> vec2(&resource2);
+        vec2.push_back(100);
+
+        vec2 = std::move(vec1);
+
+        CHECK_EQ(vec2.size(), 10);
+        for (int i = 0; i < 10; ++i) {
+            CHECK_EQ(vec2[i], i);
+        }
+        CHECK_EQ(vec2.get_allocator().resource(), &resource2);  // Kept original allocator
+    }
+
+    SUBCASE("string elements with PMR") {
+        std::pmr::monotonic_buffer_resource resource;
+        stdb::pmr::small_vectra<std::string, 4> vec(&resource);
+
+        vec.push_back("hello");
+        vec.push_back("world");
+        vec.push_back("test");
+
+        CHECK_EQ(vec.size(), 3);
+        CHECK_EQ(vec[0], "hello");
+        CHECK_EQ(vec[1], "world");
+        CHECK_EQ(vec[2], "test");
+    }
+
+    SUBCASE("transition from inline to heap with PMR") {
+        std::pmr::monotonic_buffer_resource resource;
+        stdb::pmr::small_vectra<int, 4> vec(&resource);
+
+        // Start inline
+        vec.push_back(1);
+        vec.push_back(2);
+        CHECK(vec.is_small());
+
+        // Force transition to heap
+        for (int i = 3; i <= 10; ++i) {
+            vec.push_back(i);
+        }
+        CHECK(!vec.is_small());
+        CHECK_EQ(vec.size(), 10);
+
+        // Verify all elements
+        for (int i = 0; i < 10; ++i) {
+            CHECK_EQ(vec[i], i + 1);
+        }
+    }
+}
+
 // NOLINTEND
 }  // namespace stdb::container


### PR DESCRIPTION
## Summary

Add full C++17 PMR (Polymorphic Memory Resource) allocator support across all dynamic container types:
- **dense_map**: New PMR support
- **btree_map/set**: Fix existing PMR allocator handling
- **skiplist_map/set**: Fix existing PMR allocator handling + add type aliases
- **small_vectra**: Complete rewrite from malloc/free to allocator_traits

## Changes

### dense_map (New PMR Support)

- Add allocator-only and allocator-extended constructors
- Copy/move assignment respects propagate traits
- Add `stdb::container::pmr::dense_map` and `pmr::fast_map` type aliases

### btree_map/set (PMR Fixes)

- Copy assignment checks `propagate_on_container_copy_assignment`
- Move assignment checks `propagate_on_container_move_assignment` and handles unequal allocators
- Added conditional `noexcept` based on allocator traits

### skiplist_map/set (PMR Fixes + Type Aliases)

- Copy assignment checks `propagate_on_container_copy_assignment`
- Move assignment checks `propagate_on_container_move_assignment` and handles unequal allocators
- Swap checks `propagate_on_container_swap`
- Add `stdb::pmr::skiplist_map` and `stdb::pmr::skiplist_set` type aliases

### small_vectra (Complete PMR Rewrite)

**Major change: Replace malloc/free with std::allocator_traits**

- Add allocator member variable with `[[no_unique_address]]`
- Replace all `std::malloc`/`std::free` calls with `AllocTraits::allocate`/`deallocate`
- Add allocator-only and allocator-extended constructors
- Copy constructor uses `select_on_container_copy_construction`
- Copy/move assignment respects propagate traits
- Swap checks `propagate_on_container_swap`
- Add `get_allocator()` function
- Add `stdb::pmr::small_vectra` type alias

## Test Plan

- [x] All existing tests pass
  - dense_map: 200,693 assertions
  - btree_map: 88,344 assertions
  - skiplist: 51,511 assertions
  - small_vectra: 453 assertions
- [x] New PMR test suites
  - dense_map: 11 subcases
  - btree_map: 10 subcases
  - skiplist_map: 10 subcases
  - small_vectra: 12 subcases

## Usage Example

```cpp
#include "container/dense_map.hpp"
#include "container/btree_map.hpp"
#include "container/skiplist_map.hpp"
#include "container/small_vectra.hpp"

std::pmr::monotonic_buffer_resource resource;

// All containers now work correctly with PMR
stdb::container::pmr::dense_map<int, std::string> dmap(&resource);
stdb::pmr::btree_map<int, std::string> bmap(&resource);
stdb::pmr::skiplist_map<int, std::string> smap(&resource);
stdb::pmr::small_vectra<int> vec(&resource);
```

🤖 Generated with [Claude Code](https://claude.ai/code)