### PR TITLE
immutable_ordered_multimap: add from_parts (O(1) CSR reconstruct)

### DIFF
--- a/container/immutable_ordered_multimap.hpp
+++ b/container/immutable_ordered_multimap.hpp
@@ -62,6 +62,19 @@ class immutable_ordered_multimap
         return m;
     }
 
+    /// Reconstruct directly from already-built CSR parts (e.g. after deserialization),
+    /// in O(1) -- the caller guarantees `keys` is ascending & distinct, `offsets` has
+    /// keys.size()+1 entries with offsets.front()==0 and offsets.back()==values.size(),
+    /// and `values` is grouped by key. No sorting or validation is performed in release.
+    static auto from_parts(std::vector<K> keys, std::vector<uint32_t> offsets, std::vector<V> values)
+      -> immutable_ordered_multimap {
+        immutable_ordered_multimap m;
+        m.keys_ = std::move(keys);
+        m.offsets_ = std::move(offsets);
+        m.values_ = std::move(values);
+        return m;
+    }
+
     /// All values for `key`, as a contiguous span (empty if absent).
     [[nodiscard]] auto equal_range(const K& key) const -> std::span<const V> {
         const auto it = std::lower_bound(keys_.begin(), keys_.end(), key);

--- a/tests/immutable_ordered_multimap_test.cc
+++ b/tests/immutable_ordered_multimap_test.cc
@@ -60,6 +60,25 @@ TEST_CASE("immutable_ordered_multimap basic") {
     }
 }
 
+TEST_CASE("immutable_ordered_multimap from_parts round-trips build") {
+    std::vector<std::pair<int64_t, uint32_t>> pairs{{50, 0}, {7, 1}, {50, 2}, {99, 3}, {7, 4}};
+    auto built = immutable_ordered_multimap<int64_t, uint32_t>::build(pairs);
+
+    // Reconstruct from the exposed CSR parts; must answer queries identically.
+    std::vector<int64_t> keys(built.keys().begin(), built.keys().end());
+    std::vector<uint32_t> offsets(built.offsets().begin(), built.offsets().end());
+    std::vector<uint32_t> values(built.values().begin(), built.values().end());
+    auto rebuilt = immutable_ordered_multimap<int64_t, uint32_t>::from_parts(std::move(keys), std::move(offsets),
+                                                                            std::move(values));
+
+    CHECK(rebuilt.key_count() == built.key_count());
+    CHECK(rebuilt.value_count() == built.value_count());
+    CHECK(to_vec(rebuilt.equal_range(50)) == std::vector<uint32_t>{0, 2});
+    CHECK(to_vec(rebuilt.equal_range(7)) == std::vector<uint32_t>{1, 4});
+    CHECK(to_vec(rebuilt.range(7, true, 50, true)) == std::vector<uint32_t>{0, 1, 2, 4});
+    CHECK(rebuilt.equal_range(123).empty());
+}
+
 TEST_CASE("immutable_ordered_multimap matches std::multimap (randomized)") {
     std::mt19937_64 rng(2026);
     std::uniform_int_distribution<int64_t> dist(0, 500);


### PR DESCRIPTION
Adds `immutable_ordered_multimap<K,V>::from_parts(keys, offsets, values)` — reconstructs an instance directly from its three CSR arrays in O(1) (move, no sort/validation).

Build-once containers serialize as exactly these three arrays; a deserialization / mmap-load path needs to rebuild without re-sorting. `build()` (sort + group) stays the construction path from raw pairs; `from_parts()` is the inverse of `keys()/offsets()/values()`.

Test: build → dump parts → from_parts → identical equal_range/range/empty queries (+6 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)