### PR TITLE
Add immutable_ordered_multimap (build-once ordered multimap)

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -24,6 +24,9 @@ add_bench_target(boolean_vector_bench boolean_vector_bench.cc)
 # Container benchmarks (small_vectra, devectra, ring_buffer)
 add_bench_target(container_bench container_bench.cc)
 
+# immutable_ordered_multimap vs containa btree_multimap
+add_bench_target(immutable_ordered_multimap_bench immutable_ordered_multimap_bench.cc)
+
 # Dense map benchmarks
 add_executable(dense_map_bench dense_map_bench.cc)
 target_compile_definitions(dense_map_bench PRIVATE NDEBUG)

--- a/bench/immutable_ordered_multimap_bench.cc
+++ b/bench/immutable_ordered_multimap_bench.cc
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) STDB Holdings Limited
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * immutable_ordered_multimap vs containa btree_multimap: build / point / range,
+ * over an immutable build-once-read-many workload.
+ */
+
+#include "../nanobench/src/include/nanobench.h"
+
+#include <cstdint>
+#include <random>
+#include <utility>
+#include <vector>
+
+#include "container/btree_map.hpp"
+#include "container/immutable_ordered_multimap.hpp"
+
+using stdb::container::btree_multimap;
+using stdb::container::immutable_ordered_multimap;
+
+namespace {
+
+auto make_pairs(uint32_t n, int64_t distinct) -> std::vector<std::pair<int64_t, uint32_t>> {
+    std::mt19937_64 rng(12345);
+    std::uniform_int_distribution<int64_t> dist(0, distinct - 1);
+    std::vector<std::pair<int64_t, uint32_t>> pairs;
+    pairs.reserve(n);
+    for (uint32_t i = 0; i < n; ++i) {
+        pairs.emplace_back(dist(rng), i);
+    }
+    return pairs;
+}
+
+void scenario(uint32_t n, int64_t distinct, const char* title) {
+    const auto pairs = make_pairs(n, distinct);
+
+    std::mt19937_64 rng(999);
+    std::uniform_int_distribution<int64_t> dist(0, distinct - 1);
+    std::vector<int64_t> probes(50000);
+    for (auto& p : probes) {
+        p = dist(rng);
+    }
+    const int64_t width = std::max<int64_t>(1, distinct / 100);
+
+    ankerl::nanobench::Bench bench;
+    bench.title(title).warmup(1).epochs(3).relative(true);
+
+    // ---- build ----
+    bench.run("build immutable_ordered_multimap", [&] {
+        auto m = immutable_ordered_multimap<int64_t, uint32_t>::build(pairs);
+        ankerl::nanobench::doNotOptimizeAway(m.value_count());
+    });
+    bench.run("build btree_multimap", [&] {
+        btree_multimap<int64_t, uint32_t> m;
+        for (const auto& [k, v] : pairs) {
+            m.emplace(k, v);
+        }
+        ankerl::nanobench::doNotOptimizeAway(m.size());
+    });
+
+    auto im = immutable_ordered_multimap<int64_t, uint32_t>::build(pairs);
+    btree_multimap<int64_t, uint32_t> bt;
+    for (const auto& [k, v] : pairs) {
+        bt.emplace(k, v);
+    }
+
+    // ---- point: sum matching row ids (touch the values, no allocation) ----
+    bench.run("point immutable_ordered_multimap", [&] {
+        uint64_t acc = 0;
+        for (int64_t x : probes) {
+            for (uint32_t r : im.equal_range(x)) {
+                acc += r;
+            }
+        }
+        ankerl::nanobench::doNotOptimizeAway(acc);
+    });
+    bench.run("point btree_multimap", [&] {
+        uint64_t acc = 0;
+        for (int64_t x : probes) {
+            auto [b, e] = bt.equal_range(x);
+            for (auto it = b; it != e; ++it) {
+                acc += it->second;
+            }
+        }
+        ankerl::nanobench::doNotOptimizeAway(acc);
+    });
+
+    // ---- range [x, x+width] ----
+    bench.run("range immutable_ordered_multimap", [&] {
+        uint64_t acc = 0;
+        for (int64_t x : probes) {
+            for (uint32_t r : im.range(x, true, x + width, true)) {
+                acc += r;
+            }
+        }
+        ankerl::nanobench::doNotOptimizeAway(acc);
+    });
+    bench.run("range btree_multimap", [&] {
+        uint64_t acc = 0;
+        for (int64_t x : probes) {
+            for (auto it = bt.lower_bound(x); it != bt.end() && it->first <= x + width; ++it) {
+                acc += it->second;
+            }
+        }
+        ankerl::nanobench::doNotOptimizeAway(acc);
+    });
+}
+
+}  // namespace
+
+auto main() -> int {
+    scenario(22000, 22000, "per-segment high-card (n=22000, distinct=22000)");
+    scenario(22000, 200, "per-segment low-card (n=22000, distinct=200)");
+    scenario(1000000, 1000000, "1M high-card (n=1000000, distinct=1000000)");
+    return 0;
+}

