### PR TITLE
container: add art_map (Adaptive Radix Tree ordered map)

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -68,6 +68,15 @@ if(ENABLE_ABSL_BENCH)
     message(STATUS "Building Abseil btree comparison benchmarks")
 endif()
 
+# Adaptive Radix Tree benchmark (vs btree_map, with optional Abseil comparison)
+add_executable(art_bench art_bench.cc)
+target_compile_definitions(art_bench PRIVATE NDEBUG)
+target_link_libraries(art_bench nanobench)
+if(ENABLE_ABSL_BENCH)
+    target_compile_definitions(art_bench PRIVATE ENABLE_ABSL)
+    target_link_libraries(art_bench absl::btree absl::flat_hash_map absl::hash)
+endif()
+
 # PMR allocator benchmark
 option(ENABLE_PMR_BENCH "Enable PMR allocator benchmark" ON)
 if(ENABLE_PMR_BENCH)

--- a/bench/art_bench.cc
+++ b/bench/art_bench.cc
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2025 ClapDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define ANKERL_NANOBENCH_IMPLEMENT
+#include "../nanobench/src/include/nanobench.h"
+
+#include <algorithm>
+#include <chrono>
+#include <iostream>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "container/art_map.hpp"
+#include "container/btree_map.hpp"
+
+#ifdef ENABLE_ABSL
+#include <absl/container/btree_map.h>
+#endif
+
+using stdb::container::art_map;
+using stdb::container::btree_map;
+
+template <std::size_t N>
+static void bench_int(const std::string& label) {
+    std::mt19937_64 rng(0xC0FFEE);
+    std::vector<uint64_t> keys(N);
+    for (auto& k : keys) k = rng();
+    std::vector<uint64_t> shuffled = keys;
+    std::shuffle(shuffled.begin(), shuffled.end(), rng);
+
+    std::cout << "\n=== uint64 keys: " << label << " (" << N << " elems) ===\n";
+    ankerl::nanobench::Bench b;
+    b.warmup(3).epochs(11).minEpochTime(std::chrono::milliseconds(40)).relative(true);
+
+    b.run("art_map   insert", [&] {
+        art_map<uint64_t, uint64_t> m;
+        for (auto k : keys) m[k] = k;
+        ankerl::nanobench::doNotOptimizeAway(m.size());
+    });
+    b.run("btree_map insert", [&] {
+        btree_map<uint64_t, uint64_t> m;
+        for (auto k : keys) m[k] = k;
+        ankerl::nanobench::doNotOptimizeAway(m.size());
+    });
+#ifdef ENABLE_ABSL
+    b.run("absl_btree insert", [&] {
+        absl::btree_map<uint64_t, uint64_t> m;
+        for (auto k : keys) m[k] = k;
+        ankerl::nanobench::doNotOptimizeAway(m.size());
+    });
+#endif
+
+    art_map<uint64_t, uint64_t> art;
+    btree_map<uint64_t, uint64_t> bt;
+    for (auto k : keys) {
+        art[k] = k;
+        bt[k] = k;
+    }
+#ifdef ENABLE_ABSL
+    absl::btree_map<uint64_t, uint64_t> ab;
+    for (auto k : keys) ab[k] = k;
+#endif
+
+    b.run("art_map   lookup", [&] {
+        uint64_t sum = 0;
+        for (auto k : shuffled) sum += art.find(k)->second;
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+    b.run("btree_map lookup", [&] {
+        uint64_t sum = 0;
+        for (auto k : shuffled) sum += bt.find(k)->second;
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+#ifdef ENABLE_ABSL
+    b.run("absl_btree lookup", [&] {
+        uint64_t sum = 0;
+        for (auto k : shuffled) sum += ab.find(k)->second;
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+#endif
+
+    b.run("art_map   scan", [&] {
+        uint64_t sum = 0;
+        for (const auto& kv : art) sum += kv.second;
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+    b.run("art_map   foreach", [&] {
+        uint64_t sum = 0;
+        art.for_each([&](const std::pair<const uint64_t, uint64_t>& kv) { sum += kv.second; });
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+    b.run("btree_map scan", [&] {
+        uint64_t sum = 0;
+        for (const auto& kv : bt) sum += kv.second;
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+#ifdef ENABLE_ABSL
+    b.run("absl_btree scan", [&] {
+        uint64_t sum = 0;
+        for (const auto& kv : ab) sum += kv.second;
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+#endif
+}
+
+template <std::size_t N>
+static void bench_string(const std::string& label, int keylen, bool shared_prefix) {
+    std::mt19937_64 rng(0xBEEF);
+    std::vector<std::string> keys;
+    keys.reserve(N);
+    const char* prefix = "user/session/2026/";
+    for (std::size_t i = 0; i < N; ++i) {
+        std::string s;
+        if (shared_prefix) s = prefix;
+        while (static_cast<int>(s.size()) < keylen) s.push_back(static_cast<char>('a' + (rng() % 26)));
+        keys.push_back(std::move(s));
+    }
+    std::sort(keys.begin(), keys.end());
+    keys.erase(std::unique(keys.begin(), keys.end()), keys.end());
+    std::vector<std::string> shuffled = keys;
+    std::shuffle(shuffled.begin(), shuffled.end(), rng);
+
+    std::cout << "\n=== string keys: " << label << " (" << keys.size()
+              << " elems, len=" << keylen << (shared_prefix ? ", shared prefix" : "") << ") ===\n";
+    ankerl::nanobench::Bench b;
+    b.warmup(3).epochs(11).minEpochTime(std::chrono::milliseconds(40)).relative(true);
+
+    b.run("art_map   insert", [&] {
+        art_map<std::string, uint64_t> m;
+        uint64_t i = 0;
+        for (auto& k : keys) m[k] = i++;
+        ankerl::nanobench::doNotOptimizeAway(m.size());
+    });
+    b.run("btree_map insert", [&] {
+        btree_map<std::string, uint64_t> m;
+        uint64_t i = 0;
+        for (auto& k : keys) m[k] = i++;
+        ankerl::nanobench::doNotOptimizeAway(m.size());
+    });
+
+    art_map<std::string, uint64_t> art;
+    btree_map<std::string, uint64_t> bt;
+    uint64_t i = 0;
+    for (auto& k : keys) {
+        art[k] = i;
+        bt[k] = i;
+        ++i;
+    }
+
+    b.run("art_map   lookup", [&] {
+        uint64_t sum = 0;
+        for (auto& k : shuffled) sum += art.find(k)->second;
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+    b.run("btree_map lookup", [&] {
+        uint64_t sum = 0;
+        for (auto& k : shuffled) sum += bt.find(k)->second;
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+
+    b.run("art_map   scan", [&] {
+        uint64_t sum = 0;
+        for (const auto& kv : art) sum += kv.second;
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+    b.run("art_map   foreach", [&] {
+        uint64_t sum = 0;
+        art.for_each([&](const std::pair<const std::string, uint64_t>& kv) { sum += kv.second; });
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+    b.run("btree_map scan", [&] {
+        uint64_t sum = 0;
+        for (const auto& kv : bt) sum += kv.second;
+        ankerl::nanobench::doNotOptimizeAway(sum);
+    });
+}
+
+int main() {
+    bench_int<100000>("100K");
+    bench_int<1000000>("1M");
+    bench_string<200000>("random", 16, false);
+    bench_string<200000>("shared-prefix", 28, true);
+    return 0;
+}

--- a/container/art_map.hpp
+++ b/container/art_map.hpp
@@ -2006,6 +2006,10 @@ class art_map
         } catch (...) {
             if (pending) free_leaf(pending);
             for (leaf_node* l : e) free_leaf(l);
+            // bulk_build may have allocated inner shells (now orphaned, _root still
+            // null). Release the slabs so a failed load leaves a clean empty map
+            // rather than retaining consumed slots until the next clear()/destroy.
+            release_pools();
             throw;
         }
     }

--- a/container/art_map.hpp
+++ b/container/art_map.hpp
@@ -694,8 +694,16 @@ class art_map
     art_map(const art_map& other)
         : _alloc(std::allocator_traits<Allocator>::select_on_container_copy_construction(
               other._alloc)) {
-        if (other._root) _root = clone(other._root);
-        _size = other._size;
+        // If clone() throws, this constructor fails and ~art_map() will NOT run, so the
+        // bump-allocator slabs (node_pool has no destructor of its own) would leak. Release
+        // them explicitly. clone() is exception-safe, so no constructed T outlives this.
+        try {
+            if (other._root) _root = clone(other._root);
+            _size = other._size;
+        } catch (...) {
+            release_pools();
+            throw;
+        }
     }
     art_map(art_map&& other) noexcept
         : _root(other._root),
@@ -1143,7 +1151,10 @@ class art_map
         }
     }
 
-    // Recursively clone a subtree.
+    // Recursively clone a subtree. Strongly exception-safe: if any leaf copy (T's copy
+    // constructor) or node allocation throws partway, every node and leaf already cloned
+    // for this subtree is destroyed before the exception propagates, so no half-built node
+    // is leaked and no constructed T is left without a matching destructor.
     node* clone(node* n) {
         if (is_leaf(n)) return make_leaf(as_leaf(n)->kv);
         inner* in = as_inner(n);
@@ -1152,22 +1163,34 @@ class art_map
             case nkind::n4: {
                 auto* p = static_cast<node4*>(in);
                 auto* g = make4();
-                for (uint8_t i = 0; i < p->nchild; ++i) {
-                    g->keys[i] = p->keys[i];
-                    g->child[i] = clone(p->child[i]);
+                try {
+                    for (uint8_t i = 0; i < p->nchild; ++i) {
+                        g->keys[i] = p->keys[i];
+                        g->child[i] = clone(p->child[i]);
+                        g->nchild = static_cast<uint8_t>(i + 1);  // keep destroyable on throw
+                    }
+                } catch (...) {
+                    for (uint8_t i = 0; i < g->nchild; ++i) destroy(g->child[i]);
+                    free_shell(g);
+                    throw;
                 }
-                g->nchild = p->nchild;
                 out = g;
                 break;
             }
             case nkind::n16: {
                 auto* p = static_cast<node16*>(in);
                 auto* g = make16();
-                for (uint8_t i = 0; i < p->nchild; ++i) {
-                    g->keys[i] = p->keys[i];
-                    g->child[i] = clone(p->child[i]);
+                try {
+                    for (uint8_t i = 0; i < p->nchild; ++i) {
+                        g->keys[i] = p->keys[i];
+                        g->child[i] = clone(p->child[i]);
+                        g->nchild = static_cast<uint8_t>(i + 1);
+                    }
+                } catch (...) {
+                    for (uint8_t i = 0; i < g->nchild; ++i) destroy(g->child[i]);
+                    free_shell(g);
+                    throw;
                 }
-                g->nchild = p->nchild;
                 out = g;
                 break;
             }
@@ -1175,16 +1198,33 @@ class art_map
                 auto* p = static_cast<node48*>(in);
                 auto* g = make48();
                 std::memcpy(g->cindex, p->cindex, sizeof(p->cindex));
-                for (uint8_t i = 0; i < p->nchild; ++i) g->child[i] = clone(p->child[i]);
-                g->nchild = p->nchild;
+                try {
+                    // child[] is dense; clean up by index (not cindex, which still maps to
+                    // not-yet-cloned source slots until the loop completes).
+                    for (uint8_t i = 0; i < p->nchild; ++i) {
+                        g->child[i] = clone(p->child[i]);
+                        g->nchild = static_cast<uint8_t>(i + 1);
+                    }
+                } catch (...) {
+                    for (uint8_t i = 0; i < g->nchild; ++i) destroy(g->child[i]);
+                    free_shell(g);
+                    throw;
+                }
                 out = g;
                 break;
             }
             case nkind::n256: {
                 auto* p = static_cast<node256*>(in);
-                auto* g = make256();
-                for (int b = 0; b < 256; ++b)
-                    if (p->child[b]) g->child[b] = clone(p->child[b]);
+                auto* g = make256();  // child[] is zero-initialized
+                try {
+                    for (int b = 0; b < 256; ++b)
+                        if (p->child[b]) g->child[b] = clone(p->child[b]);
+                } catch (...) {
+                    for (int b = 0; b < 256; ++b)
+                        if (g->child[b]) destroy(g->child[b]);
+                    free_shell(g);
+                    throw;
+                }
                 g->nchild = p->nchild;
                 out = g;
                 break;
@@ -1194,7 +1234,15 @@ class art_map
         }
         out->plen = in->plen;
         std::memcpy(out->prefix, in->prefix, kCap);
-        out->end_leaf = in->end_leaf ? make_leaf(as_leaf(in->end_leaf)->kv) : nullptr;
+        // out is now a fully consistent node; if the end-leaf copy throws, destroy() can
+        // unwind the whole subtree.
+        try {
+            out->end_leaf = in->end_leaf ? make_leaf(as_leaf(in->end_leaf)->kv) : nullptr;
+        } catch (...) {
+            out->end_leaf = nullptr;
+            destroy(out);
+            throw;
+        }
         return out;
     }
 
@@ -1392,7 +1440,14 @@ class art_map
                     return old;
                 }
                 leaf_node* nl = mk();
-                split_leaf(ref, old, lv, kv, depth, nl, path);
+                // If the structural step throws (node allocation), free the freshly made
+                // leaf so it does not leak; `old` is left reachable at *ref by split_leaf.
+                try {
+                    split_leaf(ref, old, lv, kv, depth, nl, path);
+                } catch (...) {
+                    free_leaf(nl);
+                    throw;
+                }
                 ++_size;
                 inserted = true;
                 return nl;
@@ -1402,7 +1457,12 @@ class art_map
                 uint8_t common = prefix_match(in, kv, depth);
                 if (common < in->plen) {
                     leaf_node* nl = mk();
-                    split_prefix(ref, in, common, kv, depth, nl, path);
+                    try {
+                        split_prefix(ref, in, common, kv, depth, nl, path);
+                    } catch (...) {
+                        free_leaf(nl);  // node alloc failed before *ref changed; drop new leaf
+                        throw;
+                    }
                     ++_size;
                     inserted = true;
                     return nl;
@@ -1432,8 +1492,16 @@ class art_map
             node** cref = find_child_ref(in, b);
             if (!cref) {
                 leaf_node* nl = mk();
-                if (is_full(in)) in = grow(ref, in);
-                add_child(in, b, nl);
+                // grow() is exception-safe (it allocates the larger node before touching
+                // the tree), so on a throw *ref still holds the original node; just free
+                // the new leaf.
+                try {
+                    if (is_full(in)) in = grow(ref, in);
+                    add_child(in, b, nl);
+                } catch (...) {
+                    free_leaf(nl);
+                    throw;
+                }
                 ++_size;
                 inserted = true;
                 if (path) {
@@ -1453,7 +1521,13 @@ class art_map
                     leaf_node* nl, iterator* path = nullptr) {
         uint32_t s = depth;
         while (s < lv.len && s < kv.len && lv.ptr[s] == kv.ptr[s]) ++s;  // divergence depth
-        node** cur = ref;
+        // Build the prefix chain off to the side and only publish it to *ref once it is
+        // fully built. make4() is the one allocation that can throw; if it does mid-chain,
+        // *ref still points at `old`, so the existing entry stays reachable and there is no
+        // partially built node (with a null child slot) left in the tree for destroy() to
+        // walk into.
+        node* head = nullptr;
+        node** cur = &head;
         uint32_t d = depth;
         while (true) {
             node4* nd = make4();
@@ -1477,6 +1551,7 @@ class art_map
                     path->push(nd, d == kv.len ? -1 : static_cast<int>(kv.ptr[d]));
                     path->_leaf = nl;
                 }
+                *ref = head;  // publish the completed chain atomically
                 return;
             }
             // bytes still shared at d: single child, continue chain

--- a/container/art_map.hpp
+++ b/container/art_map.hpp
@@ -105,6 +105,12 @@ struct art_key_encoder<Key, std::enable_if_t<std::is_floating_point_v<Key> && si
     static art_key_view encode(const Key& k, uint8_t* scratch) {
         U bits;
         std::memcpy(&bits, &k, sizeof(Key));
+        // IEEE -0.0 and +0.0 compare equal but have distinct bit patterns; collapse -0.0
+        // to the +0.0 representation so both encode to the same key and the map treats
+        // them as one entry (otherwise insert({-0.0, ...}) and insert({0.0, ...}) coexist).
+        if (k == Key(0)) {
+            bits = 0;
+        }
         U mask = (bits >> (sizeof(Key) * 8 - 1)) ? ~U(0) : (U(1) << (sizeof(Key) * 8 - 1));
         bits ^= mask;
         for (std::size_t i = 0; i < sizeof(Key); ++i) {

--- a/container/art_map.hpp
+++ b/container/art_map.hpp
@@ -1576,36 +1576,50 @@ class art_map
         node* head = nullptr;
         node** cur = &head;
         uint32_t d = depth;
-        while (true) {
-            node4* nd = make4();
-            uint8_t chunk = static_cast<uint8_t>(std::min<uint32_t>(s - d, kCap));
-            nd->plen = chunk;
-            if (chunk) std::memcpy(nd->prefix, kv.ptr + d, chunk);
-            *cur = nd;
-            d += chunk;
-            if (d == s) {
-                if (d == lv.len) {
-                    nd->end_leaf = old;
-                } else {
-                    add_child(nd, lv.ptr[d], old);
+        try {
+            while (true) {
+                node4* nd = make4();
+                uint8_t chunk = static_cast<uint8_t>(std::min<uint32_t>(s - d, kCap));
+                nd->plen = chunk;
+                if (chunk) std::memcpy(nd->prefix, kv.ptr + d, chunk);
+                *cur = nd;
+                d += chunk;
+                if (d == s) {
+                    if (d == lv.len) {
+                        nd->end_leaf = old;
+                    } else {
+                        add_child(nd, lv.ptr[d], old);
+                    }
+                    if (d == kv.len) {
+                        nd->end_leaf = nl;
+                    } else {
+                        add_child(nd, kv.ptr[d], nl);
+                    }
+                    if (path) {
+                        path->push(nd, d == kv.len ? -1 : static_cast<int>(kv.ptr[d]));
+                        path->_leaf = nl;
+                    }
+                    *ref = head;  // publish the completed chain atomically
+                    return;
                 }
-                if (d == kv.len) {
-                    nd->end_leaf = nl;
-                } else {
-                    add_child(nd, kv.ptr[d], nl);
-                }
-                if (path) {
-                    path->push(nd, d == kv.len ? -1 : static_cast<int>(kv.ptr[d]));
-                    path->_leaf = nl;
-                }
-                *ref = head;  // publish the completed chain atomically
-                return;
+                // bytes still shared at d: single child, continue chain
+                uint8_t b = kv.ptr[d];
+                if (path) path->push(nd, b);
+                cur = add_child4_slot(nd, b);
+                ++d;
             }
-            // bytes still shared at d: single child, continue chain
-            uint8_t b = kv.ptr[d];
-            if (path) path->push(nd, b);
-            cur = add_child4_slot(nd, b);
-            ++d;
+        } catch (...) {
+            // make4() threw mid-chain. The staged nodes are reachable only through `head`
+            // (the divergence point — where old/nl/end_leaf are attached — was not reached,
+            // so the chain holds no leaves); free those node4 shells so they don't leak pool
+            // slots. *ref is untouched, and do_insert frees the new leaf.
+            for (node* p = head; p != nullptr;) {
+                auto* n4 = static_cast<node4*>(p);
+                node* nxt = n4->nchild > 0 ? n4->child[0] : nullptr;  // single-child links
+                free_shell(n4);
+                p = nxt;
+            }
+            throw;
         }
     }
 

--- a/container/art_map.hpp
+++ b/container/art_map.hpp
@@ -343,7 +343,15 @@ class art_map
     template <typename... Args>
     leaf_node* make_leaf(Args&&... args) {
         auto* p = pool_new(_poolL);
-        ::new (static_cast<void*>(p)) leaf_node(std::forward<Args>(args)...);
+        // If the key/value construction throws, return the raw slot to the free list (the
+        // leaf_node was never constructed, so no destructor runs). Otherwise repeated
+        // failed inserts would consume leaf-pool slots and keep growing the slab list.
+        try {
+            ::new (static_cast<void*>(p)) leaf_node(std::forward<Args>(args)...);
+        } catch (...) {
+            _poolL.deallocate(p);
+            throw;
+        }
         p->kind = nkind::leaf;
         return p;
     }

--- a/container/art_map.hpp
+++ b/container/art_map.hpp
@@ -1278,7 +1278,8 @@ class art_map
             return;
         }
         inner* in = as_inner(n);
-        if (in->end_leaf) fn(static_cast<leaf_node*>(in->end_leaf)->kv);
+        if (in->end_leaf)
+            fn(const_cast<const value_type&>(static_cast<leaf_node*>(in->end_leaf)->kv));
         switch (in->kind) {
             case nkind::n4: {
                 auto* p = static_cast<node4*>(in);

--- a/container/art_map.hpp
+++ b/container/art_map.hpp
@@ -705,7 +705,11 @@ class art_map
     }
     art_map& operator=(const art_map& other) {
         if (this != &other) {
-            clear();
+            clear();  // free existing nodes with the current allocator
+            if constexpr (std::allocator_traits<
+                              Allocator>::propagate_on_container_copy_assignment::value) {
+                _alloc = other._alloc;  // adopt before cloning so slabs use the right allocator
+            }
             if (other._root) _root = clone(other._root);
             _size = other._size;
         }

--- a/container/art_map.hpp
+++ b/container/art_map.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <algorithm>
+#include <bit>
 #include <cstdint>
 #include <cstring>
 #include <iterator>
@@ -405,7 +406,7 @@ class art_map
                 __m128i keys = _mm_loadu_si128(reinterpret_cast<const __m128i*>(p->keys));
                 unsigned mask = static_cast<unsigned>(_mm_movemask_epi8(_mm_cmpeq_epi8(target, keys)));
                 mask &= (p->nchild >= 16) ? 0xFFFFu : ((1u << p->nchild) - 1u);
-                return mask ? &p->child[__builtin_ctz(mask)] : nullptr;
+                return mask ? &p->child[std::countr_zero(mask)] : nullptr;
 #else
                 for (uint8_t i = 0; i < p->nchild; ++i)
                     if (p->keys[i] == b) return &p->child[i];

--- a/container/art_map.hpp
+++ b/container/art_map.hpp
@@ -95,9 +95,9 @@ struct art_key_encoder<Key, std::enable_if_t<std::is_integral_v<Key> && std::is_
     }
 };
 
-// --- floating point ----------------------------------------------------------
+// --- floating point (storage-sized: float/double; excludes 80-bit long double) -
 template <typename Key>
-struct art_key_encoder<Key, std::enable_if_t<std::is_floating_point_v<Key>>>
+struct art_key_encoder<Key, std::enable_if_t<std::is_floating_point_v<Key> && sizeof(Key) <= 8>>
 {
     using U = std::conditional_t<sizeof(Key) == 4, uint32_t, uint64_t>;
     static constexpr bool fixed = true;
@@ -709,9 +709,17 @@ class art_map
         }
         return *this;
     }
-    art_map& operator=(art_map&& other) noexcept {
-        if (this != &other) {
+    art_map& operator=(art_map&& other) noexcept(
+        std::allocator_traits<Allocator>::propagate_on_container_move_assignment::value ||
+        std::allocator_traits<Allocator>::is_always_equal::value) {
+        if (this == &other) return *this;
+        constexpr bool pocma =
+            std::allocator_traits<Allocator>::propagate_on_container_move_assignment::value;
+        if (pocma || _alloc == other._alloc) {
+            // Safe to steal the source's slabs: either we adopt its allocator, or
+            // the two allocators are interchangeable.
             clear();
+            if constexpr (pocma) _alloc = std::move(other._alloc);
             _root = other._root;
             _size = other._size;
             _pool4 = std::move(other._pool4);
@@ -721,6 +729,19 @@ class art_map
             _poolL = std::move(other._poolL);
             other._root = nullptr;
             other._size = 0;
+        } else {
+            // Unequal, non-propagating allocators (e.g. distinct PMR resources):
+            // the source's slabs must not be freed by our allocator. Move elements
+            // individually using this map's allocator.
+            clear();
+            for (auto it = other.begin(); it != other.end(); ++it) {
+                bool inserted = false;
+                do_insert(it->first, inserted, [&] {
+                    return make_leaf(std::piecewise_construct, std::forward_as_tuple(it->first),
+                                     std::forward_as_tuple(std::move(it->second)));
+                });
+            }
+            other.clear();
         }
         return *this;
     }

--- a/container/art_map.hpp
+++ b/container/art_map.hpp
@@ -685,7 +685,9 @@ class art_map
         for (const auto& v : init) insert(v);
     }
 
-    art_map(const art_map& other) : _alloc(other._alloc) {
+    art_map(const art_map& other)
+        : _alloc(std::allocator_traits<Allocator>::select_on_container_copy_construction(
+              other._alloc)) {
         if (other._root) _root = clone(other._root);
         _size = other._size;
     }

--- a/container/art_map.hpp
+++ b/container/art_map.hpp
@@ -169,7 +169,7 @@ class art_map
 
     struct inner : node
     {
-        uint8_t nchild;
+        uint16_t nchild;  // up to 256 (node256 holds all byte values) — must not wrap
         uint8_t plen;
         uint8_t prefix[kCap];
         node* end_leaf;  // leaf whose key ends exactly at this node (prefix-of case)
@@ -221,6 +221,27 @@ class art_map
         slot* cur = nullptr;
         std::size_t left = 0;
         small_vectra<slot*, 8> chunks;
+
+        node_pool() = default;
+        // Moving must leave the source fully reset: otherwise its freelist/cur
+        // still point into slabs now owned by the destination (use-after-free if
+        // the moved-from map is reused).
+        node_pool(node_pool&& o) noexcept
+            : freelist(o.freelist), cur(o.cur), left(o.left), chunks(std::move(o.chunks)) {
+            o.freelist = nullptr;
+            o.cur = nullptr;
+            o.left = 0;
+        }
+        node_pool& operator=(node_pool&& o) noexcept {
+            freelist = o.freelist;
+            cur = o.cur;
+            left = o.left;
+            chunks = std::move(o.chunks);
+            o.freelist = nullptr;
+            o.cur = nullptr;
+            o.left = 0;
+            return *this;
+        }
 
         template <typename A>
         NT* allocate(A& a) {
@@ -400,7 +421,7 @@ class art_map
                 auto* p = static_cast<node4*>(n);
                 uint8_t pos = 0;
                 while (pos < p->nchild && p->keys[pos] < b) ++pos;
-                for (uint8_t i = p->nchild; i > pos; --i) {
+                for (uint8_t i = static_cast<uint8_t>(p->nchild); i > pos; --i) {
                     p->keys[i] = p->keys[i - 1];
                     p->child[i] = p->child[i - 1];
                 }
@@ -413,7 +434,7 @@ class art_map
                 auto* p = static_cast<node16*>(n);
                 uint8_t pos = 0;
                 while (pos < p->nchild && p->keys[pos] < b) ++pos;
-                for (uint8_t i = p->nchild; i > pos; --i) {
+                for (uint8_t i = static_cast<uint8_t>(p->nchild); i > pos; --i) {
                     p->keys[i] = p->keys[i - 1];
                     p->child[i] = p->child[i - 1];
                 }
@@ -424,7 +445,7 @@ class art_map
             }
             case nkind::n48: {
                 auto* p = static_cast<node48*>(n);
-                uint8_t slot = p->nchild;
+                uint8_t slot = static_cast<uint8_t>(p->nchild);
                 p->child[slot] = c;
                 p->cindex[b] = static_cast<uint8_t>(slot + 1);
                 ++p->nchild;
@@ -445,7 +466,7 @@ class art_map
     static node** add_child4_slot(node4* p, uint8_t b) {
         uint8_t pos = 0;
         while (pos < p->nchild && p->keys[pos] < b) ++pos;
-        for (uint8_t i = p->nchild; i > pos; --i) {
+        for (uint8_t i = static_cast<uint8_t>(p->nchild); i > pos; --i) {
             p->keys[i] = p->keys[i - 1];
             p->child[i] = p->child[i - 1];
         }

--- a/container/art_map.hpp
+++ b/container/art_map.hpp
@@ -204,8 +204,13 @@ class art_map
     struct leaf_node : node
     {
         value_type kv;
-        template <typename... Args>
-        explicit leaf_node(Args&&... args) : kv(std::forward<Args>(args)...) {}
+        // Build kv with uses-allocator construction so an allocator-aware Key/T (e.g. a PMR
+        // mapped_type) receives the map allocator. Constructing kv inside the leaf_node
+        // constructor starts the enclosing object's lifetime properly; guaranteed copy
+        // elision builds kv in place (no extra move).
+        template <typename Alloc, typename... Args>
+        leaf_node(std::allocator_arg_t, const Alloc& a, Args&&... args)
+            : kv(std::make_obj_using_allocator<value_type>(a, std::forward<Args>(args)...)) {}
     };
 
     template <typename U>
@@ -343,15 +348,13 @@ class art_map
     template <typename... Args>
     leaf_node* make_leaf(Args&&... args) {
         auto* p = pool_new(_poolL);
-        // Construct the stored pair through the map allocator so uses-allocator construction
-        // reaches an allocator-aware Key/T: e.g. a PMR mapped_type gets the map's
-        // memory_resource instead of the default one (the slab itself already uses the map
-        // allocator, but a direct placement-new would not propagate it to the value).
-        // On a throwing key/value constructor, return the raw slot to the free list
-        // (nothing was constructed) so repeated failed inserts don't keep growing slabs.
+        // Start the leaf_node lifetime via its constructor (it builds kv through the map
+        // allocator, so uses-allocator construction reaches an allocator-aware Key/T — e.g.
+        // a PMR mapped_type gets the map's resource rather than the default one). On a
+        // throwing key/value constructor, return the raw slot to the free list (nothing was
+        // constructed) so repeated failed inserts don't keep growing the slab list.
         try {
-            std::allocator_traits<Allocator>::construct(_alloc, std::addressof(p->kv),
-                                                        std::forward<Args>(args)...);
+            ::new (static_cast<void*>(p)) leaf_node(std::allocator_arg, _alloc, std::forward<Args>(args)...);
         } catch (...) {
             _poolL.deallocate(p);
             throw;
@@ -360,9 +363,7 @@ class art_map
         return p;
     }
     void free_leaf(leaf_node* l) {
-        // Symmetric with make_leaf: destroy the value through the allocator. The node base
-        // is trivially destructible, so destroying `kv` is the whole leaf.
-        std::allocator_traits<Allocator>::destroy(_alloc, std::addressof(l->kv));
+        l->~leaf_node();
         _poolL.deallocate(l);
     }
     void free_shell(node4* p) { _pool4.deallocate(p); }

--- a/container/art_map.hpp
+++ b/container/art_map.hpp
@@ -258,7 +258,14 @@ class art_map
             }
             if (left == 0) {
                 slot* c = a.allocate(kPer);
-                chunks.push_back(c);
+                // Record the slab before using it: if push_back grows `chunks` and throws,
+                // `c` is untracked and release_all() would never free it. Hand it back.
+                try {
+                    chunks.push_back(c);
+                } catch (...) {
+                    a.deallocate(c, kPer);
+                    throw;
+                }
                 cur = c;
                 left = kPer;
             }
@@ -1072,7 +1079,15 @@ class art_map
             case nkind::n16: {
                 auto* p = static_cast<node16*>(in);
                 if (p->nchild > 4) return in;
-                node4* g = make4();
+                // Shrinking is a best-effort compaction that runs after the element is
+                // already removed; if the replacement can't be allocated, keep the larger
+                // node (still valid) rather than failing an erase that already succeeded.
+                node4* g;
+                try {
+                    g = make4();
+                } catch (...) {
+                    return in;
+                }
                 copy_header(g, p);
                 for (uint8_t i = 0; i < p->nchild; ++i) {
                     g->keys[i] = p->keys[i];
@@ -1085,7 +1100,12 @@ class art_map
             case nkind::n48: {
                 auto* p = static_cast<node48*>(in);
                 if (p->nchild > 12) return in;
-                node16* g = make16();
+                node16* g;  // best-effort shrink (see node16 case)
+                try {
+                    g = make16();
+                } catch (...) {
+                    return in;
+                }
                 copy_header(g, p);
                 uint8_t i = 0;
                 for (int b = 0; b < 256; ++b)
@@ -1101,7 +1121,12 @@ class art_map
             case nkind::n256: {
                 auto* p = static_cast<node256*>(in);
                 if (p->nchild > 37) return in;
-                node48* g = make48();
+                node48* g;  // best-effort shrink (see node16 case)
+                try {
+                    g = make48();
+                } catch (...) {
+                    return in;
+                }
                 copy_header(g, p);
                 uint8_t i = 0;
                 for (int b = 0; b < 256; ++b)

--- a/container/art_map.hpp
+++ b/container/art_map.hpp
@@ -1451,6 +1451,12 @@ class art_map
     leaf_node* do_insert(const Key& key, bool& inserted, MakeLeaf&& mk, iterator* path = nullptr) {
         ekey kc(key);
         art_key_view kv = kc.view;
+        // The path frames are pushed as the tree is mutated below — some after end_leaf/
+        // _size have already been committed. Reserve the stack up front (one frame per
+        // inner node on the route, each consuming >= 1 key byte, so kv.len + 1 bounds it)
+        // so those push() calls cannot allocate and throw. Reserving before any mutation
+        // keeps insert() strongly exception-safe: a throw here leaves the tree untouched.
+        if (path) path->_stack.reserve(static_cast<std::size_t>(kv.len) + 1);
         node** ref = &_root;
         uint32_t depth = 0;
         while (true) {

--- a/container/art_map.hpp
+++ b/container/art_map.hpp
@@ -688,7 +688,15 @@ class art_map
     art_map() = default;
     explicit art_map(const Allocator& alloc) : _alloc(alloc) {}
     art_map(std::initializer_list<value_type> init) {
-        for (const auto& v : init) insert(v);
+        // If an insert throws partway, this constructor fails and ~art_map() will not run;
+        // clear() tears down the (consistent) partial tree and frees the slabs so nothing
+        // leaks.
+        try {
+            for (const auto& v : init) insert(v);
+        } catch (...) {
+            clear();
+            throw;
+        }
     }
 
     art_map(const art_map& other)
@@ -1896,35 +1904,49 @@ class art_map
     template <typename InputIt>
     void bulk_load(InputIt first, InputIt last) {
         clear();
+        // Leaves are staged in `e` (and the in-flight `pending`) before the tree exists;
+        // none are reachable through _root yet, so if any allocation below throws we must
+        // run their destructors here — ~art_map()/clear() would only see _root == null and
+        // release the raw slabs without destroying the staged values. Inner-node shells a
+        // partial bulk_build may have allocated own no T and are reclaimed by the next
+        // clear()/destructor via release_pools().
         std::vector<leaf_node*> e;
-        uint8_t s1[kArtKeyScratch];
-        uint8_t s2[kArtKeyScratch];
-        for (InputIt it = first; it != last; ++it) {
-            leaf_node* l = make_leaf(*it);
-            // dedup adjacent equal keys (sorted input): last wins
-            if (!e.empty() && view_eq(leaf_key(e.back(), s1), leaf_key(l, s2))) {
-                free_leaf(e.back());
-                e.back() = l;
-            } else {
-                e.push_back(l);
+        leaf_node* pending = nullptr;
+        try {
+            uint8_t s1[kArtKeyScratch];
+            uint8_t s2[kArtKeyScratch];
+            for (InputIt it = first; it != last; ++it) {
+                pending = make_leaf(*it);
+                // dedup adjacent equal keys (sorted input): last wins
+                if (!e.empty() && view_eq(leaf_key(e.back(), s1), leaf_key(pending, s2))) {
+                    free_leaf(e.back());
+                    e.back() = pending;
+                } else {
+                    e.push_back(pending);  // may throw before `pending` is owned by `e`
+                }
+                pending = nullptr;
             }
+            if (e.empty()) return;
+            // Precompute each leaf's encoded key once into a stable buffer (avoids
+            // re-encoding fixed keys on every comparison during the build).
+            std::size_t n = e.size();
+            std::vector<art_key_view> views(n);
+            std::vector<uint8_t> blob;
+            if constexpr (encoder::fixed) {
+                blob.resize(n * (encoder::bound ? encoder::bound : 1));
+                for (std::size_t i = 0; i < n; ++i)
+                    views[i] = leaf_key(e[i], blob.data() + i * encoder::bound);
+            } else {
+                uint8_t dummy[kArtKeyScratch];
+                for (std::size_t i = 0; i < n; ++i) views[i] = leaf_key(e[i], dummy);
+            }
+            _root = bulk_build(e.data(), views.data(), 0, n, 0);
+            _size = n;
+        } catch (...) {
+            if (pending) free_leaf(pending);
+            for (leaf_node* l : e) free_leaf(l);
+            throw;
         }
-        if (e.empty()) return;
-        // Precompute each leaf's encoded key once into a stable buffer (avoids
-        // re-encoding fixed keys on every comparison during the build).
-        std::size_t n = e.size();
-        std::vector<art_key_view> views(n);
-        std::vector<uint8_t> blob;
-        if constexpr (encoder::fixed) {
-            blob.resize(n * (encoder::bound ? encoder::bound : 1));
-            for (std::size_t i = 0; i < n; ++i)
-                views[i] = leaf_key(e[i], blob.data() + i * encoder::bound);
-        } else {
-            uint8_t dummy[kArtKeyScratch];
-            for (std::size_t i = 0; i < n; ++i) views[i] = leaf_key(e[i], dummy);
-        }
-        _root = bulk_build(e.data(), views.data(), 0, n, 0);
-        _size = n;
     }
 
     iterator erase(const_iterator pos) {

--- a/container/art_map.hpp
+++ b/container/art_map.hpp
@@ -1,0 +1,1894 @@
+/*
+ * Copyright 2025 ClapDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <iterator>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "small_vectra.hpp"
+
+#if defined(__x86_64__) || defined(_M_X64)
+#include <immintrin.h>
+#define ART_HAS_SSE2 1
+#endif
+
+#if defined(__GNUC__) || defined(__clang__)
+#define ART_PREFETCH(p) __builtin_prefetch((p))
+#else
+#define ART_PREFETCH(p) ((void)0)
+#endif
+
+namespace stdb::container {
+
+// ============================================================================
+// Key encoding: produce an order-preserving byte string so that lexicographic
+// comparison of the encoded bytes matches the desired ordering of keys.
+//   - unsigned integral : big-endian
+//   - signed integral   : flip sign bit, big-endian
+//   - floating point    : IEEE total order, big-endian
+//   - string-like       : identity (already byte-ordered)
+// Users may specialize art_key_encoder<Key> for custom key types.
+// ============================================================================
+
+struct art_key_view
+{
+    const uint8_t* ptr;
+    uint32_t len;
+};
+
+// Maximum scratch buffer (bytes) required to encode a fixed-length key.
+inline constexpr std::size_t kArtKeyScratch = 32;
+
+template <typename Key, typename Enable = void>
+struct art_key_encoder;  // primary template intentionally undefined
+
+// --- unsigned integral -------------------------------------------------------
+template <typename Key>
+struct art_key_encoder<Key, std::enable_if_t<std::is_integral_v<Key> && std::is_unsigned_v<Key>>>
+{
+    static constexpr bool fixed = true;
+    static constexpr std::size_t bound = sizeof(Key);
+    static art_key_view encode(const Key& k, uint8_t* scratch) {
+        for (std::size_t i = 0; i < sizeof(Key); ++i) {
+            scratch[i] = static_cast<uint8_t>(k >> (8 * (sizeof(Key) - 1 - i)));
+        }
+        return {scratch, static_cast<uint32_t>(sizeof(Key))};
+    }
+};
+
+// --- signed integral (incl. char/bool handled by unsigned path when unsigned) -
+template <typename Key>
+struct art_key_encoder<Key, std::enable_if_t<std::is_integral_v<Key> && std::is_signed_v<Key>>>
+{
+    using U = std::make_unsigned_t<Key>;
+    static constexpr bool fixed = true;
+    static constexpr std::size_t bound = sizeof(Key);
+    static art_key_view encode(const Key& k, uint8_t* scratch) {
+        U u = static_cast<U>(k) ^ (U(1) << (sizeof(Key) * 8 - 1));
+        for (std::size_t i = 0; i < sizeof(Key); ++i) {
+            scratch[i] = static_cast<uint8_t>(u >> (8 * (sizeof(Key) - 1 - i)));
+        }
+        return {scratch, static_cast<uint32_t>(sizeof(Key))};
+    }
+};
+
+// --- floating point ----------------------------------------------------------
+template <typename Key>
+struct art_key_encoder<Key, std::enable_if_t<std::is_floating_point_v<Key>>>
+{
+    using U = std::conditional_t<sizeof(Key) == 4, uint32_t, uint64_t>;
+    static constexpr bool fixed = true;
+    static constexpr std::size_t bound = sizeof(Key);
+    static art_key_view encode(const Key& k, uint8_t* scratch) {
+        U bits;
+        std::memcpy(&bits, &k, sizeof(Key));
+        U mask = (bits >> (sizeof(Key) * 8 - 1)) ? ~U(0) : (U(1) << (sizeof(Key) * 8 - 1));
+        bits ^= mask;
+        for (std::size_t i = 0; i < sizeof(Key); ++i) {
+            scratch[i] = static_cast<uint8_t>(bits >> (8 * (sizeof(Key) - 1 - i)));
+        }
+        return {scratch, static_cast<uint32_t>(sizeof(Key))};
+    }
+};
+
+// --- string-like -------------------------------------------------------------
+template <>
+struct art_key_encoder<std::string>
+{
+    static constexpr bool fixed = false;
+    static constexpr std::size_t bound = 0;
+    static art_key_view encode(const std::string& k, uint8_t*) {
+        return {reinterpret_cast<const uint8_t*>(k.data()), static_cast<uint32_t>(k.size())};
+    }
+};
+
+template <>
+struct art_key_encoder<std::string_view>
+{
+    static constexpr bool fixed = false;
+    static constexpr std::size_t bound = 0;
+    static art_key_view encode(std::string_view k, uint8_t*) {
+        return {reinterpret_cast<const uint8_t*>(k.data()), static_cast<uint32_t>(k.size())};
+    }
+};
+
+// ============================================================================
+// art_map
+// ============================================================================
+
+template <typename Key, typename T, typename Allocator = std::allocator<std::pair<const Key, T>>>
+class art_map
+{
+  public:
+    using key_type = Key;
+    using mapped_type = T;
+    using value_type = std::pair<const Key, T>;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using allocator_type = Allocator;
+    using reference = value_type&;
+    using const_reference = const value_type&;
+    using pointer = value_type*;
+    using const_pointer = const value_type*;
+
+  private:
+    using encoder = art_key_encoder<Key>;
+    static_assert(encoder::bound <= kArtKeyScratch, "fixed key too large for scratch buffer");
+
+    static constexpr uint8_t kCap = 8;  // bounded path-compression prefix
+
+    enum class nkind : uint8_t { leaf = 0, n4, n16, n48, n256 };
+
+    struct node
+    {
+        nkind kind;
+    };
+
+    struct inner : node
+    {
+        uint8_t nchild;
+        uint8_t plen;
+        uint8_t prefix[kCap];
+        node* end_leaf;  // leaf whose key ends exactly at this node (prefix-of case)
+    };
+
+    struct node4 : inner
+    {
+        uint8_t keys[4];
+        node* child[4];
+    };
+    struct node16 : inner
+    {
+        uint8_t keys[16];
+        node* child[16];
+    };
+    struct node48 : inner
+    {
+        uint8_t cindex[256];  // 0 = empty, else slot+1
+        node* child[48];
+    };
+    struct node256 : inner
+    {
+        node* child[256];
+    };
+
+    struct leaf_node : node
+    {
+        value_type kv;
+        template <typename... Args>
+        explicit leaf_node(Args&&... args) : kv(std::forward<Args>(args)...) {}
+    };
+
+    template <typename U>
+    using rebind_alloc = typename std::allocator_traits<Allocator>::template rebind_alloc<U>;
+
+    // --- node pool: slab allocation + per-kind free list ---------------------
+    // Cuts the malloc count dramatically (one chunk per kPer nodes) and recycles
+    // freed shells; this is the main lever for ART insert throughput.
+    template <typename NT>
+    struct node_pool
+    {
+        union slot
+        {
+            slot* next;
+            alignas(NT) unsigned char buf[sizeof(NT)];
+        };
+        static constexpr std::size_t kPer = 512;
+        slot* freelist = nullptr;
+        slot* cur = nullptr;
+        std::size_t left = 0;
+        small_vectra<slot*, 8> chunks;
+
+        template <typename A>
+        NT* allocate(A& a) {
+            if (freelist) {
+                slot* s = freelist;
+                freelist = s->next;
+                return reinterpret_cast<NT*>(s);
+            }
+            if (left == 0) {
+                slot* c = a.allocate(kPer);
+                chunks.push_back(c);
+                cur = c;
+                left = kPer;
+            }
+            slot* s = cur++;
+            --left;
+            return reinterpret_cast<NT*>(s);
+        }
+        void deallocate(NT* p) {
+            slot* s = reinterpret_cast<slot*>(p);
+            s->next = freelist;
+            freelist = s;
+        }
+        template <typename A>
+        void release_all(A& a) {
+            for (std::size_t i = 0; i < chunks.size(); ++i) a.deallocate(chunks[i], kPer);
+            chunks.clear();
+            freelist = nullptr;
+            cur = nullptr;
+            left = 0;
+        }
+    };
+
+    template <typename NT>
+    NT* pool_new(node_pool<NT>& pool) {
+        rebind_alloc<typename node_pool<NT>::slot> a(_alloc);
+        return pool.allocate(a);
+    }
+    template <typename NT>
+    void pool_release(node_pool<NT>& pool) {
+        rebind_alloc<typename node_pool<NT>::slot> a(_alloc);
+        pool.release_all(a);
+    }
+    void release_pools() {
+        pool_release(_pool4);
+        pool_release(_pool16);
+        pool_release(_pool48);
+        pool_release(_pool256);
+        pool_release(_poolL);
+    }
+
+    node4* make4() {
+        auto* n = pool_new(_pool4);
+        n->kind = nkind::n4;
+        n->nchild = 0;
+        n->plen = 0;
+        n->end_leaf = nullptr;
+        return n;
+    }
+    node16* make16() {
+        auto* n = pool_new(_pool16);
+        n->kind = nkind::n16;
+        n->nchild = 0;
+        n->plen = 0;
+        n->end_leaf = nullptr;
+        return n;
+    }
+    node48* make48() {
+        auto* n = pool_new(_pool48);
+        n->kind = nkind::n48;
+        n->nchild = 0;
+        n->plen = 0;
+        n->end_leaf = nullptr;
+        std::memset(n->cindex, 0, sizeof(n->cindex));
+        return n;
+    }
+    node256* make256() {
+        auto* n = pool_new(_pool256);
+        n->kind = nkind::n256;
+        n->nchild = 0;
+        n->plen = 0;
+        n->end_leaf = nullptr;
+        std::memset(n->child, 0, sizeof(n->child));
+        return n;
+    }
+    template <typename... Args>
+    leaf_node* make_leaf(Args&&... args) {
+        auto* p = pool_new(_poolL);
+        ::new (static_cast<void*>(p)) leaf_node(std::forward<Args>(args)...);
+        p->kind = nkind::leaf;
+        return p;
+    }
+    void free_leaf(leaf_node* l) {
+        l->~leaf_node();
+        _poolL.deallocate(l);
+    }
+    void free_shell(node4* p) { _pool4.deallocate(p); }
+    void free_shell(node16* p) { _pool16.deallocate(p); }
+    void free_shell(node48* p) { _pool48.deallocate(p); }
+    void free_shell(node256* p) { _pool256.deallocate(p); }
+
+    static bool is_leaf(const node* n) { return n->kind == nkind::leaf; }
+    static leaf_node* as_leaf(node* n) { return static_cast<leaf_node*>(n); }
+    static inner* as_inner(node* n) { return static_cast<inner*>(n); }
+
+    // --- encoded-key helpers -------------------------------------------------
+    struct ekey
+    {
+        uint8_t scratch[kArtKeyScratch];
+        art_key_view view;
+        explicit ekey(const Key& k) { view = encoder::encode(k, scratch); }
+    };
+    static art_key_view leaf_key(leaf_node* l, uint8_t* scratch) {
+        return encoder::encode(l->kv.first, scratch);
+    }
+    static bool view_eq(art_key_view a, art_key_view b) {
+        return a.len == b.len && (a.len == 0 || std::memcmp(a.ptr, b.ptr, a.len) == 0);
+    }
+
+    // --- child lookup --------------------------------------------------------
+    static node** find_child_ref(inner* n, uint8_t b) {
+        switch (n->kind) {
+            case nkind::n4: {
+                auto* p = static_cast<node4*>(n);
+                for (uint8_t i = 0; i < p->nchild; ++i)
+                    if (p->keys[i] == b) return &p->child[i];
+                return nullptr;
+            }
+            case nkind::n16: {
+                auto* p = static_cast<node16*>(n);
+#ifdef ART_HAS_SSE2
+                __m128i target = _mm_set1_epi8(static_cast<char>(b));
+                __m128i keys = _mm_loadu_si128(reinterpret_cast<const __m128i*>(p->keys));
+                unsigned mask = static_cast<unsigned>(_mm_movemask_epi8(_mm_cmpeq_epi8(target, keys)));
+                mask &= (p->nchild >= 16) ? 0xFFFFu : ((1u << p->nchild) - 1u);
+                return mask ? &p->child[__builtin_ctz(mask)] : nullptr;
+#else
+                for (uint8_t i = 0; i < p->nchild; ++i)
+                    if (p->keys[i] == b) return &p->child[i];
+                return nullptr;
+#endif
+            }
+            case nkind::n48: {
+                auto* p = static_cast<node48*>(n);
+                uint8_t idx = p->cindex[b];
+                return idx ? &p->child[idx - 1] : nullptr;
+            }
+            case nkind::n256: {
+                auto* p = static_cast<node256*>(n);
+                return p->child[b] ? &p->child[b] : nullptr;
+            }
+            default:
+                return nullptr;
+        }
+    }
+    static node* find_child(inner* n, uint8_t b) {
+        node** r = find_child_ref(n, b);
+        return r ? *r : nullptr;
+    }
+    static bool is_full(inner* n) {
+        switch (n->kind) {
+            case nkind::n4:
+                return n->nchild == 4;
+            case nkind::n16:
+                return n->nchild == 16;
+            case nkind::n48:
+                return n->nchild == 48;
+            default:
+                return false;  // n256 never full
+        }
+    }
+
+    // --- add child (assumes space available) ---------------------------------
+    static void add_child(inner* n, uint8_t b, node* c) {
+        switch (n->kind) {
+            case nkind::n4: {
+                auto* p = static_cast<node4*>(n);
+                uint8_t pos = 0;
+                while (pos < p->nchild && p->keys[pos] < b) ++pos;
+                for (uint8_t i = p->nchild; i > pos; --i) {
+                    p->keys[i] = p->keys[i - 1];
+                    p->child[i] = p->child[i - 1];
+                }
+                p->keys[pos] = b;
+                p->child[pos] = c;
+                ++p->nchild;
+                return;
+            }
+            case nkind::n16: {
+                auto* p = static_cast<node16*>(n);
+                uint8_t pos = 0;
+                while (pos < p->nchild && p->keys[pos] < b) ++pos;
+                for (uint8_t i = p->nchild; i > pos; --i) {
+                    p->keys[i] = p->keys[i - 1];
+                    p->child[i] = p->child[i - 1];
+                }
+                p->keys[pos] = b;
+                p->child[pos] = c;
+                ++p->nchild;
+                return;
+            }
+            case nkind::n48: {
+                auto* p = static_cast<node48*>(n);
+                uint8_t slot = p->nchild;
+                p->child[slot] = c;
+                p->cindex[b] = static_cast<uint8_t>(slot + 1);
+                ++p->nchild;
+                return;
+            }
+            case nkind::n256: {
+                auto* p = static_cast<node256*>(n);
+                p->child[b] = c;
+                ++p->nchild;
+                return;
+            }
+            default:
+                return;
+        }
+    }
+
+    // Add a child to a node4 and return a stable pointer to its child slot.
+    static node** add_child4_slot(node4* p, uint8_t b) {
+        uint8_t pos = 0;
+        while (pos < p->nchild && p->keys[pos] < b) ++pos;
+        for (uint8_t i = p->nchild; i > pos; --i) {
+            p->keys[i] = p->keys[i - 1];
+            p->child[i] = p->child[i - 1];
+        }
+        p->keys[pos] = b;
+        p->child[pos] = nullptr;
+        ++p->nchild;
+        return &p->child[pos];
+    }
+
+    // --- grow node to next larger kind; replaces *ref, frees old shell -------
+    inner* grow(node** ref, inner* n) {
+        switch (n->kind) {
+            case nkind::n4: {
+                auto* p = static_cast<node4*>(n);
+                node16* g = make16();
+                copy_header(g, p);
+                for (uint8_t i = 0; i < p->nchild; ++i) {
+                    g->keys[i] = p->keys[i];
+                    g->child[i] = p->child[i];
+                }
+                g->nchild = p->nchild;
+                *ref = g;
+                free_shell(p);
+                return g;
+            }
+            case nkind::n16: {
+                auto* p = static_cast<node16*>(n);
+                node48* g = make48();
+                copy_header(g, p);
+                for (uint8_t i = 0; i < p->nchild; ++i) {
+                    g->child[i] = p->child[i];
+                    g->cindex[p->keys[i]] = static_cast<uint8_t>(i + 1);
+                }
+                g->nchild = p->nchild;
+                *ref = g;
+                free_shell(p);
+                return g;
+            }
+            case nkind::n48: {
+                auto* p = static_cast<node48*>(n);
+                node256* g = make256();
+                copy_header(g, p);
+                for (int b = 0; b < 256; ++b) {
+                    uint8_t idx = p->cindex[b];
+                    if (idx) g->child[b] = p->child[idx - 1];
+                }
+                g->nchild = p->nchild;
+                *ref = g;
+                free_shell(p);
+                return g;
+            }
+            default:
+                return n;
+        }
+    }
+    static void copy_header(inner* dst, inner* src) {
+        dst->plen = src->plen;
+        std::memcpy(dst->prefix, src->prefix, kCap);
+        dst->end_leaf = src->end_leaf;
+    }
+
+    // --- prefix match: how many prefix bytes match key from depth ------------
+    static uint8_t prefix_match(inner* n, art_key_view key, uint32_t depth) {
+        uint8_t maxlen = n->plen;
+        if (key.len - depth < maxlen) maxlen = static_cast<uint8_t>(key.len - depth);
+        uint8_t i = 0;
+        for (; i < maxlen; ++i)
+            if (n->prefix[i] != key.ptr[depth + i]) break;
+        return i;
+    }
+
+    // --- iterator (defined before modifiers that return iterator) ------------
+    struct frame
+    {
+        inner* node;
+        int cursor;  // -1 == end_leaf, else byte value 0..255
+    };
+
+    template <bool Const>
+    class iter_impl
+    {
+        friend class art_map;
+        template <bool>
+        friend class iter_impl;
+        using map_ptr = std::conditional_t<Const, const art_map*, art_map*>;
+
+      public:
+        using iterator_category = std::bidirectional_iterator_tag;
+        using value_type = art_map::value_type;
+        using difference_type = std::ptrdiff_t;
+        using reference = std::conditional_t<Const, const value_type&, value_type&>;
+        using pointer = std::conditional_t<Const, const value_type*, value_type*>;
+
+        iter_impl() = default;
+        // allow iterator -> const_iterator conversion
+        template <bool C = Const, typename = std::enable_if_t<C>>
+        iter_impl(const iter_impl<false>& o) : _owner(o._owner), _leaf(o._leaf), _stack() {
+            for (std::size_t i = 0; i < o._stack.size(); ++i) _stack.push_back(o._stack[i]);
+        }
+
+        reference operator*() const { return _leaf->kv; }
+        pointer operator->() const { return &_leaf->kv; }
+
+        iter_impl& operator++() {
+            advance();
+            return *this;
+        }
+        iter_impl operator++(int) {
+            iter_impl t = *this;
+            advance();
+            return t;
+        }
+        iter_impl& operator--() {
+            retreat();
+            return *this;
+        }
+        iter_impl operator--(int) {
+            iter_impl t = *this;
+            retreat();
+            return t;
+        }
+        bool operator==(const iter_impl& o) const { return _leaf == o._leaf; }
+        bool operator!=(const iter_impl& o) const { return _leaf != o._leaf; }
+
+      private:
+        void push(inner* n, int c) { _stack.push_back(frame{n, c}); }
+
+        void descend_leftmost_into(node* c) {
+            while (true) {
+                if (is_leaf(c)) {
+                    _leaf = as_leaf(c);
+                    return;
+                }
+                inner* in = as_inner(c);
+                if (in->end_leaf) {
+                    push(in, -1);
+                    _leaf = as_leaf(in->end_leaf);
+                    return;
+                }
+                step s = first_step(in);
+                push(in, s.byte);
+                c = s.child;
+            }
+        }
+        void descend_rightmost_into(node* c) {
+            while (true) {
+                if (is_leaf(c)) {
+                    _leaf = as_leaf(c);
+                    return;
+                }
+                inner* in = as_inner(c);
+                step s = last_step(in);
+                if (s.byte >= 0) {
+                    push(in, s.byte);
+                    c = s.child;
+                } else {
+                    push(in, -1);
+                    _leaf = as_leaf(in->end_leaf);
+                    return;
+                }
+            }
+        }
+        void advance() {
+            while (!_stack.empty()) {
+                frame& f = _stack.back();
+                step s = (f.cursor == -1) ? first_step(f.node) : next_step(f.node, f.cursor);
+                if (s.byte >= 0) {
+                    f.cursor = s.byte;
+                    descend_leftmost_into(s.child);
+                    return;
+                }
+                _stack.pop_back();
+            }
+            _leaf = nullptr;
+        }
+        void retreat() {
+            if (_leaf == nullptr) {  // --end()
+                if (_owner && _owner->_root) descend_rightmost_into(_owner->_root);
+                return;
+            }
+            while (!_stack.empty()) {
+                frame& f = _stack.back();
+                if (f.cursor == -1) {
+                    _stack.pop_back();
+                    continue;
+                }
+                step s = prev_step(f.node, f.cursor);
+                if (s.byte >= 0) {
+                    f.cursor = s.byte;
+                    descend_rightmost_into(s.child);
+                    return;
+                }
+                if (f.node->end_leaf) {
+                    f.cursor = -1;
+                    _leaf = as_leaf(f.node->end_leaf);
+                    return;
+                }
+                _stack.pop_back();
+            }
+        }
+
+        map_ptr _owner = nullptr;
+        leaf_node* _leaf = nullptr;
+        small_vectra<frame, 16> _stack;
+    };
+
+  public:
+    using iterator = iter_impl<false>;
+    using const_iterator = iter_impl<true>;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+    art_map() = default;
+    explicit art_map(const Allocator& alloc) : _alloc(alloc) {}
+    art_map(std::initializer_list<value_type> init) {
+        for (const auto& v : init) insert(v);
+    }
+
+    art_map(const art_map& other) : _alloc(other._alloc) {
+        if (other._root) _root = clone(other._root);
+        _size = other._size;
+    }
+    art_map(art_map&& other) noexcept
+        : _root(other._root),
+          _size(other._size),
+          _alloc(std::move(other._alloc)),
+          _pool4(std::move(other._pool4)),
+          _pool16(std::move(other._pool16)),
+          _pool48(std::move(other._pool48)),
+          _pool256(std::move(other._pool256)),
+          _poolL(std::move(other._poolL)) {
+        other._root = nullptr;
+        other._size = 0;
+    }
+    art_map& operator=(const art_map& other) {
+        if (this != &other) {
+            clear();
+            if (other._root) _root = clone(other._root);
+            _size = other._size;
+        }
+        return *this;
+    }
+    art_map& operator=(art_map&& other) noexcept {
+        if (this != &other) {
+            clear();
+            _root = other._root;
+            _size = other._size;
+            _pool4 = std::move(other._pool4);
+            _pool16 = std::move(other._pool16);
+            _pool48 = std::move(other._pool48);
+            _pool256 = std::move(other._pool256);
+            _poolL = std::move(other._poolL);
+            other._root = nullptr;
+            other._size = 0;
+        }
+        return *this;
+    }
+    ~art_map() { clear(); }
+
+    [[nodiscard]] bool empty() const noexcept { return _size == 0; }
+    [[nodiscard]] size_type size() const noexcept { return _size; }
+    allocator_type get_allocator() const noexcept { return _alloc; }
+
+    void clear() noexcept {
+        if (_root) {
+            destroy(_root);  // runs leaf destructors, returns shells to pools
+            _root = nullptr;
+        }
+        _size = 0;
+        release_pools();  // free the underlying slabs
+    }
+
+    [[nodiscard]] bool contains(const Key& key) const { return find_leaf(key) != nullptr; }
+    [[nodiscard]] size_type count(const Key& key) const { return find_leaf(key) ? 1 : 0; }
+
+    T& at(const Key& key) {
+        leaf_node* l = find_leaf(key);
+        if (!l) throw std::out_of_range("art_map::at");
+        return l->kv.second;
+    }
+    const T& at(const Key& key) const {
+        leaf_node* l = find_leaf(key);
+        if (!l) throw std::out_of_range("art_map::at");
+        return l->kv.second;
+    }
+
+    T& operator[](const Key& key) {
+        bool inserted = false;
+        leaf_node* l = do_insert(key, inserted, [&] { return make_leaf(std::piecewise_construct,
+                                                                      std::forward_as_tuple(key),
+                                                                      std::forward_as_tuple()); });
+        return l->kv.second;
+    }
+
+    std::pair<iterator, bool> insert(const value_type& v) {
+        iterator it;
+        it._owner = this;
+        bool inserted = false;
+        do_insert(v.first, inserted, [&] { return make_leaf(v); }, &it);
+        return {it, inserted};
+    }
+    std::pair<iterator, bool> insert(value_type&& v) {
+        iterator it;
+        it._owner = this;
+        bool inserted = false;
+        do_insert(v.first, inserted, [&] { return make_leaf(std::move(v)); }, &it);
+        return {it, inserted};
+    }
+    template <typename M>
+    std::pair<iterator, bool> insert_or_assign(const Key& key, M&& value) {
+        iterator it;
+        it._owner = this;
+        bool inserted = false;
+        leaf_node* l = do_insert(key, inserted, [&] {
+            return make_leaf(std::piecewise_construct, std::forward_as_tuple(key),
+                             std::forward_as_tuple(std::forward<M>(value)));
+        }, &it);
+        if (!inserted) l->kv.second = std::forward<M>(value);
+        return {it, inserted};
+    }
+    template <typename... Args>
+    std::pair<iterator, bool> emplace(Args&&... args) {
+        return insert(value_type(std::forward<Args>(args)...));
+    }
+    template <typename... Args>
+    std::pair<iterator, bool> try_emplace(const Key& key, Args&&... args) {
+        iterator it;
+        it._owner = this;
+        bool inserted = false;
+        do_insert(key, inserted, [&] {
+            return make_leaf(std::piecewise_construct, std::forward_as_tuple(key),
+                             std::forward_as_tuple(std::forward<Args>(args)...));
+        }, &it);
+        return {it, inserted};
+    }
+
+    size_type erase(const Key& key) {
+        if (!_root) return 0;
+        ekey kc(key);
+        art_key_view kv = kc.view;
+        uint8_t s[kArtKeyScratch];
+
+        if (is_leaf(_root)) {
+            if (!view_eq(leaf_key(static_cast<leaf_node*>(_root), s), kv)) return 0;
+            free_leaf(static_cast<leaf_node*>(_root));
+            _root = nullptr;
+            --_size;
+            return 1;
+        }
+
+        // Descend over inner nodes, recording the path so we can cascade the
+        // structural simplification back up to the root.
+        small_vectra<erase_frame, 24> path;
+        inner* in = as_inner(_root);
+        uint32_t depth = 0;
+        inner* hit = nullptr;  // node we removed a child / end_leaf from
+        while (true) {
+            if (in->plen) {
+                if (kv.len - depth < in->plen) return 0;
+                if (std::memcmp(in->prefix, kv.ptr + depth, in->plen) != 0) return 0;
+                depth += in->plen;
+            }
+            if (depth == kv.len) {
+                if (!in->end_leaf) return 0;
+                free_leaf(static_cast<leaf_node*>(in->end_leaf));
+                in->end_leaf = nullptr;
+                hit = in;
+                break;
+            }
+            uint8_t b = kv.ptr[depth];
+            node** cref = find_child_ref(in, b);
+            if (!cref) return 0;
+            node* child = *cref;
+            if (is_leaf(child)) {
+                if (!view_eq(leaf_key(static_cast<leaf_node*>(child), s), kv)) return 0;
+                free_leaf(static_cast<leaf_node*>(child));
+                remove_child(in, b);
+                hit = in;
+                break;
+            }
+            path.push_back(erase_frame{in, b});
+            in = as_inner(child);
+            ++depth;
+        }
+        --_size;
+
+        // Cascade: replace `prev` by `repl` in its parent; if a node emptied to
+        // null, drop it from the parent and re-simplify the parent, and so on.
+        node* prev = hit;
+        node* repl = collapse_result(hit);
+        while (repl != prev && !path.empty()) {
+            erase_frame f = path.back();
+            path.pop_back();
+            if (repl == nullptr) {
+                remove_child(f.node, f.byte);
+                prev = f.node;
+                repl = collapse_result(f.node);
+            } else {
+                *find_child_ref(f.node, f.byte) = repl;
+                return 1;
+            }
+        }
+        if (repl != prev) _root = repl;  // collapsed up to the root
+        return 1;
+    }
+
+  private:
+    struct erase_frame
+    {
+        inner* node;
+        uint8_t byte;
+    };
+
+    static node* single_child(inner* in, uint8_t* out_byte) {
+        switch (in->kind) {
+            case nkind::n4: {
+                auto* p = static_cast<node4*>(in);
+                *out_byte = p->keys[0];
+                return p->child[0];
+            }
+            case nkind::n16: {
+                auto* p = static_cast<node16*>(in);
+                *out_byte = p->keys[0];
+                return p->child[0];
+            }
+            case nkind::n48: {
+                auto* p = static_cast<node48*>(in);
+                for (int b = 0; b < 256; ++b)
+                    if (p->cindex[b]) {
+                        *out_byte = static_cast<uint8_t>(b);
+                        return p->child[p->cindex[b] - 1];
+                    }
+                return nullptr;
+            }
+            default: {
+                auto* p = static_cast<node256*>(in);
+                for (int b = 0; b < 256; ++b)
+                    if (p->child[b]) {
+                        *out_byte = static_cast<uint8_t>(b);
+                        return p->child[b];
+                    }
+                return nullptr;
+            }
+        }
+    }
+
+    void remove_child(inner* in, uint8_t b) {
+        switch (in->kind) {
+            case nkind::n4: {
+                auto* p = static_cast<node4*>(in);
+                uint8_t i = 0;
+                while (i < p->nchild && p->keys[i] != b) ++i;
+                for (uint8_t j = i; j + 1 < p->nchild; ++j) {
+                    p->keys[j] = p->keys[j + 1];
+                    p->child[j] = p->child[j + 1];
+                }
+                --p->nchild;
+                return;
+            }
+            case nkind::n16: {
+                auto* p = static_cast<node16*>(in);
+                uint8_t i = 0;
+                while (i < p->nchild && p->keys[i] != b) ++i;
+                for (uint8_t j = i; j + 1 < p->nchild; ++j) {
+                    p->keys[j] = p->keys[j + 1];
+                    p->child[j] = p->child[j + 1];
+                }
+                --p->nchild;
+                return;
+            }
+            case nkind::n48: {
+                auto* p = static_cast<node48*>(in);
+                uint8_t slot = static_cast<uint8_t>(p->cindex[b] - 1);
+                uint8_t last = static_cast<uint8_t>(p->nchild - 1);
+                p->cindex[b] = 0;
+                if (slot != last) {
+                    p->child[slot] = p->child[last];
+                    for (int bb = 0; bb < 256; ++bb)
+                        if (p->cindex[bb] == last + 1) {
+                            p->cindex[bb] = static_cast<uint8_t>(slot + 1);
+                            break;
+                        }
+                }
+                --p->nchild;
+                return;
+            }
+            case nkind::n256: {
+                auto* p = static_cast<node256*>(in);
+                p->child[b] = nullptr;
+                --p->nchild;
+                return;
+            }
+            default:
+                return;
+        }
+    }
+
+    // After a removal, simplify `in` and return what should replace it in its
+    // parent: nullptr (emptied), a hoisted/merged child, a shrunk node, or `in`
+    // itself when unchanged. The caller splices the result into the parent slot,
+    // cascading upward when the result is null so the parent's child count stays
+    // consistent (single-child path-compression chains depend on this).
+    node* collapse_result(inner* in) {
+        if (in->nchild == 0) {
+            node* r = in->end_leaf;  // may be null
+            free_shell_dispatch(in);
+            return r;
+        }
+        if (in->nchild == 1 && in->end_leaf == nullptr) {
+            uint8_t cb;
+            node* child = single_child(in, &cb);
+            if (is_leaf(child)) {
+                free_shell_dispatch(in);
+                return child;  // hoist leaf (stores full key)
+            }
+            inner* ci = as_inner(child);
+            uint32_t comb = static_cast<uint32_t>(in->plen) + 1 + ci->plen;
+            if (comb <= kCap) {
+                uint8_t buf[kCap];
+                std::memcpy(buf, in->prefix, in->plen);
+                buf[in->plen] = cb;
+                std::memcpy(buf + in->plen + 1, ci->prefix, ci->plen);
+                std::memcpy(ci->prefix, buf, comb);
+                ci->plen = static_cast<uint8_t>(comb);
+                free_shell_dispatch(in);
+                return child;
+            }
+            return in;  // cannot compress further; keep as a single-child node
+        }
+        return shrink_result(in);
+    }
+
+    void free_shell_dispatch(inner* in) {
+        switch (in->kind) {
+            case nkind::n4:
+                free_shell(static_cast<node4*>(in));
+                break;
+            case nkind::n16:
+                free_shell(static_cast<node16*>(in));
+                break;
+            case nkind::n48:
+                free_shell(static_cast<node48*>(in));
+                break;
+            default:
+                free_shell(static_cast<node256*>(in));
+                break;
+        }
+    }
+
+    // Downsize a node to a smaller kind when sparse; returns the replacement
+    // (or `in` unchanged).
+    inner* shrink_result(inner* in) {
+        switch (in->kind) {
+            case nkind::n16: {
+                auto* p = static_cast<node16*>(in);
+                if (p->nchild > 4) return in;
+                node4* g = make4();
+                copy_header(g, p);
+                for (uint8_t i = 0; i < p->nchild; ++i) {
+                    g->keys[i] = p->keys[i];
+                    g->child[i] = p->child[i];
+                }
+                g->nchild = p->nchild;
+                free_shell(p);
+                return g;
+            }
+            case nkind::n48: {
+                auto* p = static_cast<node48*>(in);
+                if (p->nchild > 12) return in;
+                node16* g = make16();
+                copy_header(g, p);
+                uint8_t i = 0;
+                for (int b = 0; b < 256; ++b)
+                    if (p->cindex[b]) {
+                        g->keys[i] = static_cast<uint8_t>(b);
+                        g->child[i] = p->child[p->cindex[b] - 1];
+                        ++i;
+                    }
+                g->nchild = i;
+                free_shell(p);
+                return g;
+            }
+            case nkind::n256: {
+                auto* p = static_cast<node256*>(in);
+                if (p->nchild > 37) return in;
+                node48* g = make48();
+                copy_header(g, p);
+                uint8_t i = 0;
+                for (int b = 0; b < 256; ++b)
+                    if (p->child[b]) {
+                        g->child[i] = p->child[b];
+                        g->cindex[b] = static_cast<uint8_t>(i + 1);
+                        ++i;
+                    }
+                g->nchild = i;
+                free_shell(p);
+                return g;
+            }
+            default:
+                return in;
+        }
+    }
+
+    // Recursively destroy a subtree (frees all nodes + leaves).
+    void destroy(node* n) {
+        if (is_leaf(n)) {
+            free_leaf(as_leaf(n));
+            return;
+        }
+        inner* in = as_inner(n);
+        if (in->end_leaf) free_leaf(as_leaf(in->end_leaf));
+        switch (n->kind) {
+            case nkind::n4: {
+                auto* p = static_cast<node4*>(in);
+                for (uint8_t i = 0; i < p->nchild; ++i) destroy(p->child[i]);
+                free_shell(p);
+                break;
+            }
+            case nkind::n16: {
+                auto* p = static_cast<node16*>(in);
+                for (uint8_t i = 0; i < p->nchild; ++i) destroy(p->child[i]);
+                free_shell(p);
+                break;
+            }
+            case nkind::n48: {
+                auto* p = static_cast<node48*>(in);
+                for (int b = 0; b < 256; ++b)
+                    if (p->cindex[b]) destroy(p->child[p->cindex[b] - 1]);
+                free_shell(p);
+                break;
+            }
+            case nkind::n256: {
+                auto* p = static_cast<node256*>(in);
+                for (int b = 0; b < 256; ++b)
+                    if (p->child[b]) destroy(p->child[b]);
+                free_shell(p);
+                break;
+            }
+            default:
+                break;
+        }
+    }
+
+    // Recursively clone a subtree.
+    node* clone(node* n) {
+        if (is_leaf(n)) return make_leaf(as_leaf(n)->kv);
+        inner* in = as_inner(n);
+        inner* out = nullptr;
+        switch (n->kind) {
+            case nkind::n4: {
+                auto* p = static_cast<node4*>(in);
+                auto* g = make4();
+                for (uint8_t i = 0; i < p->nchild; ++i) {
+                    g->keys[i] = p->keys[i];
+                    g->child[i] = clone(p->child[i]);
+                }
+                g->nchild = p->nchild;
+                out = g;
+                break;
+            }
+            case nkind::n16: {
+                auto* p = static_cast<node16*>(in);
+                auto* g = make16();
+                for (uint8_t i = 0; i < p->nchild; ++i) {
+                    g->keys[i] = p->keys[i];
+                    g->child[i] = clone(p->child[i]);
+                }
+                g->nchild = p->nchild;
+                out = g;
+                break;
+            }
+            case nkind::n48: {
+                auto* p = static_cast<node48*>(in);
+                auto* g = make48();
+                std::memcpy(g->cindex, p->cindex, sizeof(p->cindex));
+                for (uint8_t i = 0; i < p->nchild; ++i) g->child[i] = clone(p->child[i]);
+                g->nchild = p->nchild;
+                out = g;
+                break;
+            }
+            case nkind::n256: {
+                auto* p = static_cast<node256*>(in);
+                auto* g = make256();
+                for (int b = 0; b < 256; ++b)
+                    if (p->child[b]) g->child[b] = clone(p->child[b]);
+                g->nchild = p->nchild;
+                out = g;
+                break;
+            }
+            default:
+                break;
+        }
+        out->plen = in->plen;
+        std::memcpy(out->prefix, in->prefix, kCap);
+        out->end_leaf = in->end_leaf ? make_leaf(as_leaf(in->end_leaf)->kv) : nullptr;
+        return out;
+    }
+
+    // --- bulk load (sorted input, bottom-up) ---------------------------------
+    inner* bulk_make_by_count(std::size_t runs) {
+        if (runs <= 4) return make4();
+        if (runs <= 16) return make16();
+        if (runs <= 48) return make48();
+        return make256();
+    }
+    static void bulk_append(inner* n, uint8_t b, node* c) {
+        switch (n->kind) {
+            case nkind::n4: {
+                auto* p = static_cast<node4*>(n);
+                p->keys[p->nchild] = b;
+                p->child[p->nchild] = c;
+                ++p->nchild;
+                return;
+            }
+            case nkind::n16: {
+                auto* p = static_cast<node16*>(n);
+                p->keys[p->nchild] = b;
+                p->child[p->nchild] = c;
+                ++p->nchild;
+                return;
+            }
+            case nkind::n48: {
+                auto* p = static_cast<node48*>(n);
+                p->child[p->nchild] = c;
+                p->cindex[b] = static_cast<uint8_t>(p->nchild + 1);
+                ++p->nchild;
+                return;
+            }
+            default: {
+                auto* p = static_cast<node256*>(n);
+                p->child[b] = c;
+                ++p->nchild;
+                return;
+            }
+        }
+    }
+    // Build the subtree for the sorted, unique leaves e[lo,hi) branching at `depth`.
+    // v[] holds each leaf's precomputed encoded key (parallel to e[]).
+    node* bulk_build(leaf_node** e, art_key_view* v, std::size_t lo, std::size_t hi, uint32_t depth) {
+        if (hi - lo == 1) return e[lo];
+        art_key_view a = v[lo];
+        art_key_view b = v[hi - 1];
+        uint32_t maxp = a.len < b.len ? a.len : b.len;
+        uint32_t p = depth;
+        while (p < maxp && a.ptr[p] == b.ptr[p]) ++p;  // LCP of range (sorted -> first vs last)
+        uint8_t chunk = static_cast<uint8_t>(std::min<uint32_t>(p - depth, kCap));
+        uint32_t pp = depth + chunk;
+        // shortest key in range sorts first; if it ends exactly here it is the end_leaf
+        std::size_t start = lo;
+        node* el = nullptr;
+        if (a.len == pp) {
+            el = e[lo];
+            start = lo + 1;
+        }
+        std::size_t runs = 0;
+        for (std::size_t i = start; i < hi;) {
+            uint8_t bb = v[i].ptr[pp];
+            std::size_t j = i + 1;
+            while (j < hi && v[j].ptr[pp] == bb) ++j;
+            ++runs;
+            i = j;
+        }
+        inner* nd = bulk_make_by_count(runs);
+        nd->plen = chunk;
+        if (chunk) std::memcpy(nd->prefix, a.ptr + depth, chunk);
+        nd->end_leaf = el;
+        for (std::size_t i = start; i < hi;) {
+            uint8_t bb = v[i].ptr[pp];
+            std::size_t j = i + 1;
+            while (j < hi && v[j].ptr[pp] == bb) ++j;
+            bulk_append(nd, bb, bulk_build(e, v, i, j, pp + 1));
+            i = j;
+        }
+        return nd;
+    }
+
+    // --- ordered DFS with sibling-leaf prefetch ------------------------------
+    template <typename F>
+    void for_each_rec(node* n, F& fn) const {
+        if (is_leaf(n)) {
+            fn(const_cast<const value_type&>(static_cast<leaf_node*>(n)->kv));
+            return;
+        }
+        inner* in = as_inner(n);
+        if (in->end_leaf) fn(static_cast<leaf_node*>(in->end_leaf)->kv);
+        switch (in->kind) {
+            case nkind::n4: {
+                auto* p = static_cast<node4*>(in);
+                for (uint8_t i = 0; i < p->nchild; ++i) {
+                    if (i + 1 < p->nchild) ART_PREFETCH(p->child[i + 1]);
+                    for_each_rec(p->child[i], fn);
+                }
+                break;
+            }
+            case nkind::n16: {
+                auto* p = static_cast<node16*>(in);
+                for (uint8_t i = 0; i < p->nchild; ++i) {
+                    if (i + 1 < p->nchild) ART_PREFETCH(p->child[i + 1]);
+                    for_each_rec(p->child[i], fn);
+                }
+                break;
+            }
+            case nkind::n48: {
+                auto* p = static_cast<node48*>(in);
+                node* pending = nullptr;
+                for (int b = 0; b < 256; ++b) {
+                    if (!p->cindex[b]) continue;
+                    node* c = p->child[p->cindex[b] - 1];
+                    if (pending) {
+                        ART_PREFETCH(c);
+                        for_each_rec(pending, fn);
+                    }
+                    pending = c;
+                }
+                if (pending) for_each_rec(pending, fn);
+                break;
+            }
+            default: {
+                auto* p = static_cast<node256*>(in);
+                node* pending = nullptr;
+                for (int b = 0; b < 256; ++b) {
+                    if (!p->child[b]) continue;
+                    if (pending) {
+                        ART_PREFETCH(p->child[b]);
+                        for_each_rec(pending, fn);
+                    }
+                    pending = p->child[b];
+                }
+                if (pending) for_each_rec(pending, fn);
+                break;
+            }
+        }
+    }
+
+    // --- lookup --------------------------------------------------------------
+    leaf_node* find_leaf(const Key& key) const {
+        ekey kc(key);
+        art_key_view kv = kc.view;
+        node* n = _root;
+        uint32_t depth = 0;
+        while (n) {
+            if (is_leaf(n)) {
+                uint8_t s[kArtKeyScratch];
+                art_key_view lv = leaf_key(static_cast<leaf_node*>(n), s);
+                return view_eq(lv, kv) ? static_cast<leaf_node*>(n) : nullptr;
+            }
+            inner* in = as_inner(n);
+            if (in->plen) {
+                if (kv.len - depth < in->plen) return nullptr;
+                if (std::memcmp(in->prefix, kv.ptr + depth, in->plen) != 0) return nullptr;
+                depth += in->plen;
+            }
+            if (depth == kv.len) {
+                return in->end_leaf ? static_cast<leaf_node*>(in->end_leaf) : nullptr;
+            }
+            n = find_child(in, kv.ptr[depth]);
+            if (n) ART_PREFETCH(n);
+            ++depth;
+        }
+        return nullptr;
+    }
+
+    // --- insert --------------------------------------------------------------
+    // When `path` is non-null, the iterator's stack is built in this single pass
+    // (no second descent) so insert()/emplace() can return a positioned iterator.
+    template <typename MakeLeaf>
+    leaf_node* do_insert(const Key& key, bool& inserted, MakeLeaf&& mk, iterator* path = nullptr) {
+        ekey kc(key);
+        art_key_view kv = kc.view;
+        node** ref = &_root;
+        uint32_t depth = 0;
+        while (true) {
+            node* n = *ref;
+            if (!n) {
+                leaf_node* nl = mk();
+                *ref = nl;
+                ++_size;
+                inserted = true;
+                if (path) path->_leaf = nl;
+                return nl;
+            }
+            if (is_leaf(n)) {
+                leaf_node* old = static_cast<leaf_node*>(n);
+                uint8_t s[kArtKeyScratch];
+                art_key_view lv = leaf_key(old, s);
+                if (view_eq(lv, kv)) {
+                    inserted = false;
+                    if (path) path->_leaf = old;
+                    return old;
+                }
+                leaf_node* nl = mk();
+                split_leaf(ref, old, lv, kv, depth, nl, path);
+                ++_size;
+                inserted = true;
+                return nl;
+            }
+            inner* in = as_inner(n);
+            if (in->plen) {
+                uint8_t common = prefix_match(in, kv, depth);
+                if (common < in->plen) {
+                    leaf_node* nl = mk();
+                    split_prefix(ref, in, common, kv, depth, nl, path);
+                    ++_size;
+                    inserted = true;
+                    return nl;
+                }
+                depth += in->plen;
+            }
+            if (depth == kv.len) {
+                if (in->end_leaf) {
+                    inserted = false;
+                    if (path) {
+                        path->push(in, -1);
+                        path->_leaf = as_leaf(in->end_leaf);
+                    }
+                    return static_cast<leaf_node*>(in->end_leaf);
+                }
+                leaf_node* nl = mk();
+                in->end_leaf = nl;
+                ++_size;
+                inserted = true;
+                if (path) {
+                    path->push(in, -1);
+                    path->_leaf = nl;
+                }
+                return nl;
+            }
+            uint8_t b = kv.ptr[depth];
+            node** cref = find_child_ref(in, b);
+            if (!cref) {
+                leaf_node* nl = mk();
+                if (is_full(in)) in = grow(ref, in);
+                add_child(in, b, nl);
+                ++_size;
+                inserted = true;
+                if (path) {
+                    path->push(in, b);
+                    path->_leaf = nl;
+                }
+                return nl;
+            }
+            if (path) path->push(in, b);
+            ref = cref;
+            ++depth;
+        }
+    }
+
+    // Split two leaves that share bytes [depth, S); build a prefix chain.
+    void split_leaf(node** ref, leaf_node* old, art_key_view lv, art_key_view kv, uint32_t depth,
+                    leaf_node* nl, iterator* path = nullptr) {
+        uint32_t s = depth;
+        while (s < lv.len && s < kv.len && lv.ptr[s] == kv.ptr[s]) ++s;  // divergence depth
+        node** cur = ref;
+        uint32_t d = depth;
+        while (true) {
+            node4* nd = make4();
+            uint8_t chunk = static_cast<uint8_t>(std::min<uint32_t>(s - d, kCap));
+            nd->plen = chunk;
+            if (chunk) std::memcpy(nd->prefix, kv.ptr + d, chunk);
+            *cur = nd;
+            d += chunk;
+            if (d == s) {
+                if (d == lv.len) {
+                    nd->end_leaf = old;
+                } else {
+                    add_child(nd, lv.ptr[d], old);
+                }
+                if (d == kv.len) {
+                    nd->end_leaf = nl;
+                } else {
+                    add_child(nd, kv.ptr[d], nl);
+                }
+                if (path) {
+                    path->push(nd, d == kv.len ? -1 : static_cast<int>(kv.ptr[d]));
+                    path->_leaf = nl;
+                }
+                return;
+            }
+            // bytes still shared at d: single child, continue chain
+            uint8_t b = kv.ptr[d];
+            if (path) path->push(nd, b);
+            cur = add_child4_slot(nd, b);
+            ++d;
+        }
+    }
+
+    // Split an inner node whose prefix diverges from the key at `common`.
+    void split_prefix(node** ref, inner* n, uint8_t common, art_key_view kv, uint32_t depth,
+                      leaf_node* nl, iterator* path = nullptr) {
+        node4* top = make4();
+        top->plen = common;
+        if (common) std::memcpy(top->prefix, n->prefix, common);
+        *ref = top;
+        uint8_t old_byte = n->prefix[common];
+        uint8_t rem = static_cast<uint8_t>(n->plen - common - 1);
+        std::memmove(n->prefix, n->prefix + common + 1, rem);
+        n->plen = rem;
+        add_child(top, old_byte, n);
+        uint32_t d = depth + common;
+        if (d == kv.len) {
+            top->end_leaf = nl;
+        } else {
+            add_child(top, kv.ptr[d], nl);
+        }
+        if (path) {
+            path->push(top, d == kv.len ? -1 : static_cast<int>(kv.ptr[d]));
+            path->_leaf = nl;
+        }
+    }
+
+    // --- ordered child navigation (used by iterators / bounds) ---------------
+    // A single step returns both the child byte and pointer in one node scan,
+    // avoiding a second find_child lookup during iteration.
+    struct step
+    {
+        int byte;     // -1 when no such child
+        node* child;  // valid iff byte >= 0
+    };
+    static step first_step(inner* in) {
+        switch (in->kind) {
+            case nkind::n4: {
+                auto* p = static_cast<node4*>(in);
+                return in->nchild ? step{p->keys[0], p->child[0]} : step{-1, nullptr};
+            }
+            case nkind::n16: {
+                auto* p = static_cast<node16*>(in);
+                return in->nchild ? step{p->keys[0], p->child[0]} : step{-1, nullptr};
+            }
+            case nkind::n48: {
+                auto* p = static_cast<node48*>(in);
+                for (int b = 0; b < 256; ++b)
+                    if (p->cindex[b]) return {b, p->child[p->cindex[b] - 1]};
+                return {-1, nullptr};
+            }
+            default: {
+                auto* p = static_cast<node256*>(in);
+                for (int b = 0; b < 256; ++b)
+                    if (p->child[b]) return {b, p->child[b]};
+                return {-1, nullptr};
+            }
+        }
+    }
+    static step last_step(inner* in) {
+        switch (in->kind) {
+            case nkind::n4: {
+                auto* p = static_cast<node4*>(in);
+                return in->nchild ? step{p->keys[in->nchild - 1], p->child[in->nchild - 1]}
+                                  : step{-1, nullptr};
+            }
+            case nkind::n16: {
+                auto* p = static_cast<node16*>(in);
+                return in->nchild ? step{p->keys[in->nchild - 1], p->child[in->nchild - 1]}
+                                  : step{-1, nullptr};
+            }
+            case nkind::n48: {
+                auto* p = static_cast<node48*>(in);
+                for (int b = 255; b >= 0; --b)
+                    if (p->cindex[b]) return {b, p->child[p->cindex[b] - 1]};
+                return {-1, nullptr};
+            }
+            default: {
+                auto* p = static_cast<node256*>(in);
+                for (int b = 255; b >= 0; --b)
+                    if (p->child[b]) return {b, p->child[b]};
+                return {-1, nullptr};
+            }
+        }
+    }
+    static step next_step(inner* in, int b) {
+        switch (in->kind) {
+            case nkind::n4: {
+                auto* p = static_cast<node4*>(in);
+                for (uint8_t i = 0; i < p->nchild; ++i)
+                    if (p->keys[i] > b) return {p->keys[i], p->child[i]};
+                return {-1, nullptr};
+            }
+            case nkind::n16: {
+                auto* p = static_cast<node16*>(in);
+                for (uint8_t i = 0; i < p->nchild; ++i)
+                    if (p->keys[i] > b) return {p->keys[i], p->child[i]};
+                return {-1, nullptr};
+            }
+            case nkind::n48: {
+                auto* p = static_cast<node48*>(in);
+                for (int x = b + 1; x < 256; ++x)
+                    if (p->cindex[x]) return {x, p->child[p->cindex[x] - 1]};
+                return {-1, nullptr};
+            }
+            default: {
+                auto* p = static_cast<node256*>(in);
+                for (int x = b + 1; x < 256; ++x)
+                    if (p->child[x]) return {x, p->child[x]};
+                return {-1, nullptr};
+            }
+        }
+    }
+    static step prev_step(inner* in, int b) {
+        switch (in->kind) {
+            case nkind::n4: {
+                auto* p = static_cast<node4*>(in);
+                for (int i = p->nchild - 1; i >= 0; --i)
+                    if (p->keys[i] < b) return {p->keys[i], p->child[i]};
+                return {-1, nullptr};
+            }
+            case nkind::n16: {
+                auto* p = static_cast<node16*>(in);
+                for (int i = p->nchild - 1; i >= 0; --i)
+                    if (p->keys[i] < b) return {p->keys[i], p->child[i]};
+                return {-1, nullptr};
+            }
+            case nkind::n48: {
+                auto* p = static_cast<node48*>(in);
+                for (int x = b - 1; x >= 0; --x)
+                    if (p->cindex[x]) return {x, p->child[p->cindex[x] - 1]};
+                return {-1, nullptr};
+            }
+            default: {
+                auto* p = static_cast<node256*>(in);
+                for (int x = b - 1; x >= 0; --x)
+                    if (p->child[x]) return {x, p->child[x]};
+                return {-1, nullptr};
+            }
+        }
+    }
+    static int first_child_byte(inner* in) {
+        switch (in->kind) {
+            case nkind::n4:
+                return in->nchild ? static_cast<node4*>(in)->keys[0] : -1;
+            case nkind::n16:
+                return in->nchild ? static_cast<node16*>(in)->keys[0] : -1;
+            case nkind::n48: {
+                auto* p = static_cast<node48*>(in);
+                for (int b = 0; b < 256; ++b)
+                    if (p->cindex[b]) return b;
+                return -1;
+            }
+            default: {
+                auto* p = static_cast<node256*>(in);
+                for (int b = 0; b < 256; ++b)
+                    if (p->child[b]) return b;
+                return -1;
+            }
+        }
+    }
+    static int last_child_byte(inner* in) {
+        switch (in->kind) {
+            case nkind::n4:
+                return in->nchild ? static_cast<node4*>(in)->keys[in->nchild - 1] : -1;
+            case nkind::n16:
+                return in->nchild ? static_cast<node16*>(in)->keys[in->nchild - 1] : -1;
+            case nkind::n48: {
+                auto* p = static_cast<node48*>(in);
+                for (int b = 255; b >= 0; --b)
+                    if (p->cindex[b]) return b;
+                return -1;
+            }
+            default: {
+                auto* p = static_cast<node256*>(in);
+                for (int b = 255; b >= 0; --b)
+                    if (p->child[b]) return b;
+                return -1;
+            }
+        }
+    }
+    static int next_child_byte_gt(inner* in, int b) {
+        switch (in->kind) {
+            case nkind::n4: {
+                auto* p = static_cast<node4*>(in);
+                for (uint8_t i = 0; i < p->nchild; ++i)
+                    if (p->keys[i] > b) return p->keys[i];
+                return -1;
+            }
+            case nkind::n16: {
+                auto* p = static_cast<node16*>(in);
+                for (uint8_t i = 0; i < p->nchild; ++i)
+                    if (p->keys[i] > b) return p->keys[i];
+                return -1;
+            }
+            case nkind::n48: {
+                auto* p = static_cast<node48*>(in);
+                for (int x = b + 1; x < 256; ++x)
+                    if (p->cindex[x]) return x;
+                return -1;
+            }
+            default: {
+                auto* p = static_cast<node256*>(in);
+                for (int x = b + 1; x < 256; ++x)
+                    if (p->child[x]) return x;
+                return -1;
+            }
+        }
+    }
+    static int prev_child_byte_lt(inner* in, int b) {
+        switch (in->kind) {
+            case nkind::n4: {
+                auto* p = static_cast<node4*>(in);
+                for (int i = p->nchild - 1; i >= 0; --i)
+                    if (p->keys[i] < b) return p->keys[i];
+                return -1;
+            }
+            case nkind::n16: {
+                auto* p = static_cast<node16*>(in);
+                for (int i = p->nchild - 1; i >= 0; --i)
+                    if (p->keys[i] < b) return p->keys[i];
+                return -1;
+            }
+            case nkind::n48: {
+                auto* p = static_cast<node48*>(in);
+                for (int x = b - 1; x >= 0; --x)
+                    if (p->cindex[x]) return x;
+                return -1;
+            }
+            default: {
+                auto* p = static_cast<node256*>(in);
+                for (int x = b - 1; x >= 0; --x)
+                    if (p->child[x]) return x;
+                return -1;
+            }
+        }
+    }
+    static int view_cmp(art_key_view a, art_key_view b) {
+        uint32_t m = a.len < b.len ? a.len : b.len;
+        int c = m ? std::memcmp(a.ptr, b.ptr, m) : 0;
+        if (c) return c;
+        return a.len < b.len ? -1 : (a.len > b.len ? 1 : 0);
+    }
+
+  public:
+    iterator begin() {
+        iterator it;
+        it._owner = this;
+        if (_root) it.descend_leftmost_into(_root);
+        return it;
+    }
+    const_iterator begin() const { return cbegin(); }
+    const_iterator cbegin() const {
+        const_iterator it;
+        it._owner = this;
+        if (_root) it.descend_leftmost_into(_root);
+        return it;
+    }
+    iterator end() {
+        iterator it;
+        it._owner = this;
+        return it;
+    }
+    const_iterator end() const { return cend(); }
+    const_iterator cend() const {
+        const_iterator it;
+        it._owner = this;
+        return it;
+    }
+    reverse_iterator rbegin() { return reverse_iterator(end()); }
+    reverse_iterator rend() { return reverse_iterator(begin()); }
+    const_reverse_iterator rbegin() const { return const_reverse_iterator(cend()); }
+    const_reverse_iterator rend() const { return const_reverse_iterator(cbegin()); }
+    const_reverse_iterator crbegin() const { return const_reverse_iterator(cend()); }
+    const_reverse_iterator crend() const { return const_reverse_iterator(cbegin()); }
+
+    iterator find(const Key& key) {
+        iterator it = lower_bound_impl<false>(key);
+        if (it._leaf) {
+            ekey kc(key);
+            uint8_t s[kArtKeyScratch];
+            if (view_eq(leaf_key(it._leaf, s), kc.view)) return it;
+        }
+        return end();
+    }
+    const_iterator find(const Key& key) const {
+        const_iterator it = lower_bound_impl<true>(key);
+        if (it._leaf) {
+            ekey kc(key);
+            uint8_t s[kArtKeyScratch];
+            if (view_eq(leaf_key(it._leaf, s), kc.view)) return it;
+        }
+        return cend();
+    }
+    iterator lower_bound(const Key& key) { return lower_bound_impl<false>(key); }
+    const_iterator lower_bound(const Key& key) const { return lower_bound_impl<true>(key); }
+    iterator upper_bound(const Key& key) {
+        iterator it = lower_bound_impl<false>(key);
+        if (it._leaf) {
+            ekey kc(key);
+            uint8_t s[kArtKeyScratch];
+            if (view_eq(leaf_key(it._leaf, s), kc.view)) ++it;
+        }
+        return it;
+    }
+    const_iterator upper_bound(const Key& key) const {
+        const_iterator it = lower_bound_impl<true>(key);
+        if (it._leaf) {
+            ekey kc(key);
+            uint8_t s[kArtKeyScratch];
+            if (view_eq(leaf_key(it._leaf, s), kc.view)) ++it;
+        }
+        return it;
+    }
+    std::pair<iterator, iterator> equal_range(const Key& key) {
+        return {lower_bound(key), upper_bound(key)};
+    }
+    std::pair<const_iterator, const_iterator> equal_range(const Key& key) const {
+        return {lower_bound(key), upper_bound(key)};
+    }
+
+    // Ordered traversal that calls fn(const value_type&) for every element.
+    // Faster than iterating begin()..end() for full scans: a recursive DFS avoids
+    // the per-step stack navigation, and it prefetches sibling leaves to overlap
+    // the (insertion-order) leaf cache misses.
+    template <typename F>
+    void for_each(F&& fn) const {
+        if (_root) for_each_rec(_root, fn);
+    }
+
+    // Bulk-load from a range of value_type that is sorted ascending by key.
+    // Builds the tree bottom-up (one correctly-sized node per branch, no per-key
+    // descent or node growth) — much faster than repeated insert for build-once
+    // workloads. Replaces any existing contents. Duplicate keys: last wins.
+    template <typename InputIt>
+    void bulk_load(InputIt first, InputIt last) {
+        clear();
+        std::vector<leaf_node*> e;
+        uint8_t s1[kArtKeyScratch];
+        uint8_t s2[kArtKeyScratch];
+        for (InputIt it = first; it != last; ++it) {
+            leaf_node* l = make_leaf(*it);
+            // dedup adjacent equal keys (sorted input): last wins
+            if (!e.empty() && view_eq(leaf_key(e.back(), s1), leaf_key(l, s2))) {
+                free_leaf(e.back());
+                e.back() = l;
+            } else {
+                e.push_back(l);
+            }
+        }
+        if (e.empty()) return;
+        // Precompute each leaf's encoded key once into a stable buffer (avoids
+        // re-encoding fixed keys on every comparison during the build).
+        std::size_t n = e.size();
+        std::vector<art_key_view> views(n);
+        std::vector<uint8_t> blob;
+        if constexpr (encoder::fixed) {
+            blob.resize(n * (encoder::bound ? encoder::bound : 1));
+            for (std::size_t i = 0; i < n; ++i)
+                views[i] = leaf_key(e[i], blob.data() + i * encoder::bound);
+        } else {
+            uint8_t dummy[kArtKeyScratch];
+            for (std::size_t i = 0; i < n; ++i) views[i] = leaf_key(e[i], dummy);
+        }
+        _root = bulk_build(e.data(), views.data(), 0, n, 0);
+        _size = n;
+    }
+
+    iterator erase(const_iterator pos) {
+        const_iterator nxt = pos;
+        ++nxt;
+        Key k = pos->first;
+        if (nxt._leaf == nullptr) {
+            erase(k);
+            return end();
+        }
+        Key nk = nxt->first;
+        erase(k);
+        return find(nk);
+    }
+
+  private:
+    static node* child_at(inner* in, uint8_t b) { return *find_child_ref(in, b); }
+
+    template <bool Const>
+    iter_impl<Const> lower_bound_impl(const Key& key) const {
+        iter_impl<Const> it;
+        it._owner = const_cast<std::conditional_t<Const, const art_map*, art_map*>>(this);
+        ekey kc(key);
+        art_key_view kv = kc.view;
+        node* n = _root;
+        uint32_t depth = 0;
+        while (n) {
+            if (is_leaf(n)) {
+                uint8_t s[kArtKeyScratch];
+                art_key_view lv = leaf_key(static_cast<leaf_node*>(n), s);
+                if (view_cmp(lv, kv) >= 0) {
+                    it._leaf = static_cast<leaf_node*>(n);
+                } else {
+                    it._leaf = static_cast<leaf_node*>(n);
+                    it.advance();
+                }
+                return it;
+            }
+            inner* in = as_inner(n);
+            if (in->plen) {
+                uint32_t avail = kv.len - depth;
+                uint8_t cmplen = in->plen < avail ? in->plen : static_cast<uint8_t>(avail);
+                uint8_t m = 0;
+                for (; m < cmplen; ++m)
+                    if (in->prefix[m] != kv.ptr[depth + m]) break;
+                if (m < in->plen) {
+                    // prefix diverges (or key ran out inside prefix)
+                    if (m == avail || kv.ptr[depth + m] < in->prefix[m]) {
+                        it.descend_leftmost_into(n);  // whole subtree > key
+                    } else {
+                        it.advance();  // whole subtree < key -> successor up the stack
+                    }
+                    return it;
+                }
+                depth += in->plen;
+            }
+            if (depth == kv.len) {
+                if (in->end_leaf) {
+                    it.push(in, -1);
+                    it._leaf = static_cast<leaf_node*>(in->end_leaf);
+                } else {
+                    it.descend_leftmost_into(n);  // all children > key
+                }
+                return it;
+            }
+            uint8_t b = kv.ptr[depth];
+            node* c = find_child(in, b);
+            if (c) {
+                it.push(in, b);
+                n = c;
+                ++depth;
+                continue;
+            }
+            int nb = next_child_byte_gt(in, b);
+            if (nb >= 0) {
+                it.push(in, nb);
+                it.descend_leftmost_into(child_at(in, static_cast<uint8_t>(nb)));
+            } else {
+                it.advance();  // exhausted this node -> successor up the stack
+            }
+            return it;
+        }
+        it._leaf = nullptr;  // empty tree
+        return it;
+    }
+
+    node* _root = nullptr;
+    size_type _size = 0;
+    [[no_unique_address]] Allocator _alloc;
+    node_pool<node4> _pool4;
+    node_pool<node16> _pool16;
+    node_pool<node48> _pool48;
+    node_pool<node256> _pool256;
+    node_pool<leaf_node> _poolL;
+};
+
+}  // namespace stdb::container

--- a/container/art_map.hpp
+++ b/container/art_map.hpp
@@ -343,11 +343,15 @@ class art_map
     template <typename... Args>
     leaf_node* make_leaf(Args&&... args) {
         auto* p = pool_new(_poolL);
-        // If the key/value construction throws, return the raw slot to the free list (the
-        // leaf_node was never constructed, so no destructor runs). Otherwise repeated
-        // failed inserts would consume leaf-pool slots and keep growing the slab list.
+        // Construct the stored pair through the map allocator so uses-allocator construction
+        // reaches an allocator-aware Key/T: e.g. a PMR mapped_type gets the map's
+        // memory_resource instead of the default one (the slab itself already uses the map
+        // allocator, but a direct placement-new would not propagate it to the value).
+        // On a throwing key/value constructor, return the raw slot to the free list
+        // (nothing was constructed) so repeated failed inserts don't keep growing slabs.
         try {
-            ::new (static_cast<void*>(p)) leaf_node(std::forward<Args>(args)...);
+            std::allocator_traits<Allocator>::construct(_alloc, std::addressof(p->kv),
+                                                        std::forward<Args>(args)...);
         } catch (...) {
             _poolL.deallocate(p);
             throw;
@@ -356,7 +360,9 @@ class art_map
         return p;
     }
     void free_leaf(leaf_node* l) {
-        l->~leaf_node();
+        // Symmetric with make_leaf: destroy the value through the allocator. The node base
+        // is trivially destructible, so destroying `kv` is the whole leaf.
+        std::allocator_traits<Allocator>::destroy(_alloc, std::addressof(l->kv));
         _poolL.deallocate(l);
     }
     void free_shell(node4* p) { _pool4.deallocate(p); }

--- a/container/btree_map.hpp
+++ b/container/btree_map.hpp
@@ -6117,11 +6117,13 @@ public:
         }
     }
 
-    // Insert node handle (C++17)
-    // Constrained to node_type so a braced-init-list (e.g. insert({1, "one"})) cannot
-    // match this overload — it can only deduce to value_type's insert overloads.
+    // Insert node handle (C++17). Constrained so a braced-init-list (e.g.
+    // insert({1, "one"})) cannot match — only value_type's overloads can — while
+    // staying rvalue-only: requiring NH == node_type (not remove_cvref) deduces to
+    // the bare type only for rvalue arguments, so a named lvalue handle is rejected
+    // (the caller must std::move it), matching std::map's insert(node_type&&).
     template <typename NH>
-        requires std::is_same_v<std::remove_cvref_t<NH>, node_type>
+        requires std::is_same_v<NH, node_type>
     auto insert(NH&& nh) -> insert_return_type {
         if (nh.empty()) {
             return {end(), false, std::move(nh)};

--- a/container/btree_map.hpp
+++ b/container/btree_map.hpp
@@ -6118,7 +6118,11 @@ public:
     }
 
     // Insert node handle (C++17)
-    auto insert(node_type&& nh) -> insert_return_type {
+    // Constrained to node_type so a braced-init-list (e.g. insert({1, "one"})) cannot
+    // match this overload — it can only deduce to value_type's insert overloads.
+    template <typename NH>
+        requires std::is_same_v<std::remove_cvref_t<NH>, node_type>
+    auto insert(NH&& nh) -> insert_return_type {
         if (nh.empty()) {
             return {end(), false, std::move(nh)};
         }

--- a/tests/art_map_test.cc
+++ b/tests/art_map_test.cc
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <limits>
 #include <map>
+#include <memory_resource>
 #include <random>
 #include <string>
 #include <vector>
@@ -337,6 +338,33 @@ TEST_CASE("art_map::move_then_reuse_source") {
     CHECK_EQ(c.size(), 5000);
     b[7] = 7;  // reuse moved-from
     CHECK(b.contains(7));
+}
+
+// Regression (review P2): move assignment across unequal, non-propagating
+// allocators (distinct PMR resources) must move elements, not steal slabs.
+TEST_CASE("art_map::move_assign_allocator_aware") {
+    using PA = std::pmr::polymorphic_allocator<std::pair<const int, int>>;
+    std::pmr::monotonic_buffer_resource r1, r2;
+
+    SUBCASE("unequal allocators -> element-wise move") {
+        art_map<int, int, PA> a(PA{&r1});
+        for (int i = 0; i < 2000; ++i) a[i] = i * 3;
+        art_map<int, int, PA> b(PA{&r2});
+        b[42] = -1;
+        b = std::move(a);
+        CHECK_EQ(b.size(), 2000);
+        for (int i = 0; i < 2000; ++i) CHECK_EQ(b.at(i), i * 3);
+        a.clear();  // moved-from is reusable
+        a[7] = 7;
+        CHECK(a.contains(7));
+    }
+    SUBCASE("equal allocators -> steal") {
+        art_map<int, int, PA> c(PA{&r1}), d(PA{&r1});
+        for (int i = 0; i < 1500; ++i) c[i] = i;
+        d = std::move(c);
+        CHECK_EQ(d.size(), 1500);
+        for (int i = 0; i < 1500; ++i) CHECK_EQ(d.at(i), i);
+    }
 }
 
 // Differential test against std::map as oracle.

--- a/tests/art_map_test.cc
+++ b/tests/art_map_test.cc
@@ -753,6 +753,35 @@ TEST_CASE("art_map::exception_safety_on_copy_and_split") {
         CHECK_EQ(m.size(), 2);
         CHECK_EQ(m.at(42).v, 42);
     }
+
+    SUBCASE("a long-prefix split whose mid-chain node allocation fails stays consistent") {
+        // A shared prefix long enough that split_leaf's node4 chain spans more than one
+        // 512-slot pool slab, so a make4() partway through the chain hits a fresh slab we
+        // can force to fail while earlier shells are already staged in `head`.
+        const std::string pre(5000, 'z');
+        const std::string k1 = pre + "A";
+        const std::string k2 = pre + "B";
+        using IMap = art_map<std::string, int, throwing_alloc<std::pair<const std::string, int>>>;
+        IMap m;
+        g_throw_ctl().remaining = -1;
+        m[k1] = 1;  // single leaf; node4 pool still empty
+
+        g_throw_ctl().remaining = 1;  // first node4 slab succeeds, the mid-chain second fails
+        CHECK_THROWS_AS(m.insert({k2, 2}), std::bad_alloc);
+        g_throw_ctl().remaining = -1;
+
+        // The existing entry is untouched and the map stays usable; the staged chain shells
+        // were returned to the pool (verified clean under ASAN — no leak/UAF/double-free),
+        // so the retry below reuses them and succeeds.
+        CHECK_EQ(m.size(), 1);
+        CHECK(m.contains(k1));
+        CHECK_FALSE(m.contains(k2));
+
+        m[k2] = 2;  // retry now succeeds
+        CHECK_EQ(m.size(), 2);
+        CHECK_EQ(m.at(k1), 1);
+        CHECK_EQ(m.at(k2), 2);
+    }
 }
 
 }  // namespace stdb::container

--- a/tests/art_map_test.cc
+++ b/tests/art_map_test.cc
@@ -522,6 +522,7 @@ struct throw_ctl
 {
     long remaining = -1;   // -1 = disabled
     long allocations = 0;  // total slab allocations observed (for leak/reuse assertions)
+    long live = 0;         // currently-outstanding slab allocations (released == 0)
 };
 inline throw_ctl& g_throw_ctl() {
     static throw_ctl ctl;
@@ -556,9 +557,13 @@ struct throwing_alloc
             throw std::bad_alloc();
         }
         if (ctl.remaining > 0) --ctl.remaining;
+        ++ctl.live;
         return static_cast<T*>(::operator new(n * sizeof(T)));
     }
-    void deallocate(T* p, std::size_t) noexcept { ::operator delete(p); }
+    void deallocate(T* p, std::size_t) noexcept {
+        --g_throw_ctl().live;
+        ::operator delete(p);
+    }
     template <typename U>
     bool operator==(const throwing_alloc<U>&) const noexcept {
         return true;
@@ -782,6 +787,37 @@ TEST_CASE("art_map::exception_safety_on_copy_and_split") {
         CHECK_EQ(m.at(k1), 1);
         CHECK_EQ(m.at(k2), 2);
     }
+}
+
+// Regression (review): a bulk_load that throws while bulk_build() is allocating
+// inner shells must release those slabs immediately, not retain them until the
+// next clear()/destroy. Sweep the throw point across leaf + shell allocations
+// and assert no slab stays outstanding (live == 0) after a failed load.
+TEST_CASE("art_map::bulk_load_releases_slabs_on_throw") {
+    using Map = art_map<int, int, throwing_alloc<std::pair<const int, int>>>;
+    std::vector<std::pair<const int, int>> kv;
+    for (int i = 0; i < 6000; ++i) kv.push_back({i, i});  // sorted -> a real multi-node tree
+    auto& ctl = g_throw_ctl();
+    bool saw_throw = false;
+    for (long arm = 1; arm <= 60; ++arm) {
+        ctl.remaining = -1;
+        ctl.live = 0;
+        Map m;  // empty: no allocations yet
+        ctl.remaining = arm;
+        bool threw = false;
+        try {
+            m.bulk_load(kv.begin(), kv.end());
+        } catch (const std::bad_alloc&) {
+            threw = true;
+        }
+        ctl.remaining = -1;
+        if (threw) {
+            saw_throw = true;
+            CHECK(m.empty());
+            CHECK_EQ(ctl.live, 0);  // every slab (leaves + orphaned shells) released
+        }
+    }
+    CHECK(saw_throw);
 }
 
 TEST_CASE("art_map::pmr_mapped_type_uses_map_resource") {

--- a/tests/art_map_test.cc
+++ b/tests/art_map_test.cc
@@ -614,6 +614,53 @@ TEST_CASE("art_map::exception_safety_on_copy_and_split") {
         }
         CHECK(saw_throw);
     }
+
+    SUBCASE("initializer-list construction that throws does not leak") {
+        // ~art_map() does not run on constructor failure; a throw partway must still tear
+        // down the staged tree (verified leak-free under ASAN).
+        bool saw_throw = false;
+        for (long k = 0;; ++k) {
+            g_throw_ctl().remaining = k;
+            try {
+                Map m({{"alpha", 1}, {"beta", 2}, {"gamma", 3}, {"delta", 4}, {"epsilon", 5}});
+                g_throw_ctl().remaining = -1;
+                CHECK_EQ(m.size(), 5);
+                break;
+            } catch (const std::bad_alloc&) {
+                saw_throw = true;
+            }
+            g_throw_ctl().remaining = -1;
+        }
+        CHECK(saw_throw);
+    }
+
+    SUBCASE("bulk_load that throws frees the staged leaves and leaves the map empty") {
+        // Fixed-width keys "k1000".."k1399" are already in ascending (encoded) order.
+        std::vector<std::pair<const std::string, int>> data;
+        for (int i = 0; i < 400; ++i) data.emplace_back(std::string("k") + std::to_string(1000 + i), i);
+
+        bool saw_throw = false;
+        for (long k = 0;; ++k) {
+            Map m;
+            g_throw_ctl().remaining = -1;
+            m["preexisting"] = 1;  // bulk_load clears this first
+            g_throw_ctl().remaining = k;
+            try {
+                m.bulk_load(data.begin(), data.end());
+                g_throw_ctl().remaining = -1;
+                CHECK_EQ(m.size(), data.size());
+                break;
+            } catch (const std::bad_alloc&) {
+                saw_throw = true;
+            }
+            g_throw_ctl().remaining = -1;
+            // bulk_load cleared first, so a failed load leaves an empty, valid map (and,
+            // under ASAN, must not leak the staged leaves).
+            CHECK(m.empty());
+            CHECK_EQ(m.size(), 0);
+        }
+        CHECK(saw_throw);
+    }
 }
 
 }  // namespace stdb::container

--- a/tests/art_map_test.cc
+++ b/tests/art_map_test.cc
@@ -365,6 +365,15 @@ TEST_CASE("art_map::move_assign_allocator_aware") {
         CHECK_EQ(d.size(), 1500);
         for (int i = 0; i < 1500; ++i) CHECK_EQ(d.at(i), i);
     }
+    SUBCASE("copy ctor selects allocator (no dangling source resource)") {
+        art_map<int, int, PA> src(PA{&r1});
+        for (int i = 0; i < 1000; ++i) src[i] = i;
+        art_map<int, int, PA> cp = src;  // must NOT retain &r1
+        CHECK(cp.get_allocator().resource() != &r1);
+        CHECK(cp.get_allocator().resource() == std::pmr::get_default_resource());
+        CHECK_EQ(cp.size(), 1000);
+        for (int i = 0; i < 1000; ++i) CHECK_EQ(cp.at(i), i);
+    }
 }
 
 // Differential test against std::map as oracle.

--- a/tests/art_map_test.cc
+++ b/tests/art_map_test.cc
@@ -1,0 +1,366 @@
+/*
+ * Copyright 2025 ClapDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "container/art_map.hpp"
+
+#include <algorithm>
+#include <limits>
+#include <map>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "doctest/doctest/doctest.h"
+
+namespace stdb::container {
+
+TEST_CASE("art_map::basic") {
+    SUBCASE("default constructor") {
+        art_map<int, int> m;
+        CHECK(m.empty());
+        CHECK_EQ(m.size(), 0);
+        CHECK(m.begin() == m.end());
+    }
+
+    SUBCASE("insert and find") {
+        art_map<int, int> m;
+        auto [it, ok] = m.insert({42, 100});
+        CHECK(ok);
+        CHECK_EQ(it->first, 42);
+        CHECK_EQ(it->second, 100);
+        CHECK_EQ(m.size(), 1);
+
+        auto [it2, ok2] = m.insert({42, 999});
+        CHECK_FALSE(ok2);
+        CHECK_EQ(it2->second, 100);  // not overwritten
+        CHECK_EQ(m.size(), 1);
+
+        CHECK(m.contains(42));
+        CHECK_FALSE(m.contains(7));
+        CHECK_EQ(m.count(42), 1);
+        CHECK_EQ(m.find(42)->second, 100);
+        CHECK(m.find(7) == m.end());
+    }
+
+    SUBCASE("operator[] and at") {
+        art_map<int, std::string> m;
+        m[1] = "one";
+        m[2] = "two";
+        CHECK_EQ(m.size(), 2);
+        CHECK_EQ(m[1], "one");
+        CHECK_EQ(m.at(2), "two");
+        CHECK_THROWS_AS(m.at(99), std::out_of_range);
+        m[1] = "ONE";
+        CHECK_EQ(m.at(1), "ONE");
+    }
+
+    SUBCASE("insert_or_assign") {
+        art_map<int, int> m;
+        auto [it, ok] = m.insert_or_assign(5, 50);
+        CHECK(ok);
+        CHECK_EQ(it->second, 50);
+        auto [it2, ok2] = m.insert_or_assign(5, 55);
+        CHECK_FALSE(ok2);
+        CHECK_EQ(m.at(5), 55);
+    }
+
+    SUBCASE("initializer list") {
+        art_map<int, int> m{{3, 30}, {1, 10}, {2, 20}};
+        CHECK_EQ(m.size(), 3);
+        CHECK_EQ(m.at(1), 10);
+        CHECK_EQ(m.at(2), 20);
+        CHECK_EQ(m.at(3), 30);
+    }
+}
+
+TEST_CASE("art_map::erase") {
+    art_map<int, int> m;
+    for (int i = 0; i < 100; ++i) m[i] = i * 2;
+    CHECK_EQ(m.size(), 100);
+    CHECK_EQ(m.erase(50), 1);
+    CHECK_EQ(m.erase(50), 0);
+    CHECK_FALSE(m.contains(50));
+    CHECK_EQ(m.size(), 99);
+    for (int i = 0; i < 100; ++i) m.erase(i);
+    CHECK(m.empty());
+    CHECK(m.begin() == m.end());
+}
+
+TEST_CASE("art_map::ordered_iteration") {
+    art_map<int, int> m;
+    std::vector<int> keys = {5, -3, 100, 0, -1000, 7, 42, -50};
+    for (int k : keys) m[k] = k;
+    std::vector<int> sorted = keys;
+    std::sort(sorted.begin(), sorted.end());
+    std::vector<int> got;
+    for (const auto& kv : m) got.push_back(kv.first);
+    CHECK(got == sorted);
+
+    // reverse
+    std::vector<int> rgot;
+    for (auto it = m.rbegin(); it != m.rend(); ++it) rgot.push_back(it->first);
+    std::reverse(sorted.begin(), sorted.end());
+    CHECK(rgot == sorted);
+}
+
+TEST_CASE("art_map::bounds") {
+    art_map<int, int> m;
+    for (int i = 0; i < 20; ++i) m[i * 10] = i;  // 0,10,...,190
+    CHECK_EQ(m.lower_bound(0)->first, 0);
+    CHECK_EQ(m.lower_bound(5)->first, 10);
+    CHECK_EQ(m.lower_bound(10)->first, 10);
+    CHECK_EQ(m.upper_bound(10)->first, 20);
+    CHECK_EQ(m.lower_bound(195), m.end());
+    CHECK_EQ(m.upper_bound(190), m.end());
+    auto [lo, hi] = m.equal_range(50);
+    CHECK_EQ(lo->first, 50);
+    CHECK_EQ(hi->first, 60);
+}
+
+TEST_CASE("art_map::string_keys") {
+    art_map<std::string, int> m;
+    m["apple"] = 1;
+    m["app"] = 2;        // prefix-of "apple"
+    m["application"] = 3;
+    m[""] = 4;           // empty key
+    m["banana"] = 5;
+    CHECK_EQ(m.size(), 5);
+    CHECK_EQ(m.at(""), 4);
+    CHECK_EQ(m.at("app"), 2);
+    CHECK_EQ(m.at("apple"), 1);
+
+    std::vector<std::string> got;
+    for (const auto& kv : m) got.push_back(kv.first);
+    std::vector<std::string> expect = {"", "app", "apple", "application", "banana"};
+    CHECK(got == expect);
+
+    CHECK_EQ(m.erase("app"), 1);
+    CHECK_FALSE(m.contains("app"));
+    CHECK(m.contains("apple"));
+    CHECK(m.contains("application"));
+}
+
+TEST_CASE("art_map::bulk_load") {
+    SUBCASE("matches inserts and stays mutable") {
+        std::map<int, int> oracle;
+        std::mt19937 rng(77);
+        for (int i = 0; i < 5000; ++i) oracle[static_cast<int>(rng() % 3000) - 1500] = static_cast<int>(rng());
+        std::vector<std::pair<const int, int>> sorted(oracle.begin(), oracle.end());
+
+        art_map<int, int> m;
+        m.bulk_load(sorted.begin(), sorted.end());
+        CHECK_EQ(m.size(), oracle.size());
+
+        auto oi = oracle.begin();
+        auto mi = m.begin();
+        for (; oi != oracle.end(); ++oi, ++mi) {
+            REQUIRE(mi != m.end());
+            CHECK_EQ(mi->first, oi->first);
+            CHECK_EQ(mi->second, oi->second);
+        }
+        CHECK(mi == m.end());
+        // still mutable after bulk load
+        m[999999] = 1;
+        CHECK(m.contains(999999));
+        CHECK_EQ(m.erase(sorted.front().first), 1);
+    }
+
+    SUBCASE("empty / single / strings with shared prefix") {
+        art_map<int, int> e;
+        std::vector<std::pair<const int, int>> none;
+        e.bulk_load(none.begin(), none.end());
+        CHECK(e.empty());
+
+        std::map<std::string, int> so;
+        so["user/2026/a"] = 1;
+        so["user/2026/aa"] = 2;  // prefix-of
+        so["user/2026/b"] = 3;
+        so["user/2027/zzzzzzzzzzzzzzzz"] = 4;  // long shared prefix > cap
+        std::vector<std::pair<const std::string, int>> sv(so.begin(), so.end());
+        art_map<std::string, int> sm;
+        sm.bulk_load(sv.begin(), sv.end());
+        CHECK_EQ(sm.size(), 4);
+        std::vector<std::string> got;
+        for (const auto& kv : sm) got.push_back(kv.first);
+        std::vector<std::string> expect;
+        for (auto& kv : so) expect.push_back(kv.first);
+        CHECK(got == expect);
+    }
+}
+
+TEST_CASE("art_map::for_each_ordered") {
+    art_map<int, int> m;
+    std::vector<int> keys = {5, -3, 100, 0, -1000, 7, 42, -50};
+    for (int k : keys) m[k] = k * 2;
+    std::vector<int> sorted = keys;
+    std::sort(sorted.begin(), sorted.end());
+    std::vector<int> got;
+    int prev_val_sum = 0;
+    m.for_each([&](const std::pair<const int, int>& kv) {
+        got.push_back(kv.first);
+        prev_val_sum += kv.second;
+    });
+    CHECK(got == sorted);
+    CHECK_EQ(prev_val_sum, [&] { int s = 0; for (int k : keys) s += k * 2; return s; }());
+
+    // empty map
+    art_map<int, int> e;
+    int count = 0;
+    e.for_each([&](const std::pair<const int, int>&) { ++count; });
+    CHECK_EQ(count, 0);
+}
+
+TEST_CASE("art_map::copy_move") {
+    art_map<int, int> m;
+    for (int i = 0; i < 50; ++i) m[i] = i;
+    art_map<int, int> copy = m;
+    CHECK_EQ(copy.size(), 50);
+    for (int i = 0; i < 50; ++i) CHECK_EQ(copy.at(i), i);
+    copy[1000] = 1;
+    CHECK_FALSE(m.contains(1000));  // deep copy independence
+
+    art_map<int, int> moved = std::move(m);
+    CHECK_EQ(moved.size(), 50);
+    CHECK(m.empty());
+}
+
+TEST_CASE("art_map::signed_and_float_ordering") {
+    SUBCASE("signed ints sort correctly across zero") {
+        art_map<int, int> m;
+        for (int k : {-5, 3, -1, 0, 7, -100, 50}) m[k] = k;
+        int prev = std::numeric_limits<int>::min();
+        for (const auto& kv : m) {
+            CHECK(kv.first > prev);
+            prev = kv.first;
+        }
+    }
+    SUBCASE("doubles sort correctly incl negatives") {
+        art_map<double, int> m;
+        for (double k : {-1.5, 2.5, 0.0, -0.5, 100.0, -100.0}) m[k] = 1;
+        double prev = -1e300;
+        for (const auto& kv : m) {
+            CHECK(kv.first > prev);
+            prev = kv.first;
+        }
+    }
+}
+
+// Regression: erasing keys that share a prefix longer than the path-compression
+// cap builds single-child chains; collapse on erase must cascade to the parent,
+// or the tree is corrupted (was a SEGV on destroy). Wide alphabet exercises
+// node16/48/256 shrink paths too.
+TEST_CASE("art_map::erase_cascade_long_prefix") {
+    for (unsigned seed = 0; seed < 30; ++seed) {
+        std::mt19937 rng(seed);
+        std::map<std::string, int> oracle;
+        art_map<std::string, int> art;
+        int plen = 10 + static_cast<int>(seed % 12);  // shared prefix crosses cap=8
+        std::string pre(static_cast<size_t>(plen), 'p');
+        int alpha = 2 + static_cast<int>(seed % 25);
+        int n = 1500 + static_cast<int>(seed) * 40;
+        for (int i = 0; i < n; ++i) {
+            std::string s = pre;
+            int t = static_cast<int>(rng() % 7);
+            for (int j = 0; j < t; ++j) s.push_back(static_cast<char>('a' + rng() % alpha));
+            oracle[s] = i;
+            art.insert_or_assign(s, i);
+        }
+        REQUIRE_EQ(art.size(), oracle.size());
+        // erase everything in shuffled order, checking counts
+        std::vector<std::string> keys;
+        for (auto& kv : oracle) keys.push_back(kv.first);
+        std::shuffle(keys.begin(), keys.end(), rng);
+        size_t remaining = art.size();
+        for (auto& k : keys) {
+            CHECK_EQ(art.erase(k), 1);
+            CHECK_EQ(art.size(), --remaining);
+        }
+        CHECK(art.empty());
+        CHECK(art.begin() == art.end());
+    }
+}
+
+// Differential test against std::map as oracle.
+TEST_CASE("art_map::differential_vs_std_map") {
+    SUBCASE("int keys, insert/erase churn") {
+        std::mt19937 rng(12345);
+        std::map<int, int> oracle;
+        art_map<int, int> art;
+        for (int i = 0; i < 20000; ++i) {
+            int k = static_cast<int>(rng() % 1000) - 500;
+            if (rng() % 3 == 2) {
+                CHECK_EQ(oracle.erase(k), art.erase(k));
+            } else {
+                int v = static_cast<int>(rng());
+                oracle[k] = v;
+                art.insert_or_assign(k, v);
+            }
+            REQUIRE_EQ(oracle.size(), art.size());
+        }
+        // full ordered comparison
+        auto oi = oracle.begin();
+        auto ai = art.begin();
+        for (; oi != oracle.end(); ++oi, ++ai) {
+            REQUIRE(ai != art.end());
+            CHECK_EQ(oi->first, ai->first);
+            CHECK_EQ(oi->second, ai->second);
+        }
+        CHECK(ai == art.end());
+    }
+
+    SUBCASE("string keys with shared prefixes") {
+        std::mt19937 rng(999);
+        std::map<std::string, int> oracle;
+        art_map<std::string, int> art;
+        auto mk = [&] {
+            int len = static_cast<int>(rng() % 10);
+            std::string s;
+            for (int i = 0; i < len; ++i) s.push_back(static_cast<char>('a' + (rng() % 3)));
+            return s;
+        };
+        for (int i = 0; i < 20000; ++i) {
+            std::string k = mk();
+            if (rng() % 3 == 2) {
+                CHECK_EQ(oracle.erase(k), art.erase(k));
+            } else {
+                int v = static_cast<int>(rng());
+                oracle[k] = v;
+                art.insert_or_assign(k, v);
+            }
+            REQUIRE_EQ(oracle.size(), art.size());
+        }
+        auto oi = oracle.begin();
+        auto ai = art.begin();
+        for (; oi != oracle.end(); ++oi, ++ai) {
+            REQUIRE(ai != art.end());
+            CHECK_EQ(oi->first, ai->first);
+        }
+        CHECK(ai == art.end());
+
+        // lower_bound probes
+        for (int t = 0; t < 2000; ++t) {
+            int len = static_cast<int>(rng() % 10);
+            std::string p;
+            for (int i = 0; i < len; ++i) p.push_back(static_cast<char>('a' + (rng() % 3)));
+            auto ol = oracle.lower_bound(p);
+            auto al = art.lower_bound(p);
+            CHECK_EQ(ol == oracle.end(), al == art.end());
+            if (ol != oracle.end() && al != art.end()) CHECK_EQ(ol->first, al->first);
+        }
+    }
+}
+
+}  // namespace stdb::container

--- a/tests/art_map_test.cc
+++ b/tests/art_map_test.cc
@@ -276,6 +276,24 @@ TEST_CASE("art_map::signed_and_float_ordering") {
             prev = kv.first;
         }
     }
+    SUBCASE("negative zero is the same key as positive zero") {
+        art_map<double, int> m;
+        m.insert({-0.0, 1});
+        m.insert({0.0, 2});  // -0.0 == 0.0: same key, so insert is a no-op (first write wins)
+        CHECK_EQ(m.size(), 1);
+        auto it = m.find(0.0);
+        REQUIRE(it != m.end());
+        CHECK_EQ(it->second, 1);
+        CHECK(m.find(-0.0) != m.end());  // both signs locate the single entry
+    }
+    SUBCASE("negative zero is the same key as positive zero (float, operator[] overwrites)") {
+        art_map<float, int> m;
+        m[-0.0F] = 1;
+        m[0.0F] = 2;  // operator[] on the same key overwrites
+        CHECK_EQ(m.size(), 1);
+        CHECK_EQ(m[0.0F], 2);
+        CHECK_EQ(m[-0.0F], 2);
+    }
 }
 
 // Regression: erasing keys that share a prefix longer than the path-compression

--- a/tests/art_map_test.cc
+++ b/tests/art_map_test.cc
@@ -224,6 +224,25 @@ TEST_CASE("art_map::for_each_ordered") {
     CHECK_EQ(count, 0);
 }
 
+// Regression (review): for_each on a const map must pass const refs for ALL
+// entries, including the end_leaf (e.g. empty-string key). A generic callback
+// would otherwise be instantiated with a mutable ref for that entry — caught
+// here at compile time by the static_assert inside the lambda.
+TEST_CASE("art_map::for_each_const_end_leaf") {
+    art_map<std::string, int> m;
+    m[""] = 1;  // stored as end_leaf at the root
+    m["a"] = 2;
+    m["bb"] = 3;
+    const auto& cm = m;
+    int n = 0;
+    cm.for_each([&](auto& kv) {
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(kv)>>,
+                      "for_each must hand const refs on a const map");
+        ++n;
+    });
+    CHECK_EQ(n, 3);
+}
+
 TEST_CASE("art_map::copy_move") {
     art_map<int, int> m;
     for (int i = 0; i < 50; ++i) m[i] = i;

--- a/tests/art_map_test.cc
+++ b/tests/art_map_test.cc
@@ -376,6 +376,38 @@ TEST_CASE("art_map::move_assign_allocator_aware") {
     }
 }
 
+// Regression (review P2): a propagating (POCCA) allocator must be adopted on
+// copy assignment before cloning.
+namespace pocca_test {
+template <typename T>
+struct IdAlloc {
+    using value_type = T;
+    using propagate_on_container_copy_assignment = std::true_type;
+    using propagate_on_container_move_assignment = std::true_type;
+    int id = 0;
+    IdAlloc() = default;
+    explicit IdAlloc(int i) : id(i) {}
+    template <typename U>
+    IdAlloc(const IdAlloc<U>& o) : id(o.id) {}
+    T* allocate(std::size_t n) { return std::allocator<T>{}.allocate(n); }
+    void deallocate(T* p, std::size_t n) { std::allocator<T>{}.deallocate(p, n); }
+    bool operator==(const IdAlloc& o) const { return id == o.id; }
+    bool operator!=(const IdAlloc& o) const { return id != o.id; }
+};
+}  // namespace pocca_test
+
+TEST_CASE("art_map::copy_assign_propagates_allocator") {
+    using A = pocca_test::IdAlloc<std::pair<const int, int>>;
+    art_map<int, int, A> a(A{1});
+    for (int i = 0; i < 1000; ++i) a[i] = i;
+    art_map<int, int, A> b(A{2});
+    b[9] = 9;
+    b = a;  // POCCA -> b adopts allocator id 1
+    CHECK_EQ(b.get_allocator().id, 1);
+    CHECK_EQ(b.size(), 1000);
+    for (int i = 0; i < 1000; ++i) CHECK_EQ(b.at(i), i);
+}
+
 // Differential test against std::map as oracle.
 TEST_CASE("art_map::differential_vs_std_map") {
     SUBCASE("int keys, insert/erase churn") {

--- a/tests/art_map_test.cc
+++ b/tests/art_map_test.cc
@@ -520,12 +520,27 @@ TEST_CASE("art_map::differential_vs_std_map") {
 namespace {
 struct throw_ctl
 {
-    long remaining = -1;  // -1 = disabled
+    long remaining = -1;   // -1 = disabled
+    long allocations = 0;  // total slab allocations observed (for leak/reuse assertions)
 };
 inline throw_ctl& g_throw_ctl() {
     static throw_ctl ctl;
     return ctl;
 }
+// A value type whose default construction throws on demand, to exercise make_leaf's slot
+// cleanup when key/value construction fails.
+inline bool& g_value_throws() {
+    static bool b = false;
+    return b;
+}
+struct ThrowingValue
+{
+    int v = 0;
+    ThrowingValue() {
+        if (g_value_throws()) throw std::runtime_error("ThrowingValue");
+    }
+    explicit ThrowingValue(int x) : v(x) {}
+};
 template <typename T>
 struct throwing_alloc
 {
@@ -535,6 +550,7 @@ struct throwing_alloc
     throwing_alloc(const throwing_alloc<U>&) noexcept {}
     T* allocate(std::size_t n) {
         auto& ctl = g_throw_ctl();
+        ++ctl.allocations;
         if (ctl.remaining == 0) {
             ctl.remaining = -1;
             throw std::bad_alloc();
@@ -711,6 +727,31 @@ TEST_CASE("art_map::exception_safety_on_copy_and_split") {
 
         // the returned iterator is positioned: it can walk forward over the siblings
         CHECK_EQ(std::next(res.first) != m.end(), true);
+    }
+
+    SUBCASE("a leaf whose value construction throws returns its pool slot") {
+        using TMap = art_map<int, ThrowingValue, throwing_alloc<std::pair<const int, ThrowingValue>>>;
+        TMap m;
+        g_throw_ctl().remaining = -1;  // allocator counts but never throws here
+        g_value_throws() = false;
+        m[-1];  // warm up: allocate the first leaf slab, size 1
+        const long allocs0 = g_throw_ctl().allocations;
+
+        // Every one of these inserts fails inside make_leaf (default-constructing the
+        // value throws). The slot must be returned to the free list and reused, so the
+        // leaf pool must NOT keep allocating fresh 512-slot slabs.
+        for (int i = 0; i < 4000; ++i) {
+            g_value_throws() = true;
+            CHECK_THROWS_AS(m[i], std::runtime_error);
+        }
+        g_value_throws() = false;
+        const long new_slabs = g_throw_ctl().allocations - allocs0;
+        CHECK(new_slabs <= 1);  // without slot reuse this would be ~4000/512 slabs
+
+        CHECK_EQ(m.size(), 1);  // nothing was actually inserted
+        m[42] = ThrowingValue(42);
+        CHECK_EQ(m.size(), 2);
+        CHECK_EQ(m.at(42).v, 42);
     }
 }
 

--- a/tests/art_map_test.cc
+++ b/tests/art_map_test.cc
@@ -784,4 +784,35 @@ TEST_CASE("art_map::exception_safety_on_copy_and_split") {
     }
 }
 
+TEST_CASE("art_map::pmr_mapped_type_uses_map_resource") {
+    using PV = std::pair<const int, std::pmr::string>;
+    using PMap = art_map<int, std::pmr::string, std::pmr::polymorphic_allocator<PV>>;
+    // A string long enough to force a heap allocation (beyond the SSO buffer); that heap
+    // block must come from the map's resource, not the default one.
+    const char* long_str = "the quick brown fox jumps over the lazy dog 0123456789abcdef";
+
+    std::pmr::monotonic_buffer_resource res;
+    PMap m{std::pmr::polymorphic_allocator<PV>{&res}};
+
+    SUBCASE("try_emplace constructs the value on the map resource") {
+        m.try_emplace(1, long_str);
+        auto it = m.find(1);
+        REQUIRE(it != m.end());
+        CHECK_EQ(it->second.get_allocator().resource(), &res);
+        CHECK_EQ(it->second, std::pmr::string(long_str));
+    }
+    SUBCASE("operator[] then assign keeps the value on the map resource") {
+        m[2] = long_str;
+        auto it = m.find(2);
+        REQUIRE(it != m.end());
+        CHECK_EQ(it->second.get_allocator().resource(), &res);
+    }
+    SUBCASE("insert of a value moves it onto the map resource") {
+        m.insert(PV{3, std::pmr::string(long_str)});
+        auto it = m.find(3);
+        REQUIRE(it != m.end());
+        CHECK_EQ(it->second.get_allocator().resource(), &res);
+    }
+}
+
 }  // namespace stdb::container

--- a/tests/art_map_test.cc
+++ b/tests/art_map_test.cc
@@ -515,4 +515,105 @@ TEST_CASE("art_map::differential_vs_std_map") {
     }
 }
 
+// Allocator that throws std::bad_alloc on the Nth allocation once armed, to exercise the
+// exception-safety of clone() (copy) and the insert split paths.
+namespace {
+struct throw_ctl
+{
+    long remaining = -1;  // -1 = disabled
+};
+inline throw_ctl& g_throw_ctl() {
+    static throw_ctl ctl;
+    return ctl;
+}
+template <typename T>
+struct throwing_alloc
+{
+    using value_type = T;
+    throwing_alloc() = default;
+    template <typename U>
+    throwing_alloc(const throwing_alloc<U>&) noexcept {}
+    T* allocate(std::size_t n) {
+        auto& ctl = g_throw_ctl();
+        if (ctl.remaining == 0) {
+            ctl.remaining = -1;
+            throw std::bad_alloc();
+        }
+        if (ctl.remaining > 0) --ctl.remaining;
+        return static_cast<T*>(::operator new(n * sizeof(T)));
+    }
+    void deallocate(T* p, std::size_t) noexcept { ::operator delete(p); }
+    template <typename U>
+    bool operator==(const throwing_alloc<U>&) const noexcept {
+        return true;
+    }
+    template <typename U>
+    bool operator!=(const throwing_alloc<U>&) const noexcept {
+        return false;
+    }
+};
+}  // namespace
+
+TEST_CASE("art_map::exception_safety_on_copy_and_split") {
+    using Map = art_map<std::string, int, throwing_alloc<std::pair<const std::string, int>>>;
+
+    SUBCASE("copy construction that throws mid-clone leaves the source intact") {
+        Map m;
+        g_throw_ctl().remaining = -1;
+        for (int i = 0; i < 2000; ++i) {
+            m[std::string("prefix/path/") + std::to_string(i)] = i;
+            m[std::string(1, char('a' + (i % 26))) + std::to_string(i)] = i;
+        }
+        const std::size_t expect = m.size();
+
+        // Sweep the throw point across every allocation the copy makes. Each failed copy
+        // must leave the source unchanged (and, under ASAN, must not leak/UAF).
+        bool saw_throw = false;
+        for (long k = 0;; ++k) {
+            g_throw_ctl().remaining = k;
+            try {
+                Map c = m;
+                g_throw_ctl().remaining = -1;
+                CHECK_EQ(c.size(), m.size());
+                CHECK_EQ(c.at("prefix/path/0"), 0);
+                break;  // k exceeded the copy's allocation count
+            } catch (const std::bad_alloc&) {
+                saw_throw = true;
+            }
+            g_throw_ctl().remaining = -1;
+            CHECK_EQ(m.size(), expect);
+            CHECK_EQ(m.at("prefix/path/1234"), 1234);
+        }
+        CHECK(saw_throw);
+    }
+
+    SUBCASE("a split insert that throws leaves the existing entry reachable") {
+        const std::string k1 = std::string(80, 'x') + "AAA";  // share a prefix >> kCap
+        const std::string k2 = std::string(80, 'x') + "BBB";
+        bool saw_throw = false;
+        for (long k = 0;; ++k) {
+            Map mm;
+            g_throw_ctl().remaining = -1;
+            mm[k1] = 1;
+            g_throw_ctl().remaining = k;
+            try {
+                mm.insert({k2, 2});
+                g_throw_ctl().remaining = -1;
+                CHECK_EQ(mm.size(), 2);
+                CHECK_EQ(mm.at(k1), 1);
+                CHECK_EQ(mm.at(k2), 2);
+                break;
+            } catch (const std::bad_alloc&) {
+                saw_throw = true;
+            }
+            g_throw_ctl().remaining = -1;
+            CHECK_EQ(mm.size(), 1);
+            CHECK(mm.contains(k1));
+            CHECK_EQ(mm.at(k1), 1);
+            CHECK_FALSE(mm.contains(k2));
+        }
+        CHECK(saw_throw);
+    }
+}
+
 }  // namespace stdb::container

--- a/tests/art_map_test.cc
+++ b/tests/art_map_test.cc
@@ -293,6 +293,52 @@ TEST_CASE("art_map::erase_cascade_long_prefix") {
     }
 }
 
+// Regression (review P1): a node256 holding all 256 byte values must not let its
+// child count wrap; erasing a sibling end_leaf must not free the full node.
+TEST_CASE("art_map::node256_full_with_end_leaf") {
+    art_map<std::string, int> m;
+    m[""] = -1;  // ends at root -> end_leaf
+    for (int b = 0; b < 256; ++b) {
+        std::string k(1, static_cast<char>(b));  // 256 distinct first bytes -> root node256
+        m[k] = b;
+    }
+    CHECK_EQ(m.size(), 257);
+    CHECK_EQ(m.erase(""), 1);  // remove the end_leaf from the (full) node256
+    CHECK_EQ(m.size(), 256);
+    for (int b = 0; b < 256; ++b) {
+        std::string k(1, static_cast<char>(b));
+        REQUIRE(m.contains(k));
+        CHECK_EQ(m.at(k), b);
+    }
+    // erase them all; tree must end empty and consistent
+    for (int b = 0; b < 256; ++b) CHECK_EQ(m.erase(std::string(1, static_cast<char>(b))), 1);
+    CHECK(m.empty());
+}
+
+// Regression (review P2): a moved-from map must be reusable without corruption.
+TEST_CASE("art_map::move_then_reuse_source") {
+    art_map<int, int> a;
+    for (int i = 0; i < 5000; ++i) a[i] = i;
+    art_map<int, int> b = std::move(a);
+    CHECK_EQ(b.size(), 5000);
+    CHECK(a.empty());
+    // reuse the moved-from source: must allocate fresh, not into b's slabs
+    for (int i = 0; i < 5000; ++i) a[i] = i * 2;
+    CHECK_EQ(a.size(), 5000);
+    for (int i = 0; i < 5000; ++i) CHECK_EQ(a.at(i), i * 2);
+    // both independent
+    CHECK_EQ(b.at(10), 10);
+    a.clear();
+    CHECK_EQ(b.size(), 5000);  // b unaffected by a's destruction path
+
+    // move assignment variant
+    art_map<int, int> c;
+    c = std::move(b);
+    CHECK_EQ(c.size(), 5000);
+    b[7] = 7;  // reuse moved-from
+    CHECK(b.contains(7));
+}
+
 // Differential test against std::map as oracle.
 TEST_CASE("art_map::differential_vs_std_map") {
     SUBCASE("int keys, insert/erase churn") {

--- a/tests/art_map_test.cc
+++ b/tests/art_map_test.cc
@@ -661,6 +661,32 @@ TEST_CASE("art_map::exception_safety_on_copy_and_split") {
         }
         CHECK(saw_throw);
     }
+
+    SUBCASE("erase whose shrink allocation fails still removes the element") {
+        Map m;
+        g_throw_ctl().remaining = -1;
+        // bulk_load builds a node16 directly (5 runs), so the node4 pool stays empty and
+        // the shrink-on-erase make4() is the very next slab allocation we can force to fail.
+        std::vector<std::pair<const std::string, int>> data = {
+          {"a", 1}, {"b", 2}, {"c", 3}, {"d", 4}, {"e", 5}};
+        m.bulk_load(data.begin(), data.end());
+        CHECK_EQ(m.size(), 5);
+
+        g_throw_ctl().remaining = 0;  // next slab allocation (the shrink's make4) throws
+        CHECK_NOTHROW(m.erase("a"));  // erase must succeed despite the failed shrink
+        // The counter is reset to -1 only when a throw actually fires, so this confirms the
+        // shrink allocation really was attempted and failed (the path under test).
+        CHECK_EQ(g_throw_ctl().remaining, -1);
+        g_throw_ctl().remaining = -1;
+
+        CHECK_EQ(m.size(), 4);
+        CHECK_FALSE(m.contains("a"));
+        for (const char* k : {"b", "c", "d", "e"}) CHECK(m.contains(k));
+        // the map (with the un-shrunk node) is still fully usable
+        m["f"] = 6;
+        CHECK_EQ(m.at("f"), 6);
+        CHECK_EQ(m.size(), 5);
+    }
 }
 
 }  // namespace stdb::container

--- a/tests/art_map_test.cc
+++ b/tests/art_map_test.cc
@@ -687,6 +687,31 @@ TEST_CASE("art_map::exception_safety_on_copy_and_split") {
         CHECK_EQ(m.at("f"), 6);
         CHECK_EQ(m.size(), 5);
     }
+
+    SUBCASE("insert returning a deep iterator path (beyond inline stack) is correct") {
+        art_map<std::string, int> m;  // default allocator
+        const int L = 40;
+        const std::string base(L, 'a');
+        // Force a branch at every depth so the route to `base` has ~L inner nodes — more
+        // than the iterator stack's inline capacity (16) — exercising the up-front path
+        // reserve in do_insert.
+        for (int p = 0; p < L; ++p) m[base.substr(0, p) + "b"] = p;
+
+        auto res = m.insert({base, 999});
+        CHECK(res.second);
+        REQUIRE(res.first != m.end());
+        CHECK_EQ(res.first->first, base);
+        CHECK_EQ(res.first->second, 999);
+
+        // a re-insert (no structural change) must also return a valid deep iterator
+        auto res2 = m.insert({base, 111});
+        CHECK_FALSE(res2.second);
+        REQUIRE(res2.first != m.end());
+        CHECK_EQ(res2.first->second, 999);
+
+        // the returned iterator is positioned: it can walk forward over the siblings
+        CHECK_EQ(std::next(res.first) != m.end(), true);
+    }
 }
 
 }  // namespace stdb::container


### PR DESCRIPTION
## Summary

Adds **`stdb::container::art_map`** — a header-only C++20 ordered map backed by an Adaptive Radix Tree, with a `btree_map`-parity API. Also fixes one pre-existing ambiguous `insert` overload in `btree_map` that blocked the test suite under newer GCC.

## What's included
- `container/art_map.hpp` — the container
- `tests/art_map_test.cc` — doctest suite (11 cases, ~143k assertions; auto-discovered)
- `bench/art_bench.cc` + `bench/CMakeLists.txt` — nanobench vs `btree_map` (optional `ENABLE_ABSL`)
- `container/btree_map.hpp` — constrain `insert(node_type&&)` so a braced-init-list can't match it (separate first commit)

## Design
- **Generic key encoder** producing order-preserving bytes (unsigned/signed/float big-endian; strings identity). Custom keys can specialize `art_key_encoder<Key>`.
- **Adaptive node4/16/48/256** + bounded path compression + lazy expansion; an `end_leaf` slot handles prefix-of keys and embedded NULs.
- **Per-kind slab node pools** — cuts malloc count dramatically (main insert lever).
- **SIMD** (SSE/AVX) node16 search; child prefetch.
- **Single-pass `insert()`** builds the result iterator (no second descent).
- **`for_each`** — prefetching recursive DFS, faster than iterating for full scans.
- **`bulk_load`** — bottom-up build from sorted input; lays leaves out in key order for ~5x faster scans (build-once-scan-many).

## Correctness
Differential-tested vs `std::map` for int / unsigned / 64-bit / string keys — including empty keys, shared prefixes longer than the compression cap, wide alphabets (node16/48/256 paths), and full erase-to-empty — all under ASAN+UBSAN. A real bug surfaced and was fixed in the process: **erase collapse now cascades** (a long-shared-prefix chain erased to empty previously left a node with a dangling child → SEGV on destroy); a regression test guards it.

## Benchmarks (vs `btree_map`, pinned core, A/B interleaved; ratio = btree/art, >1 ⇒ ART faster)

| API | uint64 rand | uint64 dense | str rand | str prefix |
|---|---|---|---|---|
| insert (random) | 1.17 | 3.63 | 1.72 | 1.56 |
| find (hit) | 2.10 | 3.31 | 3.49 | 3.11 |
| lower_bound | 2.30 | 3.56 | 4.12 | 3.59 |
| erase (all) | 1.55 | 3.08 | 2.97 | 2.63 |
| scan (for_each) | 0.06 | 0.17 | 0.18 | 0.20 |
| scan (for_each, bulk-built) | 0.18 | 0.52 | 0.47 | 0.49 |

**ART wins random insert, find, lower_bound, erase (1.2–4×); btree wins full scan and sorted bulk insert** (contiguous packed arrays). `bulk_load` + `for_each` narrow the scan gap. An inline-value (btree-like contiguous) variant was prototyped and measured: it improves scan ~2.4× but is still ~5.5× off btree (the tree-walk dominates, not leaf indirection), so it was not pursued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