--- a/container/immutable_ordered_multimap.hpp
+++ b/container/immutable_ordered_multimap.hpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) STDB Holdings Limited
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @file immutable_ordered_multimap.hpp
+ * @brief Build-once, read-only ordered multimap stored as three flat arrays (CSR).
+ *
+ * immutable_ordered_multimap<K, V> maps each distinct key to a contiguous run of
+ * values, with the distinct keys held sorted. It is built once from a set of
+ * (key, value) pairs and never mutated, which lets it use the most compact and
+ * cache-friendly representation possible:
+ *
+ *   keys_[Nk]      distinct keys, ascending
+ *   offsets_[Nk+1] values of key i are values_[offsets_[i] .. offsets_[i+1])
+ *   values_[Nv]    all values, grouped by key (insertion order preserved per key)
+ *
+ * Equality and range lookups binary-search the sorted keys and return a
+ * std::span<const V> directly into values_ -- ZERO COPY, no materialization.
+ * Because the keys are sorted and the values are grouped, the result of any
+ * single-key or key-range query is a CONTIGUOUS span.
+ *
+ * This is the immutable counterpart to a btree_multimap: it cannot insert/erase
+ * (those would be O(N)), but for immutable data it is smaller (no node/pointer
+ * overhead), builds faster, and answers point/range queries as zero-copy spans.
+ * Typical use: a per-segment secondary index value->row-ids over immutable
+ * columnar segments.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <span>
+#include <utility>
+#include <vector>
+
+namespace stdb::container {
+
+template <typename K, typename V>
+class immutable_ordered_multimap
+{
+   public:
+    immutable_ordered_multimap() = default;
+
+    /// Build from (key, value) pairs. Pairs are sorted by key; the original order
+    /// of values within a key is preserved (stable).
+    static auto build(std::vector<std::pair<K, V>> pairs) -> immutable_ordered_multimap {
+        immutable_ordered_multimap m;
+        std::stable_sort(pairs.begin(), pairs.end(),
+                         [](const auto& a, const auto& b) { return a.first < b.first; });
+        m.values_.reserve(pairs.size());
+        for (std::size_t i = 0; i < pairs.size(); ++i) {
+            if (i == 0 || pairs[i].first != pairs[i - 1].first) {
+                m.keys_.push_back(pairs[i].first);
+                m.offsets_.push_back(static_cast<uint32_t>(i));
+            }
+            m.values_.push_back(std::move(pairs[i].second));
+        }
+        m.offsets_.push_back(static_cast<uint32_t>(pairs.size()));
+        return m;
+    }
+
+    /// All values for `key`, as a contiguous span (empty if absent).
+    [[nodiscard]] auto equal_range(const K& key) const -> std::span<const V> {
+        const auto it = std::lower_bound(keys_.begin(), keys_.end(), key);
+        if (it == keys_.end() || *it != key) {
+            return {};
+        }
+        const auto k = static_cast<std::size_t>(it - keys_.begin());
+        return span_of(k, k + 1);
+    }
+
+    /// All values for keys in the given bounded range, as a contiguous span.
+    /// lo_inclusive/hi_inclusive select open/closed endpoints.
+    [[nodiscard]] auto range(const K& lo, bool lo_inclusive, const K& hi, bool hi_inclusive) const
+      -> std::span<const V> {
+        const std::size_t klo = lo_inclusive ? lower(lo) : upper(lo);
+        const std::size_t khi = hi_inclusive ? upper(hi) : lower(hi);
+        return span_of(klo, khi);
+    }
+
+    /// Values for keys >= lo (or > lo when inclusive=false).
+    [[nodiscard]] auto at_least(const K& lo, bool inclusive = true) const -> std::span<const V> {
+        return span_of(inclusive ? lower(lo) : upper(lo), keys_.size());
+    }
+    /// Values for keys <= hi (or < hi when inclusive=false).
+    [[nodiscard]] auto at_most(const K& hi, bool inclusive = true) const -> std::span<const V> {
+        return span_of(0, inclusive ? upper(hi) : lower(hi));
+    }
+
+    [[nodiscard]] auto contains(const K& key) const -> bool {
+        const auto it = std::lower_bound(keys_.begin(), keys_.end(), key);
+        return it != keys_.end() && *it == key;
+    }
+    [[nodiscard]] auto count(const K& key) const -> std::size_t { return equal_range(key).size(); }
+
+    [[nodiscard]] auto key_count() const noexcept -> std::size_t { return keys_.size(); }
+    [[nodiscard]] auto value_count() const noexcept -> std::size_t { return values_.size(); }
+    [[nodiscard]] auto empty() const noexcept -> bool { return values_.empty(); }
+    [[nodiscard]] auto keys() const noexcept -> std::span<const K> { return {keys_.data(), keys_.size()}; }
+
+    // Raw component access (e.g. for serialization).
+    [[nodiscard]] auto offsets() const noexcept -> std::span<const uint32_t> {
+        return {offsets_.data(), offsets_.size()};
+    }
+    [[nodiscard]] auto values() const noexcept -> std::span<const V> { return {values_.data(), values_.size()}; }
+
+   private:
+    [[nodiscard]] auto lower(const K& x) const -> std::size_t {
+        return static_cast<std::size_t>(std::lower_bound(keys_.begin(), keys_.end(), x) - keys_.begin());
+    }
+    [[nodiscard]] auto upper(const K& x) const -> std::size_t {
+        return static_cast<std::size_t>(std::upper_bound(keys_.begin(), keys_.end(), x) - keys_.begin());
+    }
+    [[nodiscard]] auto span_of(std::size_t klo, std::size_t khi) const -> std::span<const V> {
+        if (klo >= khi || klo >= keys_.size()) {
+            return {};
+        }
+        const uint32_t begin = offsets_[klo];
+        const uint32_t end = offsets_[khi];
+        return {values_.data() + begin, static_cast<std::size_t>(end - begin)};
+    }
+
+    std::vector<K> keys_{};
+    std::vector<uint32_t> offsets_{};
+    std::vector<V> values_{};
+};
+
+}  // namespace stdb::container

--- a/tests/immutable_ordered_multimap_test.cc
+++ b/tests/immutable_ordered_multimap_test.cc
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) STDB Holdings Limited
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "container/immutable_ordered_multimap.hpp"
+
+#include <cstdint>
+#include <map>
+#include <random>
+#include <vector>
+
+#include "doctest/doctest/doctest.h"
+
+namespace stdb::container {
+
+namespace {
+
+auto to_vec(std::span<const uint32_t> s) -> std::vector<uint32_t> {
+    std::vector<uint32_t> v(s.begin(), s.end());
+    std::sort(v.begin(), v.end());
+    return v;
+}
+
+}  // namespace
+
+TEST_CASE("immutable_ordered_multimap basic") {
+    // key -> rows:  50->{0,2}  7->{1,4}  99->{3}
+    std::vector<std::pair<int64_t, uint32_t>> pairs{{50, 0}, {7, 1}, {50, 2}, {99, 3}, {7, 4}};
+    auto m = immutable_ordered_multimap<int64_t, uint32_t>::build(pairs);
+
+    CHECK(m.key_count() == 3);
+    CHECK(m.value_count() == 5);
+
+    SUBCASE("equal_range") {
+        CHECK(to_vec(m.equal_range(50)) == std::vector<uint32_t>{0, 2});
+        CHECK(to_vec(m.equal_range(7)) == std::vector<uint32_t>{1, 4});
+        CHECK(to_vec(m.equal_range(99)) == std::vector<uint32_t>{3});
+        CHECK(m.equal_range(123).empty());
+        CHECK(m.equal_range(0).empty());
+        CHECK(m.contains(50));
+        CHECK(!m.contains(8));
+        CHECK(m.count(7) == 2);
+    }
+    SUBCASE("range bounds") {
+        // [7, 50]  -> keys 7,50 -> rows 0,1,2,4
+        CHECK(to_vec(m.range(7, true, 50, true)) == std::vector<uint32_t>{0, 1, 2, 4});
+        // (7, 99)  -> key 50    -> rows 0,2
+        CHECK(to_vec(m.range(7, false, 99, false)) == std::vector<uint32_t>{0, 2});
+        // [7, 99)  -> keys 7,50 -> rows 0,1,2,4
+        CHECK(to_vec(m.range(7, true, 99, false)) == std::vector<uint32_t>{0, 1, 2, 4});
+        // >= 50 -> keys 50,99 -> rows 0,2,3
+        CHECK(to_vec(m.at_least(50)) == std::vector<uint32_t>{0, 2, 3});
+        // > 7  -> keys 50,99 -> rows 0,2,3
+        CHECK(to_vec(m.at_least(7, false)) == std::vector<uint32_t>{0, 2, 3});
+        // <= 7 -> rows 1,4
+        CHECK(to_vec(m.at_most(7)) == std::vector<uint32_t>{1, 4});
+        // < 50 -> rows 1,4
+        CHECK(to_vec(m.at_most(50, false)) == std::vector<uint32_t>{1, 4});
+    }
+}
+
+TEST_CASE("immutable_ordered_multimap matches std::multimap (randomized)") {
+    std::mt19937_64 rng(2026);
+    std::uniform_int_distribution<int64_t> dist(0, 500);
+    std::vector<std::pair<int64_t, uint32_t>> pairs;
+    std::multimap<int64_t, uint32_t> ref;
+    for (uint32_t i = 0; i < 5000; ++i) {
+        const int64_t key = dist(rng);
+        pairs.emplace_back(key, i);
+        ref.emplace(key, i);
+    }
+    auto m = immutable_ordered_multimap<int64_t, uint32_t>::build(pairs);
+
+    for (int64_t key = -5; key <= 505; ++key) {
+        auto [b, e] = ref.equal_range(key);
+        std::vector<uint32_t> expect;
+        for (auto it = b; it != e; ++it) {
+            expect.push_back(it->second);
+        }
+        std::sort(expect.begin(), expect.end());
+        CHECK(to_vec(m.equal_range(key)) == expect);
+    }
+
+    // range [lo, hi]
+    for (int trial = 0; trial < 200; ++trial) {
+        int64_t lo = dist(rng);
+        int64_t hi = dist(rng);
+        if (lo > hi) {
+            std::swap(lo, hi);
+        }
+        std::vector<uint32_t> expect;
+        for (auto it = ref.lower_bound(lo); it != ref.upper_bound(hi); ++it) {
+            expect.push_back(it->second);
+        }
+        std::sort(expect.begin(), expect.end());
+        CHECK(to_vec(m.range(lo, true, hi, true)) == expect);
+    }
+}
+
+}  // namespace stdb::container


### PR DESCRIPTION
## What

Adds `stdb::container::immutable_ordered_multimap<K, V>` — a build-once, read-only ordered multimap stored as three flat arrays (CSR):

- `keys_[Nk]` distinct keys, ascending
- `offsets_[Nk+1]` values of key *i* are `values_[offsets_[i] .. offsets_[i+1])`
- `values_[Nv]` all values, grouped by key

Equality/range lookups (`equal_range`, `range`, `at_least`, `at_most`) binary-search the sorted keys and return a `std::span<const V>` **directly into the values array — zero copy, no materialization**. Any single-key or key-range result is a contiguous span.

## Why

The immutable counterpart to `btree_multimap`: it cannot insert/erase (those would be O(N)), but for immutable, build-once-read-many data it is smaller (no node/pointer overhead), builds faster, and answers point/range queries as zero-copy spans. Intended use: per-segment secondary indexes (value → row ids) over immutable columnar data.

## Benchmark (nanobench, vs `stdb::container::btree_multimap`, fair: both sum matching rows)

| scenario | op | immutable | btree_multimap | speedup |
|---|---|---|---|---|
| 22K high-card | build | 1.19ms | 1.58ms | 1.3x |
| | point | 3.39ms | 3.45ms | ~tie |
| | range | 7.7ms | 19.9ms | **2.6x** |
| 22K low-card (200) | build | 0.90ms | 1.53ms | 1.7x |
| | point | 2.6ms | 9.97ms | **3.85x** |
| | range | 4.1ms | 26.4ms | **6.4x** |
| 1M high-card | build | 95.6ms | 138.6ms | 1.45x |
| | point | 6.6ms | 7.87ms | 1.2x |
| | range | 69ms | 1679ms | **24x** |

Wins on build, point, and range; range especially (contiguous span scan vs B-tree node walk).

## Tests

`tests/immutable_ordered_multimap_test.cc` (doctest): 2 cases / 730 assertions, including a randomized cross-check against `std::multimap`.

## Files

- `container/immutable_ordered_multimap.hpp` — the container
- `tests/immutable_ordered_multimap_test.cc` — doctest tests
- `bench/immutable_ordered_multimap_bench.cc` + `bench/CMakeLists.txt` — nanobench benchmark

🤖 Generated with [Claude Code](https://claude.com/claude-code)